### PR TITLE
Add sensor-level alpha movement export

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ conditions and cross-validation on a single dataset.
 src/pymegdec/              Package source code
   alpha_signal.py          Alpha-band filtering and phase extraction
   alpha_metrics.py         Per-trial alpha power and phase-gradient export
+  alpha_movement.py        Sensor-level alpha movement trajectory export
   alpha_visualization.py   Alpha signal and phase-shift plotting helpers
   reaction_time_analysis.py Alpha/RT join and association summaries
   classifiers.py           Classifier factories and PyTorch Lightning model
@@ -24,6 +25,7 @@ Top-level `cross_validation.py`, `evaluate_model_transfer.py`,
 `export_alpha_metrics.py` are compatibility wrappers for existing imports and
 direct script usage. `analyze_alpha_reaction_time.py` provides an exploratory
 analysis command for alpha metrics and behavioral reaction times.
+`analyze_alpha_movement.py` exports sensor-level alpha movement trajectories.
 
 ## Setup
 
@@ -100,6 +102,27 @@ The exported rows include alpha power, phase concentration, planar phase-fit
 quality, spatial phase frequency, estimated propagation speed, and dominant
 phase-gradient direction on a projected sensor plane. The `outputs/` directory
 is ignored by git.
+
+## Sensor-level alpha movement
+
+The MAT files contain CTF sensor geometry in `data.grad.chanpos`, with positions
+in millimeters. This supports sensor-array analyses of alpha topography, but not
+source-localized brain movement. The movement exporter therefore tracks a
+sensor-level proxy: for each trial and sampled time point, it filters the chosen
+MEG channels to the alpha band, computes alpha power, and writes the
+power-weighted centroid over the MEG sensor positions.
+
+By default it uses all MEG channels matching `^M`, the `8-12 Hz` alpha band, and
+a `-0.4` to `0.8 s` window around stimulus onset.
+
+```powershell
+python analyze_alpha_movement.py --participants 2 --trajectory-output outputs\part2_alpha_movement.csv --summary-output outputs\part2_alpha_movement_summary.csv
+```
+
+The trajectory CSV includes 3D CTF sensor centroids, projected 2D centroids,
+stepwise speed, displacement from the first sampled time point, the peak-power
+channel, and a spatial concentration score. Treat the trajectory as movement of
+the measured alpha topography over sensors, not as anatomical source motion.
 
 ## Alpha and reaction time
 

