### PR TITLE
Add alpha reaction-time analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ src/pymegdec/              Package source code
   alpha_signal.py          Alpha-band filtering and phase extraction
   alpha_metrics.py         Per-trial alpha power and phase-gradient export
   alpha_visualization.py   Alpha signal and phase-shift plotting helpers
+  reaction_time_analysis.py Alpha/RT join and association summaries
   classifiers.py           Classifier factories and PyTorch Lightning model
   preprocessing.py         Filtering, downsampling, window extraction, PCA
   model_transfer.py        Train-on-experiment / validate-on-cue evaluation
@@ -21,7 +22,8 @@ tests/                     Unit and data-dependent unittest suites
 Top-level `cross_validation.py`, `evaluate_model_transfer.py`,
 `extract_alpha_signal.py`, `show_bandpass_signal_and_shifts.py`, and
 `export_alpha_metrics.py` are compatibility wrappers for existing imports and
-direct script usage.
+direct script usage. `analyze_alpha_reaction_time.py` provides an exploratory
+analysis command for alpha metrics and behavioral reaction times.
 
 ## Setup
 
@@ -98,3 +100,18 @@ The exported rows include alpha power, phase concentration, planar phase-fit
 quality, spatial phase frequency, estimated propagation speed, and dominant
 phase-gradient direction on a projected sensor plane. The `outputs/` directory
 is ignored by git.
+
+## Alpha and reaction time
+
+The saved MEG `Part*Data.mat` files may not contain reaction times. The RT
+analysis command therefore accepts an external behavioral CSV with
+`participant`, `trial`, and `reaction_time` columns. If reaction times are stored
+in a future MAT `trialinfo` column, pass `--trialinfo-rt-column` instead.
+
+```powershell
+python analyze_alpha_reaction_time.py --participants 2 --reaction-times behavior_rt.csv --joined-output outputs\part2_alpha_rt_trials.csv --summary-output outputs\part2_alpha_rt_summary.csv
+```
+
+The summary includes per-participant Pearson/regression rows and a pooled
+within-participant row for each alpha metric. Phase-gradient direction is encoded
+as sine and cosine components before analysis.

--- a/analyze_alpha_reaction_time.py
+++ b/analyze_alpha_reaction_time.py
@@ -60,7 +60,9 @@ def main():
         help="Output CSV for matched trial-level alpha/RT rows.",
     )
     parser.add_argument(
-        "--summary-output", required=True, help="Output CSV for association summaries."
+        "--summary-output",
+        required=True,
+        help="Output CSV for association summaries.",
     )
     parser.add_argument(
         "--plots-dir",
@@ -102,23 +104,33 @@ def main():
         default=None,
         help="Reaction-time CSV dataset column override.",
     )
