### PR TITLE
Align decoding with MATLAB implementation

### DIFF
--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -6,6 +6,8 @@ from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.neural_network import MLPClassifier
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
 
@@ -19,9 +21,11 @@ def __getattr__(name):
 
 def train_multiclass_classifier(features, labels, classifier, classifier_param):
     if classifier == "multiclass-svm":
-        model = SVC(C=classifier_param, probability=True)
+        model = make_pipeline(StandardScaler(), SVC(C=classifier_param, kernel="linear"))
+    elif classifier == "multiclass-svm-weighted":
+        model = make_pipeline(StandardScaler(), SVC(C=classifier_param, kernel="linear", class_weight="balanced"))
     elif classifier == "random-forest":
-        model = RandomForestClassifier(n_estimators=int(classifier_param))
+        model = RandomForestClassifier(n_estimators=int(classifier_param), min_samples_leaf=5)
     elif classifier == "gradient-boosting":
         model = GradientBoostingClassifier(n_estimators=int(classifier_param))
     elif classifier == "knn":
@@ -87,28 +91,37 @@ def _train_pytorch_mlp(features, labels, classifier_param):
 
 
 def train_gradient_boosting(train_features, train_labels, classifier_param):
-    model = GradientBoostingClassifier(n_estimators=int(classifier_param), max_depth=3, learning_rate=0.1)
+    model = GradientBoostingClassifier(n_estimators=int(classifier_param), max_leaf_nodes=21, learning_rate=0.1)
     model.fit(train_features, train_labels)
     return model
 
 
 def train_for_stimulus_lasso_glm(train_features, train_labels, lambda_):
-    model = LogisticRegression(penalty="l1", C=lambda_, solver="liblinear")
+    model = make_pipeline(
+        StandardScaler(),
+        LogisticRegression(penalty="l1", C=1 / lambda_, solver="liblinear", max_iter=1000),
+    )
     model.fit(train_features, train_labels)
     return model
 
 
 def train_binary_svm(train_features, train_labels, box_constraint):
-    model = SVC(C=box_constraint, kernel="linear", probability=True)
+    model = make_pipeline(StandardScaler(), SVC(C=box_constraint, kernel="linear"))
     model.fit(train_features, train_labels)
     return model
 
 
 def get_default_classifier_param(classifier):
+    if classifier == "lasso":
+        return 0.005
     if classifier == "multiclass-svm":
-        return 3.0
+        return 0.5
+    if classifier == "multiclass-svm-weighted":
+        return 0.5
+    if classifier in ["svm-binary", "binary-svm"]:
+        return 0.5
     if classifier == "random-forest":
-        return 250
+        return 100
     if classifier == "gradient-boosting":
         return 100
     if classifier == "knn":

