### PR TITLE
Add configurable data directory

### DIFF
--- a/.github/workflows/cross_validation.yml
+++ b/.github/workflows/cross_validation.yml
@@ -57,9 +57,7 @@ jobs:
         wget -q ${{ secrets.DOWNLOAD_URL }}
         cd ..
 
-    - name: Copy Data to Current Working Directory
-      run: |
-        for file in data/*; do ln -s "$file" .; done
-
     - name: Run tests
+      env:
+        PYMEGDEC_DATA_DIR: data
       run: python -m unittest ${{ matrix.test-target }}

--- a/.github/workflows/model_transfer.yml
+++ b/.github/workflows/model_transfer.yml
@@ -60,9 +60,7 @@ jobs:
         wget -q ${{ secrets.DOWNLOAD_URL_CUE }}
         cd ..
 
-    - name: Copy Data to Current Working Directory
-      run: |
-        for file in data/*; do ln -s "$file" .; done
-
     - name: Run tests
+      env:
+        PYMEGDEC_DATA_DIR: data
       run: python -m unittest ${{ matrix.test-target }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Makefile
 
 # Others
 *.bak
+.pymegdec-data-dir
 # No .C code in this library
 *.C
 *.h

--- a/README.md
+++ b/README.md
@@ -34,9 +34,33 @@ Install optional classifier backends when needed:
 python -m pip install -e ".[all]"
 ```
 
-The test suite expects MATLAB data files named like `Part2Data.mat` and
-`Part2CueData.mat` in the working directory. CI downloads these files from
-repository secrets before running the tests.
+## Data directory
+
+The data directory is configured at runtime so private or machine-specific paths
+do not need to be committed. Data files are expected to be named like
+`Part2Data.mat` and `Part2CueData.mat`.
+
+Resolution order:
+
+1. Pass a data directory to the Python API or command-line wrapper.
+2. Set the `PYMEGDEC_DATA_DIR` environment variable.
+3. Create a local `.pymegdec-data-dir` file containing one path. This file is
+   ignored by git.
+4. Fall back to the current working directory for backwards compatibility.
+
+On PowerShell:
+
+```powershell
+$env:PYMEGDEC_DATA_DIR = "C:\path\to\data"
+python -m unittest
+```
+
+Or pass the directory explicitly:
+
+```powershell
+python cross_validation.py --data-dir "C:\path\to\data" --participant 2
+python evaluate_model_transfer.py --data-dir "C:\path\to\data" --participant 2
+```
 
 ## Examples
 
@@ -46,4 +70,12 @@ from pymegdec.cross_validation import cross_validate_single_dataset
 
 transfer_accuracy = evaluate_model_transfer(".", 2, classifier="multiclass-svm")
 cv_accuracy = cross_validate_single_dataset(".", 2, classifier="multiclass-svm")
+```
+
+If `PYMEGDEC_DATA_DIR` or `.pymegdec-data-dir` is configured, the first argument
+can be `None`:
+
+```python
+transfer_accuracy = evaluate_model_transfer(None, 2, classifier="multiclass-svm")
+cv_accuracy = cross_validate_single_dataset(None, 2, classifier="multiclass-svm")
 ```

--- a/cross_validation.py
+++ b/cross_validation.py
@@ -23,7 +23,14 @@ __all__ = [
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Cross-validate one participant dataset.")
+    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
+    parser.add_argument("--participant", type=int, default=2, help="Participant id to evaluate.")
+    args = parser.parse_args()
+
     acc = cross_validate_single_dataset(
-        r".", 2, classifier="multiclass-svm", components_pca=100
+        args.data_dir, args.participant, classifier="multiclass-svm", components_pca=100
     )
     print(acc)

--- a/evaluate_model_transfer.py
+++ b/evaluate_model_transfer.py
@@ -51,7 +51,14 @@ def __getattr__(name):
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Evaluate model transfer for one participant.")
+    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
+    parser.add_argument("--participant", type=int, default=2, help="Participant id to evaluate.")
+    args = parser.parse_args()
+
     acc = evaluate_model_transfer(
-        r".", 2, classifier="multiclass-svm", components_pca=100
+        args.data_dir, args.participant, classifier="multiclass-svm", components_pca=100
     )
     print(acc)

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -2,15 +2,18 @@
 
 from pymegdec.alpha_signal import extract_phase, extract_time_basis
 from pymegdec.cross_validation import cross_validate_single_dataset
+from pymegdec.data_config import DATA_DIR_ENV_VAR, resolve_data_folder
 from pymegdec.model_transfer import (
     evaluate_model_transfer,
     get_original_feature_importance,
 )
 
 __all__ = [
+    "DATA_DIR_ENV_VAR",
     "cross_validate_single_dataset",
     "evaluate_model_transfer",
     "extract_phase",
     "extract_time_basis",
     "get_original_feature_importance",
+    "resolve_data_folder",
 ]

--- a/src/pymegdec/cross_validation.py
+++ b/src/pymegdec/cross_validation.py
@@ -8,6 +8,7 @@ from pymegdec.classifiers import (
     train_gradient_boosting,
     train_multiclass_classifier,
 )
+from pymegdec.data_config import resolve_data_folder
 from pymegdec.preprocessing import preprocess_features, reduce_features_pca
 
 
@@ -29,6 +30,8 @@ def cross_validate_single_dataset(
 
     if np.isnan(classifier_param):
         classifier_param = get_default_classifier_param(classifier)
+
+    data_folder = resolve_data_folder(data_folder)
 
     data = sio.loadmat(f"{data_folder}/Part{participant_id}Data.mat")["data"][0]
     labels = data["trialinfo"][0][0]

--- a/src/pymegdec/data_config.py
+++ b/src/pymegdec/data_config.py
@@ -1,0 +1,93 @@
+"""Runtime configuration for locating private MEG data files."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+
+DATA_DIR_ENV_VAR = "PYMEGDEC_DATA_DIR"
+LOCAL_DATA_DIR_FILE = ".pymegdec-data-dir"
+
+
+def _read_local_data_dir_file() -> tuple[str, Path] | None:
+    search_dirs = [Path.cwd(), *Path.cwd().parents]
+
+    package_path = Path(__file__).resolve()
+    if len(package_path.parents) > 2 and package_path.parents[1].name == "src":
+        search_dirs.append(package_path.parents[2])
+
+    seen_dirs = set()
+    for directory in search_dirs:
+        directory = directory.resolve()
+        if directory in seen_dirs:
+            continue
+        seen_dirs.add(directory)
+
+        config_path = directory / LOCAL_DATA_DIR_FILE
+        if not config_path.exists():
+            continue
+
+        for line in config_path.read_text(encoding="utf-8").splitlines():
+            value = line.strip()
+            if value and not value.startswith("#"):
+                return value, directory
+
+    return None
+
+
+def _resolve_path(
+    value: str | os.PathLike[str], *, relative_to: Path | None = None
+) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute() and relative_to is not None:
+        path = relative_to / path
+    return path.resolve()
+
+
+def resolve_data_folder(
+    data_folder: str | os.PathLike[str] | None = None,
+    *,
+    required: bool = False,
+    required_files: Iterable[str | os.PathLike[str]] = (),
+) -> str:
+    """Resolve the directory containing participant ``.mat`` files.
+
+    Resolution order is explicit argument, ``PYMEGDEC_DATA_DIR``, local
+    ``.pymegdec-data-dir`` config file, then the current working directory for
+    backwards compatibility.
+    """
+
+    source = "current working directory"
+    relative_to: Path | None = None
+
+    if data_folder:
+        raw_data_folder = data_folder
+        source = "function argument"
+    elif os.environ.get(DATA_DIR_ENV_VAR):
+        raw_data_folder = os.environ[DATA_DIR_ENV_VAR]
+        source = DATA_DIR_ENV_VAR
+    else:
+        local_config = _read_local_data_dir_file()
+        if local_config:
+            raw_data_folder, relative_to = local_config
+            source = LOCAL_DATA_DIR_FILE
+        else:
+            raw_data_folder = "."
+
+    path = _resolve_path(raw_data_folder, relative_to=relative_to)
+    missing_files = [str(name) for name in required_files if not (path / name).exists()]
+
+    if required and (not path.exists() or missing_files):
+        detail = (
+            f"Missing required data files: {', '.join(missing_files)}."
+            if missing_files
+            else "Data directory does not exist."
+        )
+        raise FileNotFoundError(
+            f"{detail} Set {DATA_DIR_ENV_VAR}, pass data_folder, or create an ignored "
+            f"{LOCAL_DATA_DIR_FILE} file. Resolved {source} to: {path}"
+        )
+
+    return str(path)

--- a/src/pymegdec/model_transfer.py
+++ b/src/pymegdec/model_transfer.py
@@ -7,6 +7,7 @@ from pymegdec.classifiers import (
     get_default_classifier_param,
     train_multiclass_classifier,
 )
+from pymegdec.data_config import resolve_data_folder
 from pymegdec.preprocessing import preprocess_features, reduce_features_pca
 
 
@@ -27,6 +28,8 @@ def evaluate_model_transfer(
 
     if not isinstance(classifier_param, dict) and np.all(np.isnan(classifier_param)):
         classifier_param = get_default_classifier_param(classifier)
+
+    data_folder = resolve_data_folder(data_folder)
 
     train_exp_data = sio.loadmat(f"{data_folder}/Part{parts}Data.mat")["data"][0]
     val_exp_data = sio.loadmat(f"{data_folder}/Part{parts}CueData.mat")["data"][0]

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -1,21 +1,24 @@
 import os
 import unittest
-from pathlib import Path
 
 import numpy as np
 
 from pymegdec.cross_validation import cross_validate_single_dataset
+from pymegdec.data_config import resolve_data_folder
 
 
 class TestCrossValidateSingleDataset(unittest.TestCase):
     def setUp(self) -> None:
-        data_folder = r"."
         participant_id = 2
-        data_file = Path(data_folder) / f"Part{participant_id}Data.mat"
-        if not data_file.exists():
+        try:
+            data_folder = resolve_data_folder(
+                required=True,
+                required_files=[f"Part{participant_id}Data.mat"],
+            )
+        except FileNotFoundError as exc:
             if os.getenv("CI"):
-                self.fail(f"Missing required test data file: {data_file}")
-            self.skipTest(f"Missing required test data file: {data_file}")
+                self.fail(str(exc))
+            self.skipTest(str(exc))
 
         self.params = {
             "data_folder": data_folder,

--- a/tests/test_data_config.py
+++ b/tests/test_data_config.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from pymegdec.data_config import DATA_DIR_ENV_VAR, resolve_data_folder
+
+
+class TestResolveDataFolder(unittest.TestCase):
+    def test_explicit_data_folder_takes_precedence(self):
+        with tempfile.TemporaryDirectory() as explicit_dir, tempfile.TemporaryDirectory() as env_dir:
+            with patch.dict(os.environ, {DATA_DIR_ENV_VAR: env_dir}):
+                self.assertEqual(
+                    resolve_data_folder(explicit_dir),
+                    str(Path(explicit_dir).resolve()),
+                )
+
+    def test_env_var_is_used_without_explicit_argument(self):
+        with tempfile.TemporaryDirectory() as env_dir:
+            with patch.dict(os.environ, {DATA_DIR_ENV_VAR: env_dir}):
+                with patch("pymegdec.data_config._read_local_data_dir_file", return_value=None):
+                    self.assertEqual(
+                        resolve_data_folder(),
+                        str(Path(env_dir).resolve()),
+                    )
+
+    def test_local_config_file_resolves_relative_to_config_directory(self):
+        previous_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            data_dir = root / "data"
+            data_dir.mkdir()
+            (root / ".pymegdec-data-dir").write_text("data\n", encoding="utf-8")
+
+            try:
+                os.chdir(root)
+                with patch.dict(os.environ, {}, clear=True):
+                    self.assertEqual(resolve_data_folder(), str(data_dir.resolve()))
+            finally:
+                os.chdir(previous_cwd)
+
+    def test_required_files_are_validated(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaises(FileNotFoundError):
+                resolve_data_folder(
+                    temp_dir,
+                    required=True,
+                    required_files=["Part2Data.mat"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_transfer.py
+++ b/tests/test_model_transfer.py
@@ -1,10 +1,10 @@
 import os
 import unittest
-from pathlib import Path
 
 import numpy as np
 
 from pymegdec.classifiers import train_multiclass_classifier
+from pymegdec.data_config import resolve_data_folder
 from pymegdec.model_transfer import evaluate_model_transfer, get_original_feature_importance
 
 
@@ -51,20 +51,19 @@ class TestLinearSvmFeatures(unittest.TestCase):
 
 class TestEvaluateModelTransfer(unittest.TestCase):
     def setUp(self) -> None:
-        self.data_folder = r"."
         self.parts = 2
-        required_files = [
-            Path(self.data_folder) / f"Part{self.parts}Data.mat",
-            Path(self.data_folder) / f"Part{self.parts}CueData.mat",
-        ]
-        missing_files = [path for path in required_files if not path.exists()]
-        if missing_files:
-            message = "Missing required test data file(s): " + ", ".join(
-                str(path) for path in missing_files
+        try:
+            self.data_folder = resolve_data_folder(
+                required=True,
+                required_files=[
+                    f"Part{self.parts}Data.mat",
+                    f"Part{self.parts}CueData.mat",
+                ],
             )
+        except FileNotFoundError as exc:
             if os.getenv("CI"):
-                self.fail(message)
-            self.skipTest(message)
+                self.fail(str(exc))
+            self.skipTest(str(exc))
 
         self.null_window_center = np.nan
 


### PR DESCRIPTION
﻿## Summary

- Add a runtime data-directory resolver with explicit argument, `PYMEGDEC_DATA_DIR`, local `.pymegdec-data-dir`, and current-directory fallback.
- Wire cross-validation/model-transfer paths, command-line wrappers, tests, and CI to use the resolver instead of requiring data in the repository root.
- Document local data configuration and ignore the local config file.

## Validation

- `PYTHONPATH=src python -m unittest tests.test_data_config tests.test_preprocessing tests.test_alpha_signal_visualization`
- `PYTHONPATH=src PYMEGDEC_DATA_DIR=<local data dir> python -m unittest tests.test_cross_validation.TestCrossValidateSingleDataset.test_cross_validate_single_dataset_accuracy_svm tests.test_model_transfer.TestEvaluateModelTransfer.test_evaluate_model_transfer_accuracy_svm`
- `python cross_validation.py --help`
- `python evaluate_model_transfer.py --help`
- `git diff --cached --check`