-    parser.add_argument(
-        "--location-pattern",
-        default=DEFAULT_OCCIPITAL_PATTERN,
-        help="Regex for selecting channels by label.",
+    alpha_argument_specs = (
+        (
+            "--location-pattern",
+            {
+                "default": DEFAULT_OCCIPITAL_PATTERN,
+                "help": "Regex for selecting channels by label.",
+            },
+        ),
+        (
+            "--time-window",
+            {
+                "type": _parse_range,
+                "default": DEFAULT_TIME_WINDOW,
+                "help": "Time window as start,stop in seconds.",
+            },
+        ),
+        (
+            "--frequency-range",
+            {
+                "type": _parse_range,
+                "default": DEFAULT_FREQUENCY_RANGE,
+                "help": "Frequency range as low,high in Hz.",
+            },
+        ),
     )
-    parser.add_argument(
-        "--time-window",
-        type=_parse_range,
-        default=DEFAULT_TIME_WINDOW,
-        help="Time window as start,stop in seconds.",
-    )
-    parser.add_argument(
-        "--frequency-range",
-        type=_parse_range,
-        default=DEFAULT_FREQUENCY_RANGE,
-        help="Frequency range as low,high in Hz.",
-    )
+    for name, kwargs in alpha_argument_specs:
+        parser.add_argument(name, **kwargs)
     parser.add_argument(
         "--metrics",
         nargs="*",

--- a/analyze_alpha_reaction_time.py
+++ b/analyze_alpha_reaction_time.py
@@ -1,0 +1,103 @@
+"""Analyze exploratory alpha metrics against reaction time."""
+
+import argparse
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+from pymegdec.alpha_metrics import (  # noqa: E402
+    AlphaMetricConfig,
+    DEFAULT_FREQUENCY_RANGE,
+    DEFAULT_OCCIPITAL_PATTERN,
+    DEFAULT_TIME_WINDOW,
+)
+from pymegdec.reaction_time_analysis import (  # noqa: E402
+    AlphaReactionTimeExportConfig,
+    DEFAULT_ALPHA_RT_METRICS,
+    ReactionTimeCsvConfig,
+    available_participants,
+    export_alpha_reaction_time_analysis,
+    parse_participant_spec,
+    write_alpha_reaction_time_plots,
+)
+
+
+def _parse_range(value):
+    lower, upper = value.split(",", maxsplit=1)
+    return float(lower), float(upper)
+
+
+def _participants(value, data_dir, cue):
+    if value:
+        return parse_participant_spec(value)
+    return available_participants(data_dir, cue=cue)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze prestimulus alpha metrics against reaction time.")
+    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
+    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all available MAT files.")
+    parser.add_argument("--reaction-times", default=None, help="CSV containing participant, trial, and reaction_time columns.")
+    parser.add_argument("--alpha-metrics", default=None, help="Optional precomputed alpha metrics CSV.")
+    parser.add_argument("--joined-output", required=True, help="Output CSV for matched trial-level alpha/RT rows.")
+    parser.add_argument("--summary-output", required=True, help="Output CSV for association summaries.")
+    parser.add_argument("--plots-dir", default=None, help="Optional directory for simple alpha/RT scatter plots.")
+    parser.add_argument("--cue", action="store_true", help="Use Part*CueData.mat instead of Part*Data.mat.")
+    parser.add_argument("--trialinfo-rt-column", type=int, default=None, help="Zero-based trialinfo column containing RT when no CSV is supplied.")
+    parser.add_argument("--reaction-time-scale", type=float, default=1.0, help="Scale applied to RT values, for example 0.001 for milliseconds.")
+    parser.add_argument("--participant-column", default=None, help="Reaction-time CSV participant column override.")
+    parser.add_argument("--trial-column", default=None, help="Reaction-time CSV trial column override.")
+    parser.add_argument("--reaction-time-column", default=None, help="Reaction-time CSV RT column override.")
+    parser.add_argument("--dataset-column", default=None, help="Reaction-time CSV dataset column override.")
+    parser.add_argument("--location-pattern", default=DEFAULT_OCCIPITAL_PATTERN, help="Regex for selecting channels by label.")
+    parser.add_argument("--time-window", type=_parse_range, default=DEFAULT_TIME_WINDOW, help="Time window as start,stop in seconds.")
+    parser.add_argument("--frequency-range", type=_parse_range, default=DEFAULT_FREQUENCY_RANGE, help="Frequency range as low,high in Hz.")
+    parser.add_argument("--metrics", nargs="*", default=DEFAULT_ALPHA_RT_METRICS, help="Alpha metrics to summarize.")
+    args = parser.parse_args()
+
+    participants = _participants(args.participants, args.data_dir, args.cue)
+    if not participants and (not args.alpha_metrics or not args.reaction_times):
+        parser.error("No participants found. Pass --participants or configure a data directory with matching MAT files.")
+    default_participant = participants[0] if len(participants) == 1 else None
+    alpha_config = AlphaMetricConfig(
+        location_pattern=args.location_pattern,
+        time_window=args.time_window,
+        frequency_range=args.frequency_range,
+    )
+    csv_config = ReactionTimeCsvConfig(
+        participant_column=args.participant_column,
+        trial_column=args.trial_column,
+        reaction_time_column=args.reaction_time_column,
+        dataset_column=args.dataset_column,
+        default_participant=default_participant,
+        default_dataset="cue" if args.cue else "main",
+        reaction_time_scale=args.reaction_time_scale,
+    )
+    export_config = AlphaReactionTimeExportConfig(
+        reaction_times_path=args.reaction_times,
+        alpha_metrics_path=args.alpha_metrics,
+        joined_output_path=args.joined_output,
+        summary_output_path=args.summary_output,
+        cue=args.cue,
+        alpha_config=alpha_config,
+        csv_config=csv_config,
+        trialinfo_rt_column=args.trialinfo_rt_column,
+        metrics=tuple(args.metrics),
+    )
+
+    joined_rows, summary_rows = export_alpha_reaction_time_analysis(
+        args.data_dir,
+        participants,
+        config=export_config,
+    )
+    if args.plots_dir:
+        write_alpha_reaction_time_plots(joined_rows, args.plots_dir, metrics=args.metrics)
+    print(f"Wrote {len(joined_rows)} matched trial rows to {args.joined_output}")
+    print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analyze_alpha_reaction_time.py
+++ b/analyze_alpha_reaction_time.py
@@ -1,22 +1,20 @@
 """Analyze exploratory alpha metrics against reaction time."""
 
 import argparse
-import sys
-from pathlib import Path
 
-_SRC = Path(__file__).resolve().parent / "src"
-if _SRC.exists():
-    sys.path.insert(0, str(_SRC))
+from script_bootstrap import add_src_to_path
+
+add_src_to_path(__file__)
 
 from pymegdec.alpha_metrics import (  # noqa: E402
-    AlphaMetricConfig,
     DEFAULT_FREQUENCY_RANGE,
     DEFAULT_OCCIPITAL_PATTERN,
     DEFAULT_TIME_WINDOW,
+    AlphaMetricConfig,
 )
 from pymegdec.reaction_time_analysis import (  # noqa: E402
-    AlphaReactionTimeExportConfig,
     DEFAULT_ALPHA_RT_METRICS,
+    AlphaReactionTimeExportConfig,
     ReactionTimeCsvConfig,
     available_participants,
     export_alpha_reaction_time_analysis,
@@ -37,30 +35,104 @@ def _participants(value, data_dir, cue):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Analyze prestimulus alpha metrics against reaction time.")
-    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
-    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all available MAT files.")
-    parser.add_argument("--reaction-times", default=None, help="CSV containing participant, trial, and reaction_time columns.")
-    parser.add_argument("--alpha-metrics", default=None, help="Optional precomputed alpha metrics CSV.")
-    parser.add_argument("--joined-output", required=True, help="Output CSV for matched trial-level alpha/RT rows.")
-    parser.add_argument("--summary-output", required=True, help="Output CSV for association summaries.")
-    parser.add_argument("--plots-dir", default=None, help="Optional directory for simple alpha/RT scatter plots.")
-    parser.add_argument("--cue", action="store_true", help="Use Part*CueData.mat instead of Part*Data.mat.")
-    parser.add_argument("--trialinfo-rt-column", type=int, default=None, help="Zero-based trialinfo column containing RT when no CSV is supplied.")
-    parser.add_argument("--reaction-time-scale", type=float, default=1.0, help="Scale applied to RT values, for example 0.001 for milliseconds.")
-    parser.add_argument("--participant-column", default=None, help="Reaction-time CSV participant column override.")
-    parser.add_argument("--trial-column", default=None, help="Reaction-time CSV trial column override.")
-    parser.add_argument("--reaction-time-column", default=None, help="Reaction-time CSV RT column override.")
-    parser.add_argument("--dataset-column", default=None, help="Reaction-time CSV dataset column override.")
-    parser.add_argument("--location-pattern", default=DEFAULT_OCCIPITAL_PATTERN, help="Regex for selecting channels by label.")
-    parser.add_argument("--time-window", type=_parse_range, default=DEFAULT_TIME_WINDOW, help="Time window as start,stop in seconds.")
-    parser.add_argument("--frequency-range", type=_parse_range, default=DEFAULT_FREQUENCY_RANGE, help="Frequency range as low,high in Hz.")
-    parser.add_argument("--metrics", nargs="*", default=DEFAULT_ALPHA_RT_METRICS, help="Alpha metrics to summarize.")
+    parser = argparse.ArgumentParser(
+        description="Analyze prestimulus alpha metrics against reaction time."
+    )
+    parser.add_argument(
+        "--data-dir", default=None, help="Directory containing Part*Data.mat files."
+    )
+    parser.add_argument(
+        "--participants",
+        default=None,
+        help="Participant ids such as 1-4,6,8. Defaults to all available MAT files.",
+    )
+    parser.add_argument(
+        "--reaction-times",
+        default=None,
+        help="CSV containing participant, trial, and reaction_time columns.",
+    )
+    parser.add_argument(
+        "--alpha-metrics", default=None, help="Optional precomputed alpha metrics CSV."
+    )
+    parser.add_argument(
+        "--joined-output",
+        required=True,
+        help="Output CSV for matched trial-level alpha/RT rows.",
+    )
+    parser.add_argument(
+        "--summary-output", required=True, help="Output CSV for association summaries."
+    )
+    parser.add_argument(
+        "--plots-dir",
+        default=None,
+        help="Optional directory for simple alpha/RT scatter plots.",
+    )
+    parser.add_argument(
+        "--cue",
+        action="store_true",
+        help="Use Part*CueData.mat instead of Part*Data.mat.",
+    )
+    parser.add_argument(
+        "--trialinfo-rt-column",
+        type=int,
+        default=None,
+        help="Zero-based trialinfo column containing RT when no CSV is supplied.",
+    )
+    parser.add_argument(
+        "--reaction-time-scale",
+        type=float,
+        default=1.0,
+        help="Scale applied to RT values, for example 0.001 for milliseconds.",
+    )
+    parser.add_argument(
+        "--participant-column",
+        default=None,
+        help="Reaction-time CSV participant column override.",
+    )
+    parser.add_argument(
+        "--trial-column", default=None, help="Reaction-time CSV trial column override."
+    )
+    parser.add_argument(
+        "--reaction-time-column",
+        default=None,
+        help="Reaction-time CSV RT column override.",
+    )
+    parser.add_argument(
+        "--dataset-column",
+        default=None,
+        help="Reaction-time CSV dataset column override.",
+    )
+    parser.add_argument(
+        "--location-pattern",
+        default=DEFAULT_OCCIPITAL_PATTERN,
+        help="Regex for selecting channels by label.",
+    )
+    parser.add_argument(
+        "--time-window",
+        type=_parse_range,
+        default=DEFAULT_TIME_WINDOW,
+        help="Time window as start,stop in seconds.",
+    )
+    parser.add_argument(
+        "--frequency-range",
+        type=_parse_range,
+        default=DEFAULT_FREQUENCY_RANGE,
+        help="Frequency range as low,high in Hz.",
+    )
+    parser.add_argument(
+        "--metrics",
+        nargs="*",
+        default=DEFAULT_ALPHA_RT_METRICS,
+        help="Alpha metrics to summarize.",
+    )
     args = parser.parse_args()
 
     participants = _participants(args.participants, args.data_dir, args.cue)
     if not participants and (not args.alpha_metrics or not args.reaction_times):
-        parser.error("No participants found. Pass --participants or configure a data directory with matching MAT files.")
+        parser.error(
+            "No participants found. Pass --participants or configure a data "
+            "directory with matching MAT files."
+        )
     default_participant = participants[0] if len(participants) == 1 else None
     alpha_config = AlphaMetricConfig(
         location_pattern=args.location_pattern,
@@ -94,7 +166,9 @@ def main():
         config=export_config,
     )
     if args.plots_dir:
-        write_alpha_reaction_time_plots(joined_rows, args.plots_dir, metrics=args.metrics)
+        write_alpha_reaction_time_plots(
+            joined_rows, args.plots_dir, metrics=args.metrics
+        )
     print(f"Wrote {len(joined_rows)} matched trial rows to {args.joined_output}")
     print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
 

--- a/analyze_alpha_reaction_time.py
+++ b/analyze_alpha_reaction_time.py
@@ -6,11 +6,9 @@ from script_bootstrap import add_src_to_path
 
 add_src_to_path(__file__)
 
-from pymegdec.alpha_metrics import (  # noqa: E402
-    DEFAULT_FREQUENCY_RANGE,
-    DEFAULT_OCCIPITAL_PATTERN,
-    DEFAULT_TIME_WINDOW,
-    AlphaMetricConfig,
+from pymegdec.cli import (  # noqa: E402
+    add_alpha_metric_arguments,
+    alpha_metric_config_from_args,
 )
 from pymegdec.reaction_time_analysis import (  # noqa: E402
     DEFAULT_ALPHA_RT_METRICS,
@@ -21,11 +19,6 @@ from pymegdec.reaction_time_analysis import (  # noqa: E402
     parse_participant_spec,
     write_alpha_reaction_time_plots,
 )
-
-
-def _parse_range(value):
-    lower, upper = value.split(",", maxsplit=1)
-    return float(lower), float(upper)
 
 
 def _participants(value, data_dir, cue):
@@ -60,9 +53,7 @@ def main():
         help="Output CSV for matched trial-level alpha/RT rows.",
     )
     parser.add_argument(
-        "--summary-output",
-        required=True,
-        help="Output CSV for association summaries.",
+        "--summary-output", required=True, help="Output CSV for association summaries."
     )
     parser.add_argument(
         "--plots-dir",
@@ -104,33 +95,7 @@ def main():
         default=None,
         help="Reaction-time CSV dataset column override.",
     )
-    alpha_argument_specs = (
-        (
-            "--location-pattern",
-            {
-                "default": DEFAULT_OCCIPITAL_PATTERN,
-                "help": "Regex for selecting channels by label.",
-            },
-        ),
-        (
-            "--time-window",
-            {
-                "type": _parse_range,
-                "default": DEFAULT_TIME_WINDOW,
-                "help": "Time window as start,stop in seconds.",
-            },
-        ),
-        (
-            "--frequency-range",
-            {
-                "type": _parse_range,
-                "default": DEFAULT_FREQUENCY_RANGE,
-                "help": "Frequency range as low,high in Hz.",
-            },
-        ),
-    )
-    for name, kwargs in alpha_argument_specs:
-        parser.add_argument(name, **kwargs)
+    add_alpha_metric_arguments(parser)
     parser.add_argument(
         "--metrics",
         nargs="*",
@@ -146,11 +111,7 @@ def main():
             "directory with matching MAT files."
         )
     default_participant = participants[0] if len(participants) == 1 else None
-    alpha_config = AlphaMetricConfig(
-        location_pattern=args.location_pattern,
-        time_window=args.time_window,
-        frequency_range=args.frequency_range,
-    )
+    alpha_config = alpha_metric_config_from_args(args)
     csv_config = ReactionTimeCsvConfig(
         participant_column=args.participant_column,
         trial_column=args.trial_column,

--- a/export_alpha_metrics.py
+++ b/export_alpha_metrics.py
@@ -6,18 +6,11 @@ from script_bootstrap import add_src_to_path
 
 add_src_to_path(__file__)
 
-from pymegdec.alpha_metrics import (  # noqa: E402
-    DEFAULT_FREQUENCY_RANGE,
-    DEFAULT_OCCIPITAL_PATTERN,
-    DEFAULT_TIME_WINDOW,
-    AlphaMetricConfig,
-    export_participant_alpha_metrics,
+from pymegdec.alpha_metrics import export_participant_alpha_metrics  # noqa: E402
+from pymegdec.cli import (  # noqa: E402
+    add_alpha_metric_arguments,
+    alpha_metric_config_from_args,
 )
-
-
-def _parse_range(value):
-    lower, upper = value.split(",", maxsplit=1)
-    return float(lower), float(upper)
 
 
 def main():
@@ -36,30 +29,10 @@ def main():
         action="store_true",
         help="Use Part*CueData.mat instead of Part*Data.mat.",
     )
-    parser.add_argument(
-        "--location-pattern",
-        default=DEFAULT_OCCIPITAL_PATTERN,
-        help="Regex for selecting channels by label.",
-    )
-    parser.add_argument(
-        "--time-window",
-        type=_parse_range,
-        default=DEFAULT_TIME_WINDOW,
-        help="Time window as start,stop in seconds.",
-    )
-    parser.add_argument(
-        "--frequency-range",
-        type=_parse_range,
-        default=DEFAULT_FREQUENCY_RANGE,
-        help="Frequency range as low,high in Hz.",
-    )
+    add_alpha_metric_arguments(parser)
     args = parser.parse_args()
 
-    config = AlphaMetricConfig(
-        location_pattern=args.location_pattern,
-        time_window=args.time_window,
-        frequency_range=args.frequency_range,
-    )
+    config = alpha_metric_config_from_args(args)
     rows = export_participant_alpha_metrics(
         args.data_dir,
         args.participant,

--- a/export_alpha_metrics.py
+++ b/export_alpha_metrics.py
@@ -1,12 +1,10 @@
 """Export exploratory alpha metrics for one participant."""
 
 import argparse
-import sys
-from pathlib import Path
 
-_SRC = Path(__file__).resolve().parent / "src"
-if _SRC.exists():
-    sys.path.insert(0, str(_SRC))
+from script_bootstrap import add_src_to_path
+
+add_src_to_path(__file__)
 
 from pymegdec.alpha_metrics import (  # noqa: E402
     DEFAULT_FREQUENCY_RANGE,

--- a/script_bootstrap.py
+++ b/script_bootstrap.py
@@ -1,0 +1,12 @@
+"""Helpers for running repository scripts without installing the package."""
+
+import sys
+from pathlib import Path
+
+
+def add_src_to_path(script_file):
+    """Add the repository ``src`` directory for direct script execution."""
+
+    src_dir = Path(script_file).resolve().parent / "src"
+    if src_dir.exists():
+        sys.path.insert(0, str(src_dir))

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -8,10 +8,21 @@ from pymegdec.model_transfer import (
     evaluate_model_transfer,
     get_original_feature_importance,
 )
+from pymegdec.reaction_time_analysis import (
+    AlphaReactionTimeExportConfig,
+    ReactionTimeCsvConfig,
+    ReactionTimeUnavailableError,
+    analyze_alpha_reaction_times,
+    join_alpha_reaction_times,
+)
 
 __all__ = [
     "DATA_DIR_ENV_VAR",
     "AlphaMetricConfig",
+    "AlphaReactionTimeExportConfig",
+    "ReactionTimeCsvConfig",
+    "ReactionTimeUnavailableError",
+    "analyze_alpha_reaction_times",
     "compute_alpha_metrics",
     "cross_validate_single_dataset",
     "evaluate_model_transfer",
@@ -19,5 +30,6 @@ __all__ = [
     "extract_phase",
     "extract_time_basis",
     "get_original_feature_importance",
+    "join_alpha_reaction_times",
     "resolve_data_folder",
 ]

--- a/src/pymegdec/alpha_metrics.py
+++ b/src/pymegdec/alpha_metrics.py
@@ -10,9 +10,10 @@ from pathlib import Path
 import numpy as np
 import scipy.io as sio
 import scipy.signal
+from scipy.spatial import Delaunay  # pylint: disable=no-name-in-module
+
 from pymegdec.alpha_signal import get_data_field, get_time_vector, get_trial_signal
 from pymegdec.data_config import resolve_data_folder
-from scipy.spatial import Delaunay  # pylint: disable=no-name-in-module
 
 DEFAULT_OCCIPITAL_PATTERN = r"^M[LRZ]O"
 DEFAULT_TIME_WINDOW = (-0.4, -0.05)
@@ -117,7 +118,9 @@ def _trial_label(data, trial_idx):
     return trialinfo[trial_idx].item()
 
 
-def _n_trials(data):
+def count_trials(data):
+    """Return the number of trials in a FieldTrip-like data structure."""
+
     trial_field = np.asarray(get_data_field(data, "trial"), dtype=object)
     if trial_field.ndim == 2 and trial_field.shape[0] == 1:
         return trial_field.shape[1]
@@ -260,7 +263,7 @@ def compute_alpha_metrics(
     config = config or AlphaMetricConfig()
     channel_indices = _resolve_channel_indices(data, channel_indices, config)
 
-    n_trials = _n_trials(data)
+    n_trials = count_trials(data)
     return [
         compute_alpha_trial_metrics(
             data,

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -1,0 +1,47 @@
+"""Shared command-line helpers for PyMEGDec scripts."""
+
+from pymegdec.alpha_metrics import (
+    DEFAULT_FREQUENCY_RANGE,
+    DEFAULT_OCCIPITAL_PATTERN,
+    DEFAULT_TIME_WINDOW,
+    AlphaMetricConfig,
+)
+
+
+def parse_range(value):
+    """Parse a comma-separated numeric range."""
+
+    lower, upper = value.split(",", maxsplit=1)
+    return float(lower), float(upper)
+
+
+def add_alpha_metric_arguments(parser):
+    """Add alpha metric extraction options to an argument parser."""
+
+    parser.add_argument(
+        "--location-pattern",
+        default=DEFAULT_OCCIPITAL_PATTERN,
+        help="Regex for selecting channels by label.",
+    )
+    parser.add_argument(
+        "--time-window",
+        type=parse_range,
+        default=DEFAULT_TIME_WINDOW,
+        help="Time window as start,stop in seconds.",
+    )
+    parser.add_argument(
+        "--frequency-range",
+        type=parse_range,
+        default=DEFAULT_FREQUENCY_RANGE,
+        help="Frequency range as low,high in Hz.",
+    )
+
+
+def alpha_metric_config_from_args(args):
+    """Build alpha metric config from parsed command-line arguments."""
+
+    return AlphaMetricConfig(
+        location_pattern=args.location_pattern,
+        time_window=args.time_window,
+        frequency_range=args.frequency_range,
+    )

--- a/src/pymegdec/reaction_time_analysis.py
+++ b/src/pymegdec/reaction_time_analysis.py
@@ -190,8 +190,9 @@ def load_reaction_time_csv(path, config=None):
                         else config.default_dataset
                     ),
                     "trial": _to_int(row[trial_column]),
-                    "reaction_time": _to_float(row[rt_column])
-                    * config.reaction_time_scale,
+                    "reaction_time": (
+                        _to_float(row[rt_column]) * config.reaction_time_scale
+                    ),
                 }
             )
     return rows

--- a/src/pymegdec/reaction_time_analysis.py
+++ b/src/pymegdec/reaction_time_analysis.py
@@ -190,9 +190,8 @@ def load_reaction_time_csv(path, config=None):
                         else config.default_dataset
                     ),
                     "trial": _to_int(row[trial_column]),
-                    "reaction_time": (
-                        _to_float(row[rt_column]) * config.reaction_time_scale
-                    ),
+                    "reaction_time": _to_float(row[rt_column])
+                    * config.reaction_time_scale,
                 }
             )
     return rows

--- a/src/pymegdec/reaction_time_analysis.py
+++ b/src/pymegdec/reaction_time_analysis.py
@@ -1,0 +1,474 @@
+"""Reaction-time association analysis for exploratory alpha metrics."""
+
+from __future__ import annotations
+
+import csv
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import scipy.io as sio
+from scipy import stats
+
+from pymegdec.alpha_metrics import AlphaMetricConfig, compute_alpha_metrics, load_participant_data
+from pymegdec.alpha_signal import get_data_field
+from pymegdec.data_config import resolve_data_folder
+
+DEFAULT_ALPHA_RT_METRICS = (
+    "log_alpha_power",
+    "phase_concentration",
+    "phase_plane_fit",
+    "spatial_freq_rad_per_mm",
+    "speed_m_per_s",
+    "gradient_x",
+    "gradient_y",
+    "direction_sin",
+    "direction_cos",
+)
+
+REACTION_TIME_FIELD_CANDIDATES = (
+    "reaction_time",
+    "reaction_time_s",
+    "response_time",
+    "response_time_s",
+    "rt",
+)
+
+
+class ReactionTimeUnavailableError(ValueError):
+    """Raised when reaction times are not present in the available metadata."""
+
+
+@dataclass(frozen=True)
+class ReactionTimeCsvConfig:
+    """Column mapping for an external reaction-time CSV."""
+
+    participant_column: str | None = None
+    trial_column: str | None = None
+    reaction_time_column: str | None = None
+    dataset_column: str | None = None
+    default_participant: int | str | None = None
+    default_dataset: str = "main"
+    reaction_time_scale: float = 1.0
+
+
+@dataclass(frozen=True)
+class AlphaReactionTimeExportConfig:  # pylint: disable=too-many-instance-attributes
+    """Inputs and outputs for an alpha/RT export run."""
+
+    reaction_times_path: str | Path | None = None
+    alpha_metrics_path: str | Path | None = None
+    joined_output_path: str | Path | None = None
+    summary_output_path: str | Path | None = None
+    cue: bool = False
+    alpha_config: AlphaMetricConfig | None = None
+    csv_config: ReactionTimeCsvConfig | None = None
+    trialinfo_rt_column: int | None = None
+    metrics: tuple[str, ...] = DEFAULT_ALPHA_RT_METRICS
+
+
+def parse_participant_spec(spec):
+    """Parse participant specs like ``1-4,6,8``."""
+
+    participants: list[int] = []
+    for token in str(spec).split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if "-" in token:
+            start, stop = token.split("-", maxsplit=1)
+            participants.extend(range(int(start), int(stop) + 1))
+        else:
+            participants.append(int(token))
+    return sorted(set(participants))
+
+
+def load_csv_rows(path):
+    """Load a CSV file as dictionaries."""
+
+    with Path(path).open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        return list(reader)
+
+
+def write_csv_rows(rows, output_path):
+    """Write dictionary rows to ``output_path``."""
+
+    if not rows:
+        raise ValueError("At least one row is required.")
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _clean_id(value):
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    try:
+        number = float(text)
+    except ValueError:
+        return text
+    if number.is_integer():
+        return str(int(number))
+    return text
+
+
+def _to_float(value):
+    if value is None or value == "":
+        return np.nan
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return np.nan
+
+
+def _to_int(value):
+    return int(float(str(value).strip()))
+
+
+def _column(fieldnames, explicit, candidates, *, required=True):
+    if explicit:
+        if explicit not in fieldnames:
+            raise ValueError(f"CSV column {explicit!r} was not found.")
+        return explicit
+
+    lookup = {field_name.lower(): field_name for field_name in fieldnames}
+    for candidate in candidates:
+        if candidate.lower() in lookup:
+            return lookup[candidate.lower()]
+
+    if required:
+        raise ValueError(f"CSV must contain one of these columns: {', '.join(candidates)}.")
+    return None
+
+
+def load_reaction_time_csv(path, config=None):
+    """Load external reaction times and normalize key columns."""
+
+    config = config or ReactionTimeCsvConfig()
+    with Path(path).open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+        participant_column = _column(fieldnames, config.participant_column, ("participant", "participant_id", "part"), required=config.default_participant is None)
+        trial_column = _column(fieldnames, config.trial_column, ("trial", "trial_idx", "trial_index"))
+        rt_column = _column(fieldnames, config.reaction_time_column, REACTION_TIME_FIELD_CANDIDATES)
+        dataset_column = _column(fieldnames, config.dataset_column, ("dataset", "condition", "source"), required=False)
+
+        rows = []
+        for row in reader:
+            rows.append(
+                {
+                    "participant": _clean_id(row[participant_column] if participant_column else config.default_participant),
+                    "dataset": row[dataset_column] if dataset_column else config.default_dataset,
+                    "trial": _to_int(row[trial_column]),
+                    "reaction_time": _to_float(row[rt_column]) * config.reaction_time_scale,
+                }
+            )
+    return rows
+
+
+def _data_field_names(data):
+    if isinstance(data, dict):
+        return tuple(data.keys())
+    return tuple(data.dtype.names or ())
+
+
+def _has_field(data, field_name):
+    return field_name in _data_field_names(data)
+
+
+def _n_trials(data):
+    trial_field = np.asarray(get_data_field(data, "trial"), dtype=object)
+    if trial_field.ndim == 2 and trial_field.shape[0] == 1:
+        return trial_field.shape[1]
+    return len(trial_field.ravel())
+
+
+def _trialinfo_matrix(data):
+    trialinfo = np.asarray(get_data_field(data, "trialinfo"))
+    n_trials = _n_trials(data)
+    if trialinfo.ndim == 1:
+        return trialinfo.reshape(-1, 1)
+    if trialinfo.shape[0] == n_trials:
+        return trialinfo
+    if trialinfo.shape[1] == n_trials:
+        return trialinfo.T
+    raise ValueError(f"Cannot align trialinfo shape {trialinfo.shape} to {n_trials} trials.")
+
+
+def extract_reaction_times_from_data(
+    data,
+    *,
+    participant_id=None,
+    dataset="main",
+    trialinfo_rt_column=None,
+    reaction_time_scale=1.0,
+):
+    """Extract reaction times from MAT metadata when such a field is present."""
+
+    n_trials = _n_trials(data)
+    for field_name in REACTION_TIME_FIELD_CANDIDATES:
+        if _has_field(data, field_name):
+            values = np.asarray(get_data_field(data, field_name), dtype=float).ravel()
+            return _reaction_time_rows(values, n_trials, participant_id, dataset, reaction_time_scale)
+
+    if trialinfo_rt_column is not None:
+        trialinfo = _trialinfo_matrix(data)
+        if trialinfo_rt_column >= trialinfo.shape[1]:
+            raise ValueError(f"trialinfo column {trialinfo_rt_column} does not exist.")
+        return _reaction_time_rows(trialinfo[:, trialinfo_rt_column], n_trials, participant_id, dataset, reaction_time_scale)
+
+    raise ReactionTimeUnavailableError(
+        "Reaction times were not found in the MAT data. Provide an external reaction-time CSV or pass a trialinfo RT column if one is present."
+    )
+
+
+def _reaction_time_rows(values, n_trials, participant_id, dataset, reaction_time_scale):
+    if values.size != n_trials:
+        raise ValueError(f"Expected {n_trials} reaction times, got {values.size}.")
+    return [
+        {
+            "participant": _clean_id(participant_id),
+            "dataset": dataset,
+            "trial": trial_idx,
+            "reaction_time": float(values[trial_idx]) * reaction_time_scale,
+        }
+        for trial_idx in range(n_trials)
+    ]
+
+
+def extract_reaction_times_for_participants(data_folder, participants, *, cue=False, trialinfo_rt_column=None, reaction_time_scale=1.0):
+    """Extract reaction times for participants from MAT data metadata."""
+
+    rows = []
+    dataset = "cue" if cue else "main"
+    for participant_id in participants:
+        data = load_participant_data(data_folder, participant_id, cue=cue)
+        rows.extend(
+            extract_reaction_times_from_data(
+                data,
+                participant_id=participant_id,
+                dataset=dataset,
+                trialinfo_rt_column=trialinfo_rt_column,
+                reaction_time_scale=reaction_time_scale,
+            )
+        )
+    return rows
+
+
+def compute_alpha_rows_for_participants(data_folder, participants, *, cue=False, config=None):
+    """Compute alpha metrics for participants without writing intermediate files."""
+
+    rows = []
+    config = config or AlphaMetricConfig()
+    dataset = "cue" if cue else "main"
+    for participant_id in participants:
+        data = load_participant_data(data_folder, participant_id, cue=cue)
+        rows.extend(compute_alpha_metrics(data, participant_id=participant_id, dataset=dataset, config=config))
+    return rows
+
+
+def load_participant_alpha_rows(data_folder, participants, *, cue=False, alpha_metrics_path=None, config=None):
+    """Load precomputed alpha rows or compute them from participant MAT files."""
+
+    if alpha_metrics_path:
+        return load_csv_rows(alpha_metrics_path)
+    data_folder = resolve_data_folder(data_folder)
+    return compute_alpha_rows_for_participants(data_folder, participants, cue=cue, config=config)
+
+
+def load_participant_reaction_time_rows(
+    data_folder,
+    participants,
+    *,
+    cue=False,
+    reaction_times_path=None,
+    csv_config=None,
+    trialinfo_rt_column=None,
+):
+    """Load external reaction times or extract them from participant MAT files."""
+
+    if reaction_times_path:
+        return load_reaction_time_csv(reaction_times_path, csv_config)
+    data_folder = resolve_data_folder(data_folder)
+    scale = 1.0 if csv_config is None else csv_config.reaction_time_scale
+    return extract_reaction_times_for_participants(data_folder, participants, cue=cue, trialinfo_rt_column=trialinfo_rt_column, reaction_time_scale=scale)
+
+
+def _join_key(row):
+    return (_clean_id(row.get("participant")), str(row.get("dataset", "main")), _to_int(row.get("trial")))
+
+
+def join_alpha_reaction_times(alpha_rows, reaction_time_rows):
+    """Join alpha metric rows with reaction times by participant, dataset, and trial."""
+
+    reaction_by_key = {}
+    for row in reaction_time_rows:
+        key = _join_key(row)
+        if key in reaction_by_key:
+            raise ValueError(f"Duplicate reaction-time row for key {key}.")
+        reaction_by_key[key] = row
+
+    joined_rows = []
+    for alpha_row in alpha_rows:
+        reaction_row = reaction_by_key.get(_join_key(alpha_row))
+        if reaction_row is None:
+            continue
+        joined_row = dict(alpha_row)
+        joined_row["reaction_time"] = reaction_row["reaction_time"]
+        direction = _to_float(joined_row.get("direction_rad"))
+        joined_row["direction_sin"] = math.sin(direction) if np.isfinite(direction) else np.nan
+        joined_row["direction_cos"] = math.cos(direction) if np.isfinite(direction) else np.nan
+        joined_rows.append(joined_row)
+
+    if not joined_rows:
+        raise ValueError("No alpha rows matched the reaction-time rows.")
+    return joined_rows
+
+
+def _finite_metric_arrays(rows, metric):
+    x_values = np.array([_to_float(row.get(metric)) for row in rows], dtype=float)
+    y_values = np.array([_to_float(row.get("reaction_time")) for row in rows], dtype=float)
+    valid = np.isfinite(x_values) & np.isfinite(y_values)
+    return x_values[valid], y_values[valid]
+
+
+def _association_row(scope, participant, metric, rows, min_trials):
+    x_values, y_values = _finite_metric_arrays(rows, metric)
+    result = _empty_association(scope, participant, metric, x_values, y_values)
+    if x_values.size < min_trials or np.ptp(x_values) == 0 or np.ptp(y_values) == 0:
+        return result
+
+    pearson = stats.pearsonr(x_values, y_values)
+    regression = stats.linregress(x_values, y_values)
+    result.update(
+        {
+            "pearson_r": float(pearson.statistic),
+            "pearson_p": float(pearson.pvalue),
+            "slope_reaction_time_per_unit": float(regression.slope),
+            "intercept_reaction_time": float(regression.intercept),
+        }
+    )
+    return result
+
+
+def _empty_association(scope, participant, metric, x_values, y_values):
+    return {
+        "scope": scope,
+        "participant": participant,
+        "metric": metric,
+        "n_trials": int(x_values.size),
+        "metric_mean": float(np.mean(x_values)) if x_values.size else np.nan,
+        "reaction_time_mean": float(np.mean(y_values)) if y_values.size else np.nan,
+        "pearson_r": np.nan,
+        "pearson_p": np.nan,
+        "slope_reaction_time_per_unit": np.nan,
+        "intercept_reaction_time": np.nan,
+    }
+
+
+def _group_by_participant(rows):
+    grouped: dict[str, list[dict]] = {}
+    for row in rows:
+        grouped.setdefault(_clean_id(row.get("participant")), []).append(row)
+    return grouped
+
+
+def _within_participant_centered_rows(grouped_rows, metric):
+    centered_rows = []
+    for participant_rows in grouped_rows.values():
+        x_values, y_values = _finite_metric_arrays(participant_rows, metric)
+        for x_value, y_value in zip(x_values, y_values):
+            centered_rows.append({"participant": "", metric: x_value - np.mean(x_values), "reaction_time": y_value - np.mean(y_values)})
+    return centered_rows
+
+
+def analyze_alpha_reaction_times(rows, metrics=DEFAULT_ALPHA_RT_METRICS, min_trials=3):
+    """Compute per-participant and within-participant pooled alpha/RT associations."""
+
+    summary_rows = []
+    grouped_rows = _group_by_participant(rows)
+    for metric in metrics:
+        for participant, participant_rows in grouped_rows.items():
+            summary_rows.append(_association_row("participant", participant, metric, participant_rows, min_trials))
+        centered_rows = _within_participant_centered_rows(grouped_rows, metric)
+        summary_rows.append(_association_row("pooled_within_participant", "", metric, centered_rows, min_trials))
+    return summary_rows
+
+
+def write_alpha_reaction_time_plots(rows, output_dir, metrics=DEFAULT_ALPHA_RT_METRICS, min_trials=3):
+    """Write simple scatter plots for joined alpha/RT rows."""
+
+    import matplotlib.pyplot as plt  # pylint: disable=import-outside-toplevel
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_paths = []
+    for metric in metrics:
+        x_values, y_values = _finite_metric_arrays(rows, metric)
+        if x_values.size < min_trials:
+            continue
+        figure, axes = plt.subplots(figsize=(5, 4))
+        axes.scatter(x_values, y_values, alpha=0.6, s=18)
+        axes.set_xlabel(metric)
+        axes.set_ylabel("reaction_time")
+        figure.tight_layout()
+        output_path = output_dir / f"alpha_rt_{metric}.png"
+        figure.savefig(output_path, dpi=150)
+        plt.close(figure)
+        output_paths.append(output_path)
+    return output_paths
+
+
+def export_alpha_reaction_time_analysis(
+    data_folder,
+    participants,
+    config=None,
+):
+    """Load alpha and RT data, write joined trial rows and summary associations."""
+
+    config = config or AlphaReactionTimeExportConfig()
+    alpha_rows = load_participant_alpha_rows(data_folder, participants, cue=config.cue, alpha_metrics_path=config.alpha_metrics_path, config=config.alpha_config)
+    reaction_time_rows = load_participant_reaction_time_rows(
+        data_folder,
+        participants,
+        cue=config.cue,
+        reaction_times_path=config.reaction_times_path,
+        csv_config=config.csv_config,
+        trialinfo_rt_column=config.trialinfo_rt_column,
+    )
+    joined_rows = join_alpha_reaction_times(alpha_rows, reaction_time_rows)
+    summary_rows = analyze_alpha_reaction_times(joined_rows, metrics=config.metrics)
+
+    if config.joined_output_path:
+        write_csv_rows(joined_rows, config.joined_output_path)
+    if config.summary_output_path:
+        write_csv_rows(summary_rows, config.summary_output_path)
+    return joined_rows, summary_rows
+
+
+def available_participants(data_folder, *, cue=False):
+    """Return participant ids with matching MAT files in ``data_folder``."""
+
+    data_folder = resolve_data_folder(data_folder)
+    suffix = "CueData" if cue else "Data"
+    participants = []
+    for path in Path(data_folder).glob(f"Part*{suffix}.mat"):
+        participant = path.name.removeprefix("Part").removesuffix(f"{suffix}.mat")
+        if participant.isdigit():
+            participants.append(int(participant))
+    return sorted(participants)
+
+
+def load_mat_data(path):
+    """Load a FieldTrip-like MAT data structure."""
+
+    return sio.loadmat(path)["data"][0]

--- a/src/pymegdec/reaction_time_analysis.py
+++ b/src/pymegdec/reaction_time_analysis.py
@@ -8,10 +8,15 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-import scipy.io as sio
 from scipy import stats
 
-from pymegdec.alpha_metrics import AlphaMetricConfig, compute_alpha_metrics, load_participant_data
+from pymegdec.alpha_metrics import (
+    AlphaMetricConfig,
+    compute_alpha_metrics,
+    count_trials,
+    load_participant_data,
+    write_alpha_metrics_csv,
+)
 from pymegdec.alpha_signal import get_data_field
 from pymegdec.data_config import resolve_data_folder
 
@@ -95,15 +100,7 @@ def load_csv_rows(path):
 def write_csv_rows(rows, output_path):
     """Write dictionary rows to ``output_path``."""
 
-    if not rows:
-        raise ValueError("At least one row is required.")
-
-    output_path = Path(output_path)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
-        writer.writeheader()
-        writer.writerows(rows)
+    write_alpha_metrics_csv(rows, output_path)
 
 
 def _clean_id(value):
@@ -146,7 +143,9 @@ def _column(fieldnames, explicit, candidates, *, required=True):
             return lookup[candidate.lower()]
 
     if required:
-        raise ValueError(f"CSV must contain one of these columns: {', '.join(candidates)}.")
+        raise ValueError(
+            f"CSV must contain one of these columns: {', '.join(candidates)}."
+        )
     return None
 
 
@@ -157,19 +156,42 @@ def load_reaction_time_csv(path, config=None):
     with Path(path).open(newline="", encoding="utf-8") as handle:
         reader = csv.DictReader(handle)
         fieldnames = reader.fieldnames or []
-        participant_column = _column(fieldnames, config.participant_column, ("participant", "participant_id", "part"), required=config.default_participant is None)
-        trial_column = _column(fieldnames, config.trial_column, ("trial", "trial_idx", "trial_index"))
-        rt_column = _column(fieldnames, config.reaction_time_column, REACTION_TIME_FIELD_CANDIDATES)
-        dataset_column = _column(fieldnames, config.dataset_column, ("dataset", "condition", "source"), required=False)
+        participant_column = _column(
+            fieldnames,
+            config.participant_column,
+            ("participant", "participant_id", "part"),
+            required=config.default_participant is None,
+        )
+        trial_column = _column(
+            fieldnames, config.trial_column, ("trial", "trial_idx", "trial_index")
+        )
+        rt_column = _column(
+            fieldnames, config.reaction_time_column, REACTION_TIME_FIELD_CANDIDATES
+        )
+        dataset_column = _column(
+            fieldnames,
+            config.dataset_column,
+            ("dataset", "condition", "source"),
+            required=False,
+        )
 
         rows = []
         for row in reader:
             rows.append(
                 {
-                    "participant": _clean_id(row[participant_column] if participant_column else config.default_participant),
-                    "dataset": row[dataset_column] if dataset_column else config.default_dataset,
+                    "participant": _clean_id(
+                        row[participant_column]
+                        if participant_column
+                        else config.default_participant
+                    ),
+                    "dataset": (
+                        row[dataset_column]
+                        if dataset_column
+                        else config.default_dataset
+                    ),
                     "trial": _to_int(row[trial_column]),
-                    "reaction_time": _to_float(row[rt_column]) * config.reaction_time_scale,
+                    "reaction_time": _to_float(row[rt_column])
+                    * config.reaction_time_scale,
                 }
             )
     return rows
@@ -185,23 +207,18 @@ def _has_field(data, field_name):
     return field_name in _data_field_names(data)
 
 
-def _n_trials(data):
-    trial_field = np.asarray(get_data_field(data, "trial"), dtype=object)
-    if trial_field.ndim == 2 and trial_field.shape[0] == 1:
-        return trial_field.shape[1]
-    return len(trial_field.ravel())
-
-
 def _trialinfo_matrix(data):
     trialinfo = np.asarray(get_data_field(data, "trialinfo"))
-    n_trials = _n_trials(data)
+    n_trials = count_trials(data)
     if trialinfo.ndim == 1:
         return trialinfo.reshape(-1, 1)
     if trialinfo.shape[0] == n_trials:
         return trialinfo
     if trialinfo.shape[1] == n_trials:
         return trialinfo.T
-    raise ValueError(f"Cannot align trialinfo shape {trialinfo.shape} to {n_trials} trials.")
+    raise ValueError(
+        f"Cannot align trialinfo shape {trialinfo.shape} to {n_trials} trials."
+    )
 
 
 def extract_reaction_times_from_data(
@@ -214,20 +231,29 @@ def extract_reaction_times_from_data(
 ):
     """Extract reaction times from MAT metadata when such a field is present."""
 
-    n_trials = _n_trials(data)
+    n_trials = count_trials(data)
     for field_name in REACTION_TIME_FIELD_CANDIDATES:
         if _has_field(data, field_name):
             values = np.asarray(get_data_field(data, field_name), dtype=float).ravel()
-            return _reaction_time_rows(values, n_trials, participant_id, dataset, reaction_time_scale)
+            return _reaction_time_rows(
+                values, n_trials, participant_id, dataset, reaction_time_scale
+            )
 
     if trialinfo_rt_column is not None:
         trialinfo = _trialinfo_matrix(data)
         if trialinfo_rt_column >= trialinfo.shape[1]:
             raise ValueError(f"trialinfo column {trialinfo_rt_column} does not exist.")
-        return _reaction_time_rows(trialinfo[:, trialinfo_rt_column], n_trials, participant_id, dataset, reaction_time_scale)
+        return _reaction_time_rows(
+            trialinfo[:, trialinfo_rt_column],
+            n_trials,
+            participant_id,
+            dataset,
+            reaction_time_scale,
+        )
 
     raise ReactionTimeUnavailableError(
-        "Reaction times were not found in the MAT data. Provide an external reaction-time CSV or pass a trialinfo RT column if one is present."
+        "Reaction times were not found in the MAT data. Provide an external "
+        "reaction-time CSV or pass a trialinfo RT column if one is present."
     )
 
 
@@ -245,7 +271,14 @@ def _reaction_time_rows(values, n_trials, participant_id, dataset, reaction_time
     ]
 
 
-def extract_reaction_times_for_participants(data_folder, participants, *, cue=False, trialinfo_rt_column=None, reaction_time_scale=1.0):
+def extract_reaction_times_for_participants(
+    data_folder,
+    participants,
+    *,
+    cue=False,
+    trialinfo_rt_column=None,
+    reaction_time_scale=1.0,
+):
     """Extract reaction times for participants from MAT data metadata."""
 
     rows = []
@@ -264,7 +297,9 @@ def extract_reaction_times_for_participants(data_folder, participants, *, cue=Fa
     return rows
 
 
-def compute_alpha_rows_for_participants(data_folder, participants, *, cue=False, config=None):
+def compute_alpha_rows_for_participants(
+    data_folder, participants, *, cue=False, config=None
+):
     """Compute alpha metrics for participants without writing intermediate files."""
 
     rows = []
@@ -272,17 +307,25 @@ def compute_alpha_rows_for_participants(data_folder, participants, *, cue=False,
     dataset = "cue" if cue else "main"
     for participant_id in participants:
         data = load_participant_data(data_folder, participant_id, cue=cue)
-        rows.extend(compute_alpha_metrics(data, participant_id=participant_id, dataset=dataset, config=config))
+        rows.extend(
+            compute_alpha_metrics(
+                data, participant_id=participant_id, dataset=dataset, config=config
+            )
+        )
     return rows
 
 
-def load_participant_alpha_rows(data_folder, participants, *, cue=False, alpha_metrics_path=None, config=None):
+def load_participant_alpha_rows(
+    data_folder, participants, *, cue=False, alpha_metrics_path=None, config=None
+):
     """Load precomputed alpha rows or compute them from participant MAT files."""
 
     if alpha_metrics_path:
         return load_csv_rows(alpha_metrics_path)
     data_folder = resolve_data_folder(data_folder)
-    return compute_alpha_rows_for_participants(data_folder, participants, cue=cue, config=config)
+    return compute_alpha_rows_for_participants(
+        data_folder, participants, cue=cue, config=config
+    )
 
 
 def load_participant_reaction_time_rows(
@@ -300,11 +343,21 @@ def load_participant_reaction_time_rows(
         return load_reaction_time_csv(reaction_times_path, csv_config)
     data_folder = resolve_data_folder(data_folder)
     scale = 1.0 if csv_config is None else csv_config.reaction_time_scale
-    return extract_reaction_times_for_participants(data_folder, participants, cue=cue, trialinfo_rt_column=trialinfo_rt_column, reaction_time_scale=scale)
+    return extract_reaction_times_for_participants(
+        data_folder,
+        participants,
+        cue=cue,
+        trialinfo_rt_column=trialinfo_rt_column,
+        reaction_time_scale=scale,
+    )
 
 
 def _join_key(row):
-    return (_clean_id(row.get("participant")), str(row.get("dataset", "main")), _to_int(row.get("trial")))
+    return (
+        _clean_id(row.get("participant")),
+        str(row.get("dataset", "main")),
+        _to_int(row.get("trial")),
+    )
 
 
 def join_alpha_reaction_times(alpha_rows, reaction_time_rows):
@@ -325,8 +378,12 @@ def join_alpha_reaction_times(alpha_rows, reaction_time_rows):
         joined_row = dict(alpha_row)
         joined_row["reaction_time"] = reaction_row["reaction_time"]
         direction = _to_float(joined_row.get("direction_rad"))
-        joined_row["direction_sin"] = math.sin(direction) if np.isfinite(direction) else np.nan
-        joined_row["direction_cos"] = math.cos(direction) if np.isfinite(direction) else np.nan
+        joined_row["direction_sin"] = (
+            math.sin(direction) if np.isfinite(direction) else np.nan
+        )
+        joined_row["direction_cos"] = (
+            math.cos(direction) if np.isfinite(direction) else np.nan
+        )
         joined_rows.append(joined_row)
 
     if not joined_rows:
@@ -336,7 +393,9 @@ def join_alpha_reaction_times(alpha_rows, reaction_time_rows):
 
 def _finite_metric_arrays(rows, metric):
     x_values = np.array([_to_float(row.get(metric)) for row in rows], dtype=float)
-    y_values = np.array([_to_float(row.get("reaction_time")) for row in rows], dtype=float)
+    y_values = np.array(
+        [_to_float(row.get("reaction_time")) for row in rows], dtype=float
+    )
     valid = np.isfinite(x_values) & np.isfinite(y_values)
     return x_values[valid], y_values[valid]
 
@@ -387,7 +446,13 @@ def _within_participant_centered_rows(grouped_rows, metric):
     for participant_rows in grouped_rows.values():
         x_values, y_values = _finite_metric_arrays(participant_rows, metric)
         for x_value, y_value in zip(x_values, y_values):
-            centered_rows.append({"participant": "", metric: x_value - np.mean(x_values), "reaction_time": y_value - np.mean(y_values)})
+            centered_rows.append(
+                {
+                    "participant": "",
+                    metric: x_value - np.mean(x_values),
+                    "reaction_time": y_value - np.mean(y_values),
+                }
+            )
     return centered_rows
 
 
@@ -398,13 +463,23 @@ def analyze_alpha_reaction_times(rows, metrics=DEFAULT_ALPHA_RT_METRICS, min_tri
     grouped_rows = _group_by_participant(rows)
     for metric in metrics:
         for participant, participant_rows in grouped_rows.items():
-            summary_rows.append(_association_row("participant", participant, metric, participant_rows, min_trials))
+            summary_rows.append(
+                _association_row(
+                    "participant", participant, metric, participant_rows, min_trials
+                )
+            )
         centered_rows = _within_participant_centered_rows(grouped_rows, metric)
-        summary_rows.append(_association_row("pooled_within_participant", "", metric, centered_rows, min_trials))
+        summary_rows.append(
+            _association_row(
+                "pooled_within_participant", "", metric, centered_rows, min_trials
+            )
+        )
     return summary_rows
 
 
-def write_alpha_reaction_time_plots(rows, output_dir, metrics=DEFAULT_ALPHA_RT_METRICS, min_trials=3):
+def write_alpha_reaction_time_plots(
+    rows, output_dir, metrics=DEFAULT_ALPHA_RT_METRICS, min_trials=3
+):
     """Write simple scatter plots for joined alpha/RT rows."""
 
     import matplotlib.pyplot as plt  # pylint: disable=import-outside-toplevel
@@ -436,7 +511,13 @@ def export_alpha_reaction_time_analysis(
     """Load alpha and RT data, write joined trial rows and summary associations."""
 
     config = config or AlphaReactionTimeExportConfig()
-    alpha_rows = load_participant_alpha_rows(data_folder, participants, cue=config.cue, alpha_metrics_path=config.alpha_metrics_path, config=config.alpha_config)
+    alpha_rows = load_participant_alpha_rows(
+        data_folder,
+        participants,
+        cue=config.cue,
+        alpha_metrics_path=config.alpha_metrics_path,
+        config=config.alpha_config,
+    )
     reaction_time_rows = load_participant_reaction_time_rows(
         data_folder,
         participants,
@@ -466,9 +547,3 @@ def available_participants(data_folder, *, cue=False):
         if participant.isdigit():
             participants.append(int(participant))
     return sorted(participants)
-
-
-def load_mat_data(path):
-    """Load a FieldTrip-like MAT data structure."""
-
-    return sio.loadmat(path)["data"][0]

--- a/tests/test_reaction_time_analysis.py
+++ b/tests/test_reaction_time_analysis.py
@@ -17,16 +17,12 @@ from pymegdec.reaction_time_analysis import (
 )
 
 
-def _cell_array(values):
-    inner = np.empty((1, len(values)), dtype=object)
-    for index, value in enumerate(values):
-        inner[0, index] = value
-    return inner
-
-
 def _synthetic_data(trialinfo):
+    trials = np.empty(3, dtype=object)
+    for index in range(3):
+        trials[index] = np.zeros((1, 2))
     return {
-        "trial": _cell_array([np.zeros((1, 2)), np.zeros((1, 2)), np.zeros((1, 2))]),
+        "trial": trials,
         "trialinfo": np.asarray(trialinfo),
     }
 
@@ -44,7 +40,9 @@ class TestReactionTimeAnalysis(unittest.TestCase):
             path = Path(temp_dir) / "rt.csv"
             write_csv_rows(rows, path)
 
-            loaded = load_reaction_time_csv(path, ReactionTimeCsvConfig(default_participant=2))
+            loaded = load_reaction_time_csv(
+                path, ReactionTimeCsvConfig(default_participant=2)
+            )
 
         self.assertEqual(loaded[0]["participant"], "2")
         self.assertEqual(loaded[0]["dataset"], "main")
@@ -59,11 +57,15 @@ class TestReactionTimeAnalysis(unittest.TestCase):
             ]
         )
 
-        rows = extract_reaction_times_from_data(data, participant_id=5, trialinfo_rt_column=1)
+        rows = extract_reaction_times_from_data(
+            data, participant_id=5, trialinfo_rt_column=1
+        )
 
         self.assertEqual([row["trial"] for row in rows], [0, 1, 2])
         self.assertEqual([row["participant"] for row in rows], ["5", "5", "5"])
-        np.testing.assert_allclose([row["reaction_time"] for row in rows], [0.41, 0.52, 0.63])
+        np.testing.assert_allclose(
+            [row["reaction_time"] for row in rows], [0.41, 0.52, 0.63]
+        )
 
     def test_extract_reaction_times_raises_when_absent(self):
         data = _synthetic_data([[1, 2, 3]])
@@ -73,8 +75,20 @@ class TestReactionTimeAnalysis(unittest.TestCase):
 
     def test_join_adds_direction_components(self):
         alpha_rows = [
-            {"participant": 2, "dataset": "main", "trial": 0, "log_alpha_power": 1.0, "direction_rad": 0.0},
-            {"participant": 2, "dataset": "main", "trial": 1, "log_alpha_power": 2.0, "direction_rad": np.pi / 2},
+            {
+                "participant": 2,
+                "dataset": "main",
+                "trial": 0,
+                "log_alpha_power": 1.0,
+                "direction_rad": 0.0,
+            },
+            {
+                "participant": 2,
+                "dataset": "main",
+                "trial": 1,
+                "log_alpha_power": 2.0,
+                "direction_rad": np.pi / 2,
+            },
         ]
         reaction_rows = [
             {"participant": 2, "dataset": "main", "trial": 0, "reaction_time": 0.4},

--- a/tests/test_reaction_time_analysis.py
+++ b/tests/test_reaction_time_analysis.py
@@ -1,0 +1,125 @@
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from pymegdec.reaction_time_analysis import (
+    ReactionTimeCsvConfig,
+    ReactionTimeUnavailableError,
+    analyze_alpha_reaction_times,
+    extract_reaction_times_from_data,
+    join_alpha_reaction_times,
+    load_reaction_time_csv,
+    parse_participant_spec,
+    write_csv_rows,
+)
+
+
+def _cell_array(values):
+    inner = np.empty((1, len(values)), dtype=object)
+    for index, value in enumerate(values):
+        inner[0, index] = value
+    return inner
+
+
+def _synthetic_data(trialinfo):
+    return {
+        "trial": _cell_array([np.zeros((1, 2)), np.zeros((1, 2)), np.zeros((1, 2))]),
+        "trialinfo": np.asarray(trialinfo),
+    }
+
+
+class TestReactionTimeAnalysis(unittest.TestCase):
+    def test_parse_participant_spec(self):
+        self.assertEqual(parse_participant_spec("1-3,2,8"), [1, 2, 3, 8])
+
+    def test_load_reaction_time_csv_uses_single_participant_default(self):
+        rows = [
+            {"trial": 0, "rt": 0.45},
+            {"trial": 1, "rt": 0.50},
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "rt.csv"
+            write_csv_rows(rows, path)
+
+            loaded = load_reaction_time_csv(path, ReactionTimeCsvConfig(default_participant=2))
+
+        self.assertEqual(loaded[0]["participant"], "2")
+        self.assertEqual(loaded[0]["dataset"], "main")
+        self.assertEqual(loaded[1]["reaction_time"], 0.50)
+
+    def test_extract_reaction_times_from_trialinfo_column(self):
+        data = _synthetic_data(
+            [
+                [1, 0.41],
+                [2, 0.52],
+                [3, 0.63],
+            ]
+        )
+
+        rows = extract_reaction_times_from_data(data, participant_id=5, trialinfo_rt_column=1)
+
+        self.assertEqual([row["trial"] for row in rows], [0, 1, 2])
+        self.assertEqual([row["participant"] for row in rows], ["5", "5", "5"])
+        np.testing.assert_allclose([row["reaction_time"] for row in rows], [0.41, 0.52, 0.63])
+
+    def test_extract_reaction_times_raises_when_absent(self):
+        data = _synthetic_data([[1, 2, 3]])
+
+        with self.assertRaises(ReactionTimeUnavailableError):
+            extract_reaction_times_from_data(data)
+
+    def test_join_adds_direction_components(self):
+        alpha_rows = [
+            {"participant": 2, "dataset": "main", "trial": 0, "log_alpha_power": 1.0, "direction_rad": 0.0},
+            {"participant": 2, "dataset": "main", "trial": 1, "log_alpha_power": 2.0, "direction_rad": np.pi / 2},
+        ]
+        reaction_rows = [
+            {"participant": 2, "dataset": "main", "trial": 0, "reaction_time": 0.4},
+            {"participant": 2, "dataset": "main", "trial": 1, "reaction_time": 0.6},
+        ]
+
+        joined = join_alpha_reaction_times(alpha_rows, reaction_rows)
+
+        self.assertEqual(len(joined), 2)
+        self.assertAlmostEqual(joined[0]["direction_cos"], 1.0)
+        self.assertAlmostEqual(joined[1]["direction_sin"], 1.0)
+
+    def test_analyze_alpha_reaction_times_reports_participant_and_pooled_rows(self):
+        rows = []
+        for participant in (1, 2):
+            for trial_idx in range(4):
+                value = float(trial_idx)
+                rows.append(
+                    {
+                        "participant": participant,
+                        "dataset": "main",
+                        "trial": trial_idx,
+                        "log_alpha_power": value,
+                        "reaction_time": 0.3 + value * 0.1 + participant,
+                    }
+                )
+
+        summary = analyze_alpha_reaction_times(rows, metrics=("log_alpha_power",))
+
+        self.assertEqual(len(summary), 3)
+        for row in summary:
+            self.assertEqual(row["metric"], "log_alpha_power")
+            self.assertAlmostEqual(row["pearson_r"], 1.0)
+
+    def test_write_csv_rows(self):
+        rows = [{"a": 1, "b": "x"}]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "rows.csv"
+            write_csv_rows(rows, path)
+            with path.open(newline="", encoding="utf-8") as handle:
+                loaded = list(csv.DictReader(handle))
+
+        self.assertEqual(loaded, [{"a": "1", "b": "x"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `reaction_time_analysis` utilities for joining alpha metrics to reaction times by participant, dataset, and trial.
- Add `analyze_alpha_reaction_time.py` CLI for producing matched trial rows, association summaries, and optional scatter plots.
- Support external behavioral RT CSVs and explicit `trialinfo` RT columns, while failing clearly when the current MAT metadata lacks RT.
- Document the alpha/RT workflow and add unit coverage for CSV loading, RT extraction, joins, direction encoding, and association summaries.

## Validation
- `PYTHONPATH=src python -m unittest tests.test_reaction_time_analysis tests.test_alpha_metrics tests.test_alpha_signal_visualization tests.test_preprocessing tests.test_data_config`
- `PYTHONPATH=src python -m ruff check .`
- `PYTHONPATH=src python -m mypy src`
- `PYTHONPATH=src python -m pylint src analyze_alpha_reaction_time.py export_alpha_metrics.py`
- Smoke-tested participant 2 with a temporary synthetic RT CSV and real MEG data: 720 matched trial rows, 18 summary rows.
- Verified current `Part2Data.mat` raises `ReactionTimeUnavailableError` when no RT source is supplied.