--- a/src/pymegdec/cross_validation.py
+++ b/src/pymegdec/cross_validation.py
@@ -75,11 +75,10 @@ def cross_validate_single_dataset(
                     model = train_for_stimulus_lasso_glm(train_features, train_labels == stim, classifier_param)
                 elif classifier == "svm-binary":
                     model = train_binary_svm(train_features, train_labels == stim, classifier_param)
-                all_pred[:, stim - 1] = (
-                    model.predict_proba(test_features)[:, 1]
-                    if classifier == "svm-binary"
-                    else model.predict(test_features)
-                )
+                if classifier in ["lasso", "svm-binary"]:
+                    all_pred[:, stim - 1] = _positive_class_score(model, test_features)
+                else:
+                    all_pred[:, stim - 1] = model.predict(test_features)
             pred_lbl[fold == f] = np.argmax(all_pred, axis=1) + 1
         else:
             model = train_multiclass_classifier(train_features, train_labels, classifier, classifier_param)
@@ -98,6 +97,12 @@ def cross_validate_single_dataset(
     print(f'Participant {participant_id}: {accuracy * 100:.2f}% accuracy')
 
     return accuracy
+
+
+def _positive_class_score(model, features):
+    if hasattr(model, "decision_function"):
+        return model.decision_function(features)
+    return model.predict_proba(features)[:, 1]
 
 
 if __name__ == "__main__":

--- a/src/pymegdec/preprocessing.py
+++ b/src/pymegdec/preprocessing.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from scipy.interpolate import interp1d
-from scipy.signal import butter, filtfilt
+from scipy.signal import butter, detrend, filtfilt
 from sklearn.decomposition import PCA
 
 
@@ -44,16 +44,19 @@ def filter_features(data, low_freq, high_freq):
     else:
         raise ValueError("Highpass filter not supported.")
 
-    for i in range(len(data["trial"][0])):
-        data["trial"][0][i] = filtfilt(b, a, data["trial"][0][i].T).T
+    for i in range(len(data["trial"][0][0])):
+        data["trial"][0][0][i] = filtfilt(b, a, data["trial"][0][0][i].T, axis=0).T
     return data
 
 
 def downsample_data(data, new_framerate):
-    raw_fs = float(1 / np.diff(data["time"][0][0][0][0, :2])[0])
+    raw_fs = round(float(1 / np.median(np.diff(data["time"][0][0][0][0]))))
     if new_framerate != raw_fs:
-        new_t = np.arange(data["time"][0][0][0][0, 0], data["time"][0][0][0][0, -1], 1 / new_framerate)
+        first_time = data["time"][0][0][0][0]
+        step = 1 / new_framerate
+        new_t = np.arange(first_time[0], first_time[-1] + step / 2, step)
         for i in range(len(data["trial"][0][0])):
+            data["trial"][0][0][i] = detrend(data["trial"][0][0][i], axis=1)
             interpolator = interp1d(
                 data["time"][0][0][i][0, :],
                 data["trial"][0][0][i],
@@ -66,19 +69,22 @@ def downsample_data(data, new_framerate):
 
 
 def extract_windows(data, train_window, null_time_window):
-    train_begin_index = np.argmin(np.abs(data["time"][0][0][0] - train_window[0]))
-    train_end_index = np.argmin(np.abs(data["time"][0][0][0] - train_window[1]))
+    time = data["time"][0][0][0]
+    train_begin_index = np.argmin(np.abs(time - train_window[0]))
+    train_end_index = np.argmin(np.abs(time - train_window[1]))
     stimuli_features_cell = [
-        trial[:, train_begin_index:train_end_index].reshape(-1, 1) for trial in data["trial"][0][0]
+        trial[:, train_begin_index : train_end_index + 1].reshape(-1, 1, order="F") for trial in data["trial"][0][0]
     ]
 
     if np.isnan(null_time_window).all():
         null_features_cell = []
+    elif null_time_window[1] > 0:
+        raise ValueError("Null window should not contain positive time points")
     elif null_time_window[1] - null_time_window[0] >= 0:
-        null_begin_index = np.argmin(np.abs(data["time"][0][0][0] - null_time_window[0]))
+        null_begin_index = np.argmin(np.abs(time - null_time_window[0]))
         null_end_index = null_begin_index + (train_end_index - train_begin_index)
         null_features_cell = [
-            trial[:, null_begin_index:null_end_index].reshape(-1, 1) for trial in data["trial"][0][0]
+            trial[:, null_begin_index : null_end_index + 1].reshape(-1, 1, order="F") for trial in data["trial"][0][0]
         ]
     else:
         raise ValueError("Invalid null window")
@@ -87,6 +93,7 @@ def extract_windows(data, train_window, null_time_window):
 
 
 def reduce_features_pca(features, n_components):
+    n_components = min(n_components, features.shape[0], features.shape[1])
     pca = PCA(n_components=n_components)
     features_train_exp_mean = np.mean(features, axis=0)
     features_centered = features - features_train_exp_mean

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,80 @@
+import unittest
+
+import numpy as np
+
+from pymegdec.classifiers import get_default_classifier_param
+from pymegdec.preprocessing import downsample_data, extract_windows, filter_features
+
+
+def _cell_array(values):
+    inner = np.empty((1, len(values)), dtype=object)
+    for index, value in enumerate(values):
+        inner[0, index] = value
+
+    outer = np.empty((1,), dtype=object)
+    outer[0] = inner
+    return outer
+
+
+def _data(trials, times):
+    return {
+        "trial": _cell_array(trials),
+        "time": _cell_array(times),
+    }
+
+
+class TestPreprocessing(unittest.TestCase):
+    def test_extract_windows_uses_inclusive_matlab_column_order(self):
+        time = np.array([[-0.2, -0.1, 0.0, 0.1, 0.2]])
+        trial = np.array(
+            [
+                [1, 2, 3, 4, 5],
+                [11, 12, 13, 14, 15],
+            ]
+        )
+        data = _data([trial], [time])
+
+        stimuli, null = extract_windows(data, (-0.1, 0.1), (-0.2, 0.0))
+
+        np.testing.assert_array_equal(stimuli[0].ravel(), [2, 12, 3, 13, 4, 14])
+        np.testing.assert_array_equal(null[0].ravel(), [1, 11, 2, 12, 3, 13])
+
+    def test_downsample_updates_all_trials_and_keeps_endpoint(self):
+        time = np.array([[0.0, 0.25, 0.5, 0.75, 1.0]])
+        trials = [
+            np.array([[0, 1, 0, -1, 0], [2, 3, 2, 1, 2]], dtype=float),
+            np.array([[10, 11, 10, 9, 10], [-1, 0, -1, -2, -1]], dtype=float),
+        ]
+        data = _data(trials, [time.copy(), time.copy()])
+
+        downsample_data(data, 2)
+
+        for index in range(2):
+            np.testing.assert_allclose(data["time"][0][0][index], [[0.0, 0.5, 1.0]])
+            self.assertEqual(data["trial"][0][0][index].shape, (2, 3))
+
+    def test_filter_updates_all_trials(self):
+        time = np.arange(0.0, 1.0, 0.01)[None, :]
+        trial = np.vstack(
+            [
+                np.sin(2 * np.pi * 5 * time.ravel()) + 0.5 * np.sin(2 * np.pi * 40 * time.ravel()),
+                np.cos(2 * np.pi * 5 * time.ravel()) + 0.5 * np.cos(2 * np.pi * 40 * time.ravel()),
+            ]
+        )
+        data = _data([trial.copy(), 2 * trial.copy()], [time.copy(), time.copy()])
+        original_second_trial = data["trial"][0][0][1].copy()
+
+        filter_features(data, 0, 10)
+
+        self.assertFalse(np.allclose(data["trial"][0][0][1], original_second_trial))
+        self.assertEqual(data["trial"][0][0][1].shape, original_second_trial.shape)
+
+    def test_matlab_classifier_defaults_are_preserved(self):
+        self.assertEqual(get_default_classifier_param("multiclass-svm"), 0.5)
+        self.assertEqual(get_default_classifier_param("svm-binary"), 0.5)
+        self.assertEqual(get_default_classifier_param("lasso"), 0.005)
+        self.assertEqual(get_default_classifier_param("random-forest"), 100)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- align classifier defaults and SVM setup with the MATLAB implementation
- fix MATLAB-style preprocessing details for filtering, downsampling, window extraction, and PCA component bounds
- use positive-class scores for binary cross-validation classifiers
- add focused preprocessing/default-parameter regression tests

## Root Cause
PyMEGDec diverged from MEG-Decoding in several translated defaults and array-processing details: the multiclass SVM used scikit-learn's default RBF kernel and a different C value, filtering/downsampling/window extraction did not match MATLAB semantics exactly, and binary classifier aggregation used hard predictions instead of comparable scores.

## Validation
- `python -m pytest` -> 4 passed, 5 skipped
- Direct benchmark on `D:\Uni-Data\Bush_MEGData` with `PYTHONPATH=src` showed default-null model transfer improving from roughly 17.17% to 27.27%, and cross-validation from roughly 30.56% to 32.92%.