### PR TITLE
Add regression tests for decoding correctness fixes

### DIFF
--- a/tests/matlab_fixtures.py
+++ b/tests/matlab_fixtures.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+
+def cell_array(values):
+    inner = np.empty((1, len(values)), dtype=object)
+    for index, value in enumerate(values):
+        inner[0, index] = value
+
+    outer = np.empty((1,), dtype=object)
+    outer[0] = inner
+    return outer

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -1,10 +1,38 @@
 import os
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 
 from pymegdec.cross_validation import cross_validate_single_dataset
+
+
+def _cell_array(values):
+    inner = np.empty((1, len(values)), dtype=object)
+    for index, value in enumerate(values):
+        inner[0, index] = value
+
+    outer = np.empty((1,), dtype=object)
+    outer[0] = inner
+    return outer
+
+
+def _mat_data(labels):
+    trialinfo = np.empty((1, 1), dtype=object)
+    trialinfo[0, 0] = labels
+    return {
+        "trial": _cell_array([np.zeros((1, 2)) for _ in labels]),
+        "trialinfo": trialinfo,
+    }
+
+
+class _ConstantClassifier:
+    def __init__(self, label):
+        self.label = label
+
+    def predict(self, features):
+        return np.full(features.shape[0], self.label)
 
 
 class TestCrossValidateSingleDataset(unittest.TestCase):
@@ -48,6 +76,39 @@ class TestCrossValidateSingleDataset(unittest.TestCase):
         accuracy = self._accuracy("scikit-mlp")
 
         self.assertGreaterEqual(accuracy, 0.15, "Accuracy should be at least 0.15")
+
+
+class TestCrossValidateSingleDatasetSynthetic(unittest.TestCase):
+    def test_cross_validate_single_dataset_without_null_window(self):
+        labels = np.array([1, 2, 1, 2])
+        stimuli_features = [
+            np.array([[index], [index + 1]], dtype=float)
+            for index in range(len(labels))
+        ]
+
+        with (
+            patch(
+                "pymegdec.cross_validation.sio.loadmat",
+                return_value={"data": np.array([_mat_data(labels)], dtype=object)},
+            ),
+            patch(
+                "pymegdec.cross_validation.preprocess_features",
+                return_value=(stimuli_features, []),
+            ),
+            patch(
+                "pymegdec.cross_validation.train_multiclass_classifier",
+                return_value=_ConstantClassifier(1),
+            ),
+        ):
+            accuracy = cross_validate_single_dataset(
+                "unused",
+                1,
+                n_folds=2,
+                null_window_center=np.nan,
+                components_pca=float("inf"),
+            )
+
+        self.assertEqual(accuracy, 0.5)
 
 
 if __name__ == "__main__":

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -7,22 +7,14 @@ import numpy as np
 
 from pymegdec.cross_validation import cross_validate_single_dataset
 
-
-def _cell_array(values):
-    inner = np.empty((1, len(values)), dtype=object)
-    for index, value in enumerate(values):
-        inner[0, index] = value
-
-    outer = np.empty((1,), dtype=object)
-    outer[0] = inner
-    return outer
+from tests.matlab_fixtures import cell_array
 
 
 def _mat_data(labels):
     trialinfo = np.empty((1, 1), dtype=object)
     trialinfo[0, 0] = labels
     return {
-        "trial": _cell_array([np.zeros((1, 2)) for _ in labels]),
+        "trial": cell_array([np.zeros((1, 2)) for _ in labels]),
         "trialinfo": trialinfo,
     }
 

--- a/tests/test_model_transfer.py
+++ b/tests/test_model_transfer.py
@@ -7,22 +7,14 @@ import numpy as np
 
 from pymegdec.model_transfer import evaluate_model_transfer
 
-
-def _cell_array(values):
-    inner = np.empty((1, len(values)), dtype=object)
-    for index, value in enumerate(values):
-        inner[0, index] = value
-
-    outer = np.empty((1,), dtype=object)
-    outer[0] = inner
-    return outer
+from tests.matlab_fixtures import cell_array
 
 
 def _mat_data_with_time(time):
     trialinfo = np.empty((1, 1), dtype=object)
     trialinfo[0, 0] = np.array([1, 2])
     return {
-        "time": _cell_array([np.array([time])]),
+        "time": cell_array([np.array([time])]),
         "trialinfo": trialinfo,
     }
 

--- a/tests/test_model_transfer.py
+++ b/tests/test_model_transfer.py
@@ -1,10 +1,30 @@
 import os
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 
 from pymegdec.model_transfer import evaluate_model_transfer