--- a/analyze_alpha_movement.py
+++ b/analyze_alpha_movement.py
@@ -1,0 +1,111 @@
+"""Export sensor-level alpha movement trajectories."""
+
+import argparse
+
+from script_bootstrap import add_src_to_path
+
+add_src_to_path(__file__)
+
+from pymegdec.alpha_movement import (  # noqa: E402
+    DEFAULT_MOVEMENT_TIME_WINDOW,
+    DEFAULT_SENSOR_PATTERN,
+    DEFAULT_TRAJECTORY_STEP_S,
+    AlphaMovementConfig,
+    export_alpha_movement,
+)
+from pymegdec.cli import parse_range  # noqa: E402
+from pymegdec.reaction_time_analysis import (  # noqa: E402
+    available_participants,
+    parse_participant_spec,
+)
+
+
+def _participants(value, data_dir, cue):
+    if value:
+        return parse_participant_spec(value)
+    return available_participants(data_dir, cue=cue)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export sensor-level alpha movement trajectories. The trajectory is "
+            "a MEG sensor-array proxy, not source-localized brain movement."
+        )
+    )
+    parser.add_argument(
+        "--data-dir", default=None, help="Directory containing Part*Data.mat files."
+    )
+    parser.add_argument(
+        "--participants",
+        default=None,
+        help="Participant ids such as 1-4,6,8. Defaults to all available MAT files.",
+    )
+    parser.add_argument(
+        "--trajectory-output",
+        required=True,
+        help="Output CSV for trial/timepoint sensor-level trajectories.",
+    )
+    parser.add_argument(
+        "--summary-output",
+        default=None,
+        help="Optional output CSV averaged by participant, condition, and time.",
+    )
+    parser.add_argument(
+        "--cue",
+        action="store_true",
+        help="Use Part*CueData.mat instead of Part*Data.mat.",
+    )
+    parser.add_argument(
+        "--location-pattern",
+        default=DEFAULT_SENSOR_PATTERN,
+        help="Regex for selecting channels by label. Defaults to all MEG channels.",
+    )
+    parser.add_argument(
+        "--time-window",
+        type=parse_range,
+        default=DEFAULT_MOVEMENT_TIME_WINDOW,
+        help="Time window as start,stop in seconds.",
+    )
+    parser.add_argument(
+        "--frequency-range",
+        type=parse_range,
+        default=(8.0, 12.0),
+        help="Frequency range as low,high in Hz.",
+    )
+    parser.add_argument(
+        "--trajectory-step-s",
+        type=float,
+        default=DEFAULT_TRAJECTORY_STEP_S,
+        help="Trajectory sampling step in seconds.",
+    )
+    args = parser.parse_args()
+
+    participants = _participants(args.participants, args.data_dir, args.cue)
+    if not participants:
+        parser.error(
+            "No participants found. Pass --participants or configure a data "
+            "directory with matching MAT files."
+        )
+
+    config = AlphaMovementConfig(
+        location_pattern=args.location_pattern,
+        time_window=args.time_window,
+        frequency_range=args.frequency_range,
+        trajectory_step_s=args.trajectory_step_s,
+    )
+    rows, summary_rows = export_alpha_movement(
+        args.data_dir,
+        participants,
+        args.trajectory_output,
+        summary_output_path=args.summary_output,
+        cue=args.cue,
+        config=config,
+    )
+    print(f"Wrote {len(rows)} trajectory rows to {args.trajectory_output}")
+    if args.summary_output:
+        print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -5,6 +5,11 @@ from pymegdec.alpha_metrics import (
     compute_alpha_metrics,
     export_participant_alpha_metrics,
 )
+from pymegdec.alpha_movement import (
+    AlphaMovementConfig,
+    compute_alpha_movement,
+    export_alpha_movement,
+)
 from pymegdec.alpha_signal import extract_phase, extract_time_basis
 from pymegdec.cross_validation import cross_validate_single_dataset
 from pymegdec.data_config import DATA_DIR_ENV_VAR, resolve_data_folder