+
+
+def _cell_array(values):
+    inner = np.empty((1, len(values)), dtype=object)
+    for index, value in enumerate(values):
+        inner[0, index] = value
+
+    outer = np.empty((1,), dtype=object)
+    outer[0] = inner
+    return outer
+
+
+def _mat_data_with_time(time):
+    trialinfo = np.empty((1, 1), dtype=object)
+    trialinfo[0, 0] = np.array([1, 2])
+    return {
+        "time": _cell_array([np.array([time])]),
+        "trialinfo": trialinfo,
+    }
 
 
 class TestEvaluateModelTransfer(unittest.TestCase):
@@ -61,6 +81,22 @@ class TestEvaluateModelTransfer(unittest.TestCase):
         )
 
         self.assertGreaterEqual(accuracy, 0.15, "Accuracy should be at least 0.15")
+
+
+class TestEvaluateModelTransferSynthetic(unittest.TestCase):
+    def test_evaluate_model_transfer_rejects_sampling_rate_mismatch(self):
+        train_data = _mat_data_with_time([0.0, 0.1])
+        val_data = _mat_data_with_time([0.0, 0.2])
+
+        with patch(
+            "pymegdec.model_transfer.sio.loadmat",
+            side_effect=[
+                {"data": np.array([train_data], dtype=object)},
+                {"data": np.array([val_data], dtype=object)},
+            ],
+        ):
+            with self.assertRaisesRegex(ValueError, "Sampling rate"):
+                evaluate_model_transfer("unused", 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -5,21 +5,13 @@ import numpy as np
 from pymegdec.classifiers import get_default_classifier_param
 from pymegdec.preprocessing import downsample_data, extract_windows, filter_features
 
-
-def _cell_array(values):
-    inner = np.empty((1, len(values)), dtype=object)
-    for index, value in enumerate(values):
-        inner[0, index] = value
-
-    outer = np.empty((1,), dtype=object)
-    outer[0] = inner
-    return outer
+from tests.matlab_fixtures import cell_array
 
 
 def _data(trials, times):
     return {
-        "trial": _cell_array(trials),
-        "time": _cell_array(times),
+        "trial": cell_array(trials),
+        "time": cell_array(times),
     }
 
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -71,6 +71,20 @@ class TestPreprocessing(unittest.TestCase):
         self.assertFalse(np.allclose(data["trial"][0][0][1], original_second_trial))
         self.assertEqual(data["trial"][0][0][1].shape, original_second_trial.shape)
 
+    def test_bandpass_filter_accepts_low_and_high_frequency_cutoffs(self):
+        time = np.arange(0.0, 1.0, 0.01)[None, :]
+        trial = np.vstack(
+            [
+                np.sin(2 * np.pi * 5 * time.ravel()),
+                np.cos(2 * np.pi * 5 * time.ravel()),
+            ]
+        )
+        data = _data([trial.copy()], [time.copy()])
+
+        filter_features(data, 1, 10)
+
+        self.assertEqual(data["trial"][0][0][0].shape, trial.shape)
+
     def test_matlab_classifier_defaults_are_preserved(self):
         self.assertEqual(get_default_classifier_param("multiclass-svm"), 0.5)
         self.assertEqual(get_default_classifier_param("svm-binary"), 0.5)

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -1,0 +1,24 @@
+import unittest
+
+
+class TestMLPClassifierTorch(unittest.TestCase):
+    def test_configured_learning_rate_is_used_by_optimizer(self):
+        try:
+            from pymegdec.torch_models import MLPClassifierTorch
+        except ImportError as exc:
+            self.skipTest(f"PyTorch dependencies are not installed: {exc}")
+
+        model = MLPClassifierTorch(
+            input_dim=2,
+            hidden_dim=3,
+            output_dim=2,
+            learning_rate=0.123,
+        )
+
+        optimizer = model.configure_optimizers()
+
+        self.assertEqual(optimizer.param_groups[0]["lr"], 0.123)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add synthetic regression coverage for cross-validation without a null window.
- Add model-transfer coverage for train/validation sampling-rate mismatches.
- Add preprocessing coverage for bandpass cutoff handling.
- Add optional PyTorch coverage that verifies the configured learning rate reaches the optimizer.

## Context
The current main branch already contains the source-level fixes for the item-1 correctness issues. This PR locks those behaviors with focused tests so the regressions are caught without requiring private MEG data for the synthetic cases.

## Validation
- `PYTHONPATH=src python -m unittest discover` from the PR worktree: 19 tests passed, 6 skipped.
- Ran the cross-validation SVM and model-transfer SVM integration tests from the local MEG data directory; both passed. The data path was used only at command time and was not written into committed files.