@@ -23,13 +28,16 @@ from pymegdec.reaction_time_analysis import (
 __all__ = [
     "DATA_DIR_ENV_VAR",
     "AlphaMetricConfig",
+    "AlphaMovementConfig",
     "AlphaReactionTimeExportConfig",
     "ReactionTimeCsvConfig",
     "ReactionTimeUnavailableError",
     "analyze_alpha_reaction_times",
+    "compute_alpha_movement",
     "compute_alpha_metrics",
     "cross_validate_single_dataset",
     "evaluate_model_transfer",
+    "export_alpha_movement",
     "export_participant_alpha_metrics",
     "extract_phase",
     "extract_time_basis",

--- a/src/pymegdec/alpha_metrics.py
+++ b/src/pymegdec/alpha_metrics.py
@@ -178,7 +178,9 @@ def _resolve_channel_indices(data, channel_indices, config):
     return channel_indices
 
 
-def _alpha_window_and_phase(signal, time_vector, config):
+def compute_alpha_analytic_window(signal, time_vector, config):
+    """Return alpha-band analytic signal samples in ``config.time_window``."""
+
     sampling_rate = 1 / np.diff(time_vector[:2])[0]
     time_indices = np.flatnonzero(_time_mask(time_vector, config.time_window))
     low_freq, high_freq = config.frequency_range
@@ -193,6 +195,11 @@ def _alpha_window_and_phase(signal, time_vector, config):
     alpha_signal = scipy.signal.sosfiltfilt(sos, signal, axis=-1)
     analytic_signal = scipy.signal.hilbert(alpha_signal, axis=-1)
     alpha_window = np.take(analytic_signal, time_indices, axis=-1)
+    return alpha_window, time_indices
+
+
+def _alpha_window_and_phase(signal, time_vector, config):
+    alpha_window, _ = compute_alpha_analytic_window(signal, time_vector, config)
     return alpha_window, np.angle(alpha_window)
 
 

--- a/src/pymegdec/alpha_movement.py
+++ b/src/pymegdec/alpha_movement.py
@@ -1,0 +1,411 @@
+"""Sensor-level alpha movement trajectories for MEG trials."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+import numpy as np
+
+from pymegdec.alpha_metrics import (
+    DEFAULT_FREQUENCY_RANGE,
+    compute_alpha_analytic_window,
+    count_trials,
+    get_channel_names,
+    get_channel_positions,
+    load_participant_data,
+    project_sensor_positions,
+    select_channels,
+    write_alpha_metrics_csv,
+)
+from pymegdec.alpha_signal import get_data_field, get_time_vector, get_trial_signal
+
+DEFAULT_SENSOR_PATTERN = r"^M"
+DEFAULT_MOVEMENT_TIME_WINDOW = (-0.4, 0.8)
+DEFAULT_TRAJECTORY_STEP_S = 0.02
+POWER_EPSILON = 1e-12
+
+
+@dataclass(frozen=True)
+class AlphaMovementConfig:
+    """Parameters for sensor-level alpha movement trajectory extraction."""
+
+    location_pattern: str = DEFAULT_SENSOR_PATTERN
+    time_window: tuple[float, float] = DEFAULT_MOVEMENT_TIME_WINDOW
+    frequency_range: tuple[float, float] = DEFAULT_FREQUENCY_RANGE
+    trajectory_step_s: float | None = DEFAULT_TRAJECTORY_STEP_S
+    filter_order: int = 5
+
+
+@dataclass(frozen=True)
+class _MovementContext:
+    data: object
+    trial_idx: int
+    participant_id: object
+    dataset: str
+    config: AlphaMovementConfig
+
+
+@dataclass(frozen=True)
+class _MovementGeometry:
+    channel_indices: np.ndarray
+    channel_names: np.ndarray
+    positions: np.ndarray
+    projected_positions: np.ndarray
+
+
+@dataclass
+class _MovementState:
+    first: dict | None = None
+    previous: dict | None = None
+    previous_time: float = np.nan
+
+
+def _trial_label(data, trial_idx):
+    try:
+        trialinfo = np.asarray(get_data_field(data, "trialinfo")).ravel()
+    except (KeyError, ValueError):
+        return np.nan
+    return trialinfo[trial_idx].item()
+
+
+def _resolve_channel_indices(data, channel_indices, location_pattern):
+    if channel_indices is None:
+        channel_indices = select_channels(data, location_pattern)
+
+    resolved = np.asarray(channel_indices, dtype=int)
+    if resolved.size == 0:
+        raise ValueError(f"No channels matched pattern: {location_pattern}")
+    return resolved
+
+
+def _sampling_rate(time_vector):
+    diffs = np.diff(time_vector)
+    if diffs.size == 0:
+        raise ValueError("Time vector must contain at least two samples.")
+    return float(1 / np.median(diffs))
+
+
+def sample_time_indices(time_vector, time_window, trajectory_step_s):
+    """Return time indices inside ``time_window`` sampled at ``trajectory_step_s``."""
+
+    start, stop = time_window
+    if start >= stop:
+        raise ValueError("time_window start must be before stop.")
+
+    time_vector = np.asarray(time_vector, dtype=float).ravel()
+    if time_vector.size < 2:
+        raise ValueError("Time vector must contain at least two samples.")
+    tolerance = max(abs(float(np.median(np.diff(time_vector)))) * 1e-6, 1e-12)
+    window_indices = np.flatnonzero(
+        (time_vector >= start - tolerance) & (time_vector <= stop + tolerance)
+    )
+    if window_indices.size == 0:
+        raise ValueError(f"time_window {time_window} does not overlap the data.")
+    if trajectory_step_s is None:
+        return window_indices
+    if trajectory_step_s <= 0:
+        raise ValueError("trajectory_step_s must be positive.")
+
+    first_time = max(start, float(time_vector[window_indices[0]]))
+    last_time = min(stop, float(time_vector[window_indices[-1]]))
+    targets = np.arange(
+        first_time, last_time + trajectory_step_s / 2, trajectory_step_s
+    )
+    sampled = [
+        int(window_indices[np.argmin(np.abs(time_vector[window_indices] - target))])
+        for target in targets
+    ]
+    return np.unique(sampled)
+
+
+def _alpha_power(signal, time_vector, sample_indices, config):
+    _sampling_rate(time_vector)
+    alpha_window, window_indices = compute_alpha_analytic_window(
+        signal, time_vector, config
+    )
+    relative_indices = np.array(
+        [
+            int(np.argmin(np.abs(window_indices - sample_index)))
+            for sample_index in sample_indices
+        ],
+        dtype=int,
+    )
+    return np.abs(np.take(alpha_window, relative_indices, axis=-1)) ** 2
+
+
+def _spatial_concentration(weights):
+    probabilities = weights / np.sum(weights)
+    entropy = -float(np.sum(probabilities * np.log(probabilities + POWER_EPSILON)))
+    max_entropy = np.log(weights.size)
+    if max_entropy <= 0:
+        return 1.0
+    return float(1 - entropy / max_entropy)
+
+
+def _movement_values(centroid, projected, first, previous, previous_time, time_s):
+    if previous is None:
+        return {
+            "displacement_mm": 0.0,
+            "projected_displacement_mm": 0.0,
+            "speed_mm_per_s": np.nan,
+            "projected_speed_mm_per_s": np.nan,
+            "projected_direction_rad": np.nan,
+        }
+
+    dt = time_s - previous_time
+    if dt <= 0:
+        speed = np.nan
+        projected_speed = np.nan
+    else:
+        speed = float(np.linalg.norm(centroid - previous["centroid"]) / dt)
+        projected_speed = float(np.linalg.norm(projected - previous["projected"]) / dt)
+
+    projected_step = projected - previous["projected"]
+    return {
+        "displacement_mm": float(np.linalg.norm(centroid - first["centroid"])),
+        "projected_displacement_mm": float(
+            np.linalg.norm(projected - first["projected"])
+        ),
+        "speed_mm_per_s": speed,
+        "projected_speed_mm_per_s": projected_speed,
+        "projected_direction_rad": float(
+            np.arctan2(projected_step[1], projected_step[0])
+        ),
+    }
+
+
+def _selected_geometry(data, trial_signal, channel_indices):
+    positions = np.take(
+        get_channel_positions(data, trial_signal.shape[0]), channel_indices, axis=0
+    )
+    channel_names = np.asarray(
+        get_channel_names(data, trial_signal.shape[0]), dtype=object
+    )[channel_indices]
+    return _MovementGeometry(
+        channel_indices=channel_indices,
+        channel_names=channel_names,
+        positions=positions,
+        projected_positions=project_sensor_positions(positions),
+    )
+
+
+def _trajectory_row(context, geometry, weights, time_s, state):
+    centroid = np.average(geometry.positions, axis=0, weights=weights)
+    projected = np.average(geometry.projected_positions, axis=0, weights=weights)
+    peak_local_index = int(np.argmax(weights))
+    current = {"centroid": centroid, "projected": projected}
+    if state.first is None:
+        state.first = current
+
+    row = {
+        "participant": (
+            context.participant_id if context.participant_id is not None else ""
+        ),
+        "dataset": context.dataset,
+        "trial": context.trial_idx,
+        "trial_label": _trial_label(context.data, context.trial_idx),
+        "time_s": time_s,
+        "low_freq": context.config.frequency_range[0],
+        "high_freq": context.config.frequency_range[1],
+        "n_channels": int(geometry.channel_indices.size),
+        "mean_alpha_power": float(np.mean(weights)),
+        "total_alpha_power": float(np.sum(weights)),
+        "peak_alpha_power": float(weights[peak_local_index]),
+        "peak_channel": int(geometry.channel_indices[peak_local_index]),
+        "peak_channel_name": str(geometry.channel_names[peak_local_index]),
+        "spatial_concentration": _spatial_concentration(weights),
+        "centroid_x_mm": float(centroid[0]),
+        "centroid_y_mm": float(centroid[1]),
+        "centroid_z_mm": float(centroid[2]),
+        "projected_x_mm": float(projected[0]),
+        "projected_y_mm": float(projected[1]),
+    }
+    row.update(
+        _movement_values(
+            centroid,
+            projected,
+            state.first,
+            state.previous,
+            state.previous_time,
+            time_s,
+        )
+    )
+    state.previous = current
+    state.previous_time = time_s
+    return row
+
+
+def compute_alpha_movement_trajectory(
+    data,
+    trial_idx,
+    *,
+    participant_id=None,
+    dataset="main",
+    channel_indices=None,
+    config=None,
+):
+    """Track the alpha-power centroid across the MEG sensor array for one trial."""
+
+    config = config or AlphaMovementConfig()
+    trial_signal = get_trial_signal(data, trial_idx)
+    channel_indices = _resolve_channel_indices(
+        data, channel_indices, config.location_pattern
+    )
+    time_vector = get_time_vector(data, trial_idx)
+    sample_indices = sample_time_indices(
+        time_vector, config.time_window, config.trajectory_step_s
+    )
+    powers = _alpha_power(
+        np.take(trial_signal, channel_indices, axis=0),
+        time_vector,
+        sample_indices,
+        config,
+    )
+    geometry = _selected_geometry(data, trial_signal, channel_indices)
+    context = _MovementContext(data, trial_idx, participant_id, dataset, config)
+    state = _MovementState()
+    return [
+        _trajectory_row(
+            context,
+            geometry,
+            powers[:, column] + POWER_EPSILON,
+            float(time_vector[time_index]),
+            state,
+        )
+        for column, time_index in enumerate(sample_indices)
+    ]
+
+
+def compute_alpha_movement(
+    data,
+    *,
+    participant_id=None,
+    dataset="main",
+    channel_indices=None,
+    config=None,
+):
+    """Track alpha-power centroids for every trial in ``data``."""
+
+    config = config or AlphaMovementConfig()
+    channel_indices = _resolve_channel_indices(
+        data, channel_indices, config.location_pattern
+    )
+    rows = []
+    for trial_idx in range(count_trials(data)):
+        rows.extend(
+            compute_alpha_movement_trajectory(
+                data,
+                trial_idx,
+                participant_id=participant_id,
+                dataset=dataset,
+                channel_indices=channel_indices,
+                config=config,
+            )
+        )
+    return rows
+
+
+def _finite_mean(values):
+    array = np.asarray(list(values), dtype=float)
+    array = array[np.isfinite(array)]
+    if array.size == 0:
+        return np.nan
+    return float(np.mean(array))
+
+
+def summarize_alpha_movement(rows):
+    """Average sensor-level alpha movement by participant, condition, and time."""
+
+    grouped = defaultdict(list)
+    for row in rows:
+        key = (
+            str(row["participant"]),
+            str(row["dataset"]),
+            str(row["trial_label"]),
+            round(float(row["time_s"]), 9),
+        )
+        grouped[key].append(row)
+
+    summary_rows = []
+    for key, group_rows in sorted(grouped.items(), key=lambda item: item[0]):
+        participant, dataset, trial_label, time_s = key
+        trials = {int(row["trial"]) for row in group_rows}
+        summary_rows.append(
+            {
+                "participant": participant,
+                "dataset": dataset,
+                "trial_label": trial_label,
+                "time_s": time_s,
+                "n_trials": len(trials),
+                "mean_alpha_power": _finite_mean(
+                    row["mean_alpha_power"] for row in group_rows
+                ),
+                "spatial_concentration": _finite_mean(
+                    row["spatial_concentration"] for row in group_rows
+                ),
+                "centroid_x_mm": _finite_mean(
+                    row["centroid_x_mm"] for row in group_rows
+                ),
+                "centroid_y_mm": _finite_mean(
+                    row["centroid_y_mm"] for row in group_rows
+                ),
+                "centroid_z_mm": _finite_mean(
+                    row["centroid_z_mm"] for row in group_rows
+                ),
+                "projected_x_mm": _finite_mean(
+                    row["projected_x_mm"] for row in group_rows
+                ),
+                "projected_y_mm": _finite_mean(
+                    row["projected_y_mm"] for row in group_rows
+                ),
+                "displacement_mm": _finite_mean(
+                    row["displacement_mm"] for row in group_rows
+                ),
+                "speed_mm_per_s": _finite_mean(
+                    row["speed_mm_per_s"] for row in group_rows
+                ),
+                "projected_speed_mm_per_s": _finite_mean(
+                    row["projected_speed_mm_per_s"] for row in group_rows
+                ),
+            }
+        )
+    return summary_rows
+
+
+def write_alpha_movement_csv(rows, output_path):
+    """Write alpha movement rows to ``output_path``."""
+
+    write_alpha_metrics_csv(rows, output_path)
+
+
+def export_alpha_movement(
+    data_folder,
+    participants,
+    trajectory_output_path,
+    *,
+    summary_output_path=None,
+    cue=False,
+    config=None,
+):
+    """Export sensor-level alpha movement trajectories for participants."""
+
+    config = config or AlphaMovementConfig()
+    dataset = "cue" if cue else "main"
+    rows = []
+    for participant_id in participants:
+        data = load_participant_data(data_folder, participant_id, cue=cue)
+        rows.extend(
+            compute_alpha_movement(
+                data,
+                participant_id=participant_id,
+                dataset=dataset,
+                config=config,
+            )
+        )
+
+    write_alpha_movement_csv(rows, trajectory_output_path)
+    summary_rows = summarize_alpha_movement(rows)
+    if summary_output_path:
+        write_alpha_movement_csv(summary_rows, summary_output_path)
+    return rows, summary_rows

--- a/tests/test_alpha_movement.py
+++ b/tests/test_alpha_movement.py
@@ -1,0 +1,112 @@
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from pymegdec.alpha_movement import (
+    AlphaMovementConfig,
+    compute_alpha_movement,
+    sample_time_indices,
+    summarize_alpha_movement,
+    write_alpha_movement_csv,
+)
+
+
+def _cell_array(values):
+    inner = np.empty((1, len(values)), dtype=object)
+    for index, value in enumerate(values):
+        inner[0, index] = value
+    return inner
+
+
+def _moving_alpha_data():
+    sampling_rate = 200
+    time = np.arange(-0.5, 1.0, 1 / sampling_rate)
+    carrier = np.sin(2 * np.pi * 10 * time)
+    progress = (time - time[0]) / (time[-1] - time[0])
+    left_envelope = 1.6 - progress
+    right_envelope = 0.2 + 1.4 * progress
+
+    positions = np.array(
+        [
+            [-20.0, 0.0, 0.0],
+            [20.0, 0.0, 0.0],
+            [0.0, 20.0, 0.0],
+            [0.0, -20.0, 0.0],
+        ]
+    )
+    trial = np.vstack(
+        [
+            left_envelope * carrier,
+            right_envelope * carrier,
+            0.25 * carrier,
+            0.25 * carrier,
+        ]
+    )
+
+    return {
+        "label": np.array(["MLO11", "MRO11", "MZO01", "MLF11"], dtype=object)[:, None],
+        "trial": _cell_array([trial, trial]),
+        "time": _cell_array([time[None, :], time[None, :]]),
+        "trialinfo": np.array([[1, 2]]),
+        "grad": {"chanpos": positions},
+    }
+
+
+class TestAlphaMovement(unittest.TestCase):
+    def setUp(self):
+        self.data = _moving_alpha_data()
+        self.config = AlphaMovementConfig(
+            time_window=(-0.2, 0.6),
+            trajectory_step_s=0.1,
+        )
+
+    def test_sample_time_indices_returns_windowed_stride(self):
+        time = np.arange(-0.5, 0.6, 0.1)
+
+        indices = sample_time_indices(time, (-0.2, 0.2), 0.2)
+
+        np.testing.assert_allclose(time[indices], [-0.2, 0.0, 0.2], atol=1e-12)
+
+    def test_compute_alpha_movement_tracks_weighted_centroid(self):
+        rows = compute_alpha_movement(self.data, participant_id=2, config=self.config)
+
+        self.assertGreater(len(rows), 10)
+        first_trial_rows = [row for row in rows if row["trial"] == 0]
+        self.assertLess(
+            first_trial_rows[0]["centroid_x_mm"],
+            first_trial_rows[-1]["centroid_x_mm"],
+        )
+        self.assertEqual(first_trial_rows[0]["participant"], 2)
+        self.assertEqual(first_trial_rows[0]["trial_label"], 1)
+        self.assertTrue(np.isnan(first_trial_rows[0]["speed_mm_per_s"]))
+        self.assertTrue(np.isfinite(first_trial_rows[-1]["speed_mm_per_s"]))
+        self.assertIn(first_trial_rows[-1]["peak_channel_name"], {"MLO11", "MRO11"})
+
+    def test_summarize_alpha_movement_groups_by_condition_and_time(self):
+        rows = compute_alpha_movement(self.data, participant_id=2, config=self.config)
+
+        summary_rows = summarize_alpha_movement(rows)
+
+        labels = {row["trial_label"] for row in summary_rows}
+        self.assertEqual(labels, {"1", "2"})
+        self.assertTrue(all(row["n_trials"] == 1 for row in summary_rows))
+
+    def test_write_alpha_movement_csv(self):
+        rows = compute_alpha_movement(self.data, participant_id=2, config=self.config)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "movement.csv"
+            write_alpha_movement_csv(rows, output_path)
+
+            with output_path.open(newline="", encoding="utf-8") as handle:
+                loaded_rows = list(csv.DictReader(handle))
+
+        self.assertEqual(len(loaded_rows), len(rows))
+        self.assertEqual(loaded_rows[0]["dataset"], "main")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `alpha_movement` utilities for tracking alpha-power centroids over MEG sensor positions through time.
- Add `analyze_alpha_movement.py` CLI to export trial/timepoint trajectories and condition/time summaries.
- Reuse the alpha analytic-window helper from `alpha_metrics` and document the sensor-level caveat explicitly.
- Add unit coverage for time sampling, centroid tracking, summaries, and CSV writing.

## Scientific scope
This tracks movement of measured alpha topography over the MEG sensor array using `data.grad.chanpos`. It is not source-localized brain movement and should be interpreted as a sensor-level proxy.

## Validation
- `PYTHONPATH=src python -m unittest`
- `PYTHONPATH=src python -m mypy src`
- `PYTHONPATH=src python -m pylint src analyze_alpha_movement.py analyze_alpha_reaction_time.py export_alpha_metrics.py script_bootstrap.py`
- `PYTHONPATH=src python -m ruff check .`
- `python -m black --check .`
- `python -m isort --check-only --profile black src\pymegdec\alpha_metrics.py src\pymegdec\alpha_movement.py analyze_alpha_movement.py tests\test_alpha_movement.py src\pymegdec\__init__.py`
- `python -m flake8 src\pymegdec\alpha_metrics.py src\pymegdec\alpha_movement.py analyze_alpha_movement.py tests\test_alpha_movement.py src\pymegdec\__init__.py --max-line-length=88`
- `npx.cmd --yes jscpd --gitignore --reporters console --threshold 0 --pattern **/*.py .`
- Smoke-tested participant 2 with real MEG data over `-0.2..0.2 s` at `0.1 s` trajectory steps: 3600 trajectory rows and 80 summary rows.