### PR TITLE
Add alpha movement result analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ stepwise speed, displacement from the first sampled time point, the peak-power
 channel, and a spatial concentration score. Treat the trajectory as movement of
 the measured alpha topography over sensors, not as anatomical source motion.
 
+Movement summaries can be analyzed into pre/post stimulus effects and simple
+condition-level plots:
+
+```powershell
+python analyze_alpha_movement_results.py --movement-summary outputs\part2_alpha_movement_summary.csv --effect-output outputs\part2_alpha_movement_effects.csv --condition-summary-output outputs\part2_alpha_movement_condition_summary.csv --plots-dir outputs\part2_alpha_movement_plots
+```
+
+The effects compare the mean pre-stimulus centroid with the mean post-stimulus
+centroid, and summarize speed, alpha power, and spatial concentration changes.
+
 ## Alpha and reaction time
 
 The saved MEG `Part*Data.mat` files may not contain reaction times. The RT

--- a/analyze_alpha_movement_results.py
+++ b/analyze_alpha_movement_results.py
@@ -1,0 +1,15 @@
+"""Analyze exported sensor-level alpha movement summaries."""
+
+from script_bootstrap import add_src_to_path
+
+add_src_to_path(__file__)
+
+from pymegdec.cli import alpha_movement_results  # noqa: E402
+
+
+def main():
+    return alpha_movement_results()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
 pymegdec = "pymegdec.cli:main"
 pymegdec-cross-validate = "pymegdec.cli:cross_validate"
 pymegdec-transfer = "pymegdec.cli:transfer"
+pymegdec-alpha-movement-results = "pymegdec.cli:alpha_movement_results"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -10,6 +10,12 @@ from pymegdec.alpha_movement import (
     compute_alpha_movement,
     export_alpha_movement,
 )
+from pymegdec.alpha_movement_analysis import (
+    AlphaMovementAnalysisConfig,
+    analyze_alpha_movement_windows,
+    export_alpha_movement_analysis,
+    summarize_alpha_movement_effects,
+)
 from pymegdec.alpha_signal import extract_phase, extract_time_basis
 from pymegdec.cross_validation import cross_validate_single_dataset
 from pymegdec.data_config import DATA_DIR_ENV_VAR, resolve_data_folder
@@ -32,19 +38,23 @@ __all__ = [
     "DATA_DIR_ENV_VAR",
     "AlphaMetricConfig",
     "AlphaMovementConfig",
+    "AlphaMovementAnalysisConfig",
     "AlphaReactionTimeExportConfig",
     "ReactionTimeCsvConfig",
     "ReactionTimeUnavailableError",
     "analyze_alpha_reaction_times",
+    "analyze_alpha_movement_windows",
     "compute_alpha_movement",
     "compute_alpha_metrics",
     "cross_validate_single_dataset",
     "evaluate_model_transfer",
     "export_alpha_movement",
+    "export_alpha_movement_analysis",
     "export_participant_alpha_metrics",
     "extract_phase",
     "extract_time_basis",
     "get_original_feature_importance",
     "join_alpha_reaction_times",
     "resolve_data_folder",
+    "summarize_alpha_movement_effects",
 ]

--- a/src/pymegdec/alpha_movement_analysis.py
+++ b/src/pymegdec/alpha_movement_analysis.py
@@ -1,0 +1,351 @@
+"""Analyze and plot sensor-level alpha movement summaries."""
+
+from __future__ import annotations
+
+import csv
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+
+DEFAULT_PRE_WINDOW = (-0.4, -0.02)
+DEFAULT_POST_WINDOW = (0.0, 0.4)
+DEFAULT_ANALYSIS_METRICS = (
+    "centroid_shift_mm",
+    "projected_shift_mm",
+    "post_minus_pre_speed_mm_per_s",
+    "post_peak_speed_mm_per_s",
+    "post_minus_pre_alpha_power",
+    "post_minus_pre_spatial_concentration",
+)
+
+
+@dataclass(frozen=True)
+class AlphaMovementAnalysisConfig:
+    """Parameters for alpha movement summary analysis."""
+
+    pre_window: tuple[float, float] = DEFAULT_PRE_WINDOW
+    post_window: tuple[float, float] = DEFAULT_POST_WINDOW
+    metrics: tuple[str, ...] = DEFAULT_ANALYSIS_METRICS
+    plot_labels: tuple[str, ...] | None = None
+
+
+def load_alpha_movement_rows(path):
+    """Load alpha movement CSV rows."""
+
+    with Path(path).open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def write_csv_rows(rows, output_path):
+    """Write dictionaries to CSV."""
+
+    write_alpha_metrics_csv(rows, output_path)
+
+
+def _clean_id(value):
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _to_float(value):
+    if value in (None, ""):
+        return np.nan
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return np.nan
+
+
+def _window_rows(rows, window):
+    start, stop = window
+    if start >= stop:
+        raise ValueError("Window start must be before stop.")
+    return [row for row in rows if start <= _to_float(row.get("time_s")) <= stop]
+
+
+def _mean(rows, key):
+    values = np.asarray([_to_float(row.get(key)) for row in rows], dtype=float)
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        return np.nan
+    return float(np.mean(values))
+
+
+def _mean_vector(rows, keys):
+    return np.asarray([_mean(rows, key) for key in keys], dtype=float)
+
+
+def _peak_value_and_time(rows, value_key):
+    best_value = -np.inf
+    best_time = np.nan
+    for row in rows:
+        value = _to_float(row.get(value_key))
+        if np.isfinite(value) and value > best_value:
+            best_value = value
+            best_time = _to_float(row.get("time_s"))
+    if not np.isfinite(best_value):
+        return np.nan, np.nan
+    return float(best_value), float(best_time)
+
+
+def _participant_condition_key(row):
+    return (
+        _clean_id(row.get("participant")),
+        _clean_id(row.get("dataset")),
+        _clean_id(row.get("trial_label")),
+    )
+
+
+def _group_rows(rows, key_fn):
+    grouped = defaultdict(list)
+    for row in rows:
+        grouped[key_fn(row)].append(row)
+    return grouped
+
+
+def _movement_effect_row(key, rows, config):
+    participant, dataset, trial_label = key
+    pre_rows = _window_rows(rows, config.pre_window)
+    post_rows = _window_rows(rows, config.post_window)
+    pre_centroid = _mean_vector(
+        pre_rows, ("centroid_x_mm", "centroid_y_mm", "centroid_z_mm")
+    )
+    post_centroid = _mean_vector(
+        post_rows, ("centroid_x_mm", "centroid_y_mm", "centroid_z_mm")
+    )
+    pre_projected = _mean_vector(pre_rows, ("projected_x_mm", "projected_y_mm"))
+    post_projected = _mean_vector(post_rows, ("projected_x_mm", "projected_y_mm"))
+    peak_speed, peak_speed_time = _peak_value_and_time(
+        post_rows, "projected_speed_mm_per_s"
+    )
+
+    return {
+        "participant": participant,
+        "dataset": dataset,
+        "trial_label": trial_label,
+        "pre_window_start": config.pre_window[0],
+        "pre_window_stop": config.pre_window[1],
+        "post_window_start": config.post_window[0],
+        "post_window_stop": config.post_window[1],
+        "n_pre_points": len(pre_rows),
+        "n_post_points": len(post_rows),
+        "pre_centroid_x_mm": pre_centroid[0],
+        "pre_centroid_y_mm": pre_centroid[1],
+        "pre_centroid_z_mm": pre_centroid[2],
+        "post_centroid_x_mm": post_centroid[0],
+        "post_centroid_y_mm": post_centroid[1],
+        "post_centroid_z_mm": post_centroid[2],
+        "centroid_shift_mm": float(np.linalg.norm(post_centroid - pre_centroid)),
+        "pre_projected_x_mm": pre_projected[0],
+        "pre_projected_y_mm": pre_projected[1],
+        "post_projected_x_mm": post_projected[0],
+        "post_projected_y_mm": post_projected[1],
+        "projected_shift_mm": float(np.linalg.norm(post_projected - pre_projected)),
+        "pre_speed_mm_per_s": _mean(pre_rows, "projected_speed_mm_per_s"),
+        "post_speed_mm_per_s": _mean(post_rows, "projected_speed_mm_per_s"),
+        "post_minus_pre_speed_mm_per_s": _mean(post_rows, "projected_speed_mm_per_s")
+        - _mean(pre_rows, "projected_speed_mm_per_s"),
+        "post_peak_speed_mm_per_s": peak_speed,
+        "post_peak_speed_time_s": peak_speed_time,
+        "pre_alpha_power": _mean(pre_rows, "mean_alpha_power"),
+        "post_alpha_power": _mean(post_rows, "mean_alpha_power"),
+        "post_minus_pre_alpha_power": _mean(post_rows, "mean_alpha_power")
+        - _mean(pre_rows, "mean_alpha_power"),
+        "pre_spatial_concentration": _mean(pre_rows, "spatial_concentration"),
+        "post_spatial_concentration": _mean(post_rows, "spatial_concentration"),
+        "post_minus_pre_spatial_concentration": _mean(
+            post_rows, "spatial_concentration"
+        )
+        - _mean(pre_rows, "spatial_concentration"),
+    }
+
+
+def analyze_alpha_movement_windows(rows, config=None):
+    """Compute pre/post movement effects per participant and condition."""
+
+    config = config or AlphaMovementAnalysisConfig()
+    grouped = _group_rows(rows, _participant_condition_key)
+    return [
+        _movement_effect_row(key, group_rows, config)
+        for key, group_rows in sorted(grouped.items())
+    ]
+
+
+def _summary_stats(values):
+    values = np.asarray(list(values), dtype=float)
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        return np.nan, np.nan, np.nan
+    std = float(np.std(values, ddof=1)) if values.size > 1 else 0.0
+    return float(np.mean(values)), std, float(std / np.sqrt(values.size))
+
+
+def summarize_alpha_movement_effects(effect_rows, config=None):
+    """Summarize movement effects across participants by condition."""
+
+    config = config or AlphaMovementAnalysisConfig()
+    grouped = _group_rows(
+        effect_rows, lambda row: (_clean_id(row.get("dataset")), row["trial_label"])
+    )
+    summary_rows = []
+    for key, rows in sorted(grouped.items()):
+        dataset, trial_label = key
+        participants = {_clean_id(row.get("participant")) for row in rows}
+        summary_row = {
+            "dataset": dataset,
+            "trial_label": trial_label,
+            "n_participants": len(participants),
+        }
+        for metric in config.metrics:
+            mean, std, sem = _summary_stats(_to_float(row.get(metric)) for row in rows)
+            summary_row[f"{metric}_mean"] = mean
+            summary_row[f"{metric}_std"] = std
+            summary_row[f"{metric}_sem"] = sem
+        summary_rows.append(summary_row)
+    return summary_rows
+
+
+def _selected_labels(rows, plot_labels):
+    def label_key(value):
+        numeric = _to_float(value)
+        if np.isfinite(numeric):
+            return (0, numeric, value)
+        return (1, 0.0, value)
+
+    labels = sorted(
+        {_clean_id(row.get("trial_label")) for row in rows},
+        key=label_key,
+    )
+    if plot_labels is None:
+        return labels
+    requested = {_clean_id(label) for label in plot_labels}
+    return [label for label in labels if label in requested]
+
+
+def _mean_timecourse(rows, metric, plot_labels):
+    selected = set(_selected_labels(rows, plot_labels))
+    grouped = defaultdict(list)
+    for row in rows:
+        label = _clean_id(row.get("trial_label"))
+        if label in selected:
+            grouped[(label, _to_float(row.get("time_s")))].append(
+                _to_float(row.get(metric))
+            )
+
+    timecourses = defaultdict(list)
+    for key, values in grouped.items():
+        label, time_s = key
+        mean, _, sem = _summary_stats(values)
+        timecourses[label].append((time_s, mean, sem))
+    return {
+        label: sorted(values, key=lambda item: item[0])
+        for label, values in timecourses.items()
+    }
+
+
+def _plot_metric_timecourse(rows, metric, ylabel, output_path, plot_labels):
+    timecourses = _mean_timecourse(rows, metric, plot_labels)
+    figure, axes = plt.subplots(figsize=(8, 5))
+    for label, values in timecourses.items():
+        array = np.asarray(values, dtype=float)
+        axes.plot(array[:, 0], array[:, 1], label=f"condition {label}")
+        axes.fill_between(
+            array[:, 0],
+            array[:, 1] - array[:, 2],
+            array[:, 1] + array[:, 2],
+            alpha=0.15,
+        )
+
+    axes.axvline(0, color="black", linewidth=1, linestyle="--")
+    axes.set_xlabel("time from stimulus (s)")
+    axes.set_ylabel(ylabel)
+    axes.legend(fontsize="small", ncol=2)
+    axes.grid(True, alpha=0.25)
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=150)
+    plt.close(figure)
+
+
+def _plot_projected_trajectories(rows, output_path, plot_labels):
+    labels = _selected_labels(rows, plot_labels)
+    figure, axes = plt.subplots(figsize=(6, 6))
+    for label in labels:
+        label_rows = [row for row in rows if _clean_id(row.get("trial_label")) == label]
+        grouped_by_time = _group_rows(
+            label_rows, lambda row: _to_float(row.get("time_s"))
+        )
+        points = []
+        for time_s, time_rows in sorted(grouped_by_time.items()):
+            points.append(
+                (
+                    time_s,
+                    _mean(time_rows, "projected_x_mm"),
+                    _mean(time_rows, "projected_y_mm"),
+                )
+            )
+        array = np.asarray(points, dtype=float)
+        axes.plot(array[:, 1], array[:, 2], marker=".", label=f"condition {label}")
+        zero_index = int(np.argmin(np.abs(array[:, 0])))
+        axes.scatter(array[zero_index, 1], array[zero_index, 2], s=25)
+
+    axes.set_xlabel("projected x (mm)")
+    axes.set_ylabel("projected y (mm)")
+    axes.set_aspect("equal", adjustable="datalim")
+    axes.legend(fontsize="small", ncol=2)
+    axes.grid(True, alpha=0.25)
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=150)
+    plt.close(figure)
+
+
+def write_alpha_movement_plots(rows, output_dir, *, plot_labels=None):
+    """Write condition-level movement plots from summary rows."""
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _plot_projected_trajectories(
+        rows, output_dir / "alpha_movement_projected_trajectories.png", plot_labels
+    )
+    _plot_metric_timecourse(
+        rows,
+        "projected_speed_mm_per_s",
+        "projected speed (mm/s)",
+        output_dir / "alpha_movement_projected_speed.png",
+        plot_labels,
+    )
+    _plot_metric_timecourse(
+        rows,
+        "displacement_mm",
+        "3D displacement from first sample (mm)",
+        output_dir / "alpha_movement_displacement.png",
+        plot_labels,
+    )
+
+
+def export_alpha_movement_analysis(
+    movement_summary_path,
+    effect_output_path,
+    condition_summary_output_path,
+    *,
+    plots_dir=None,
+    config=None,
+):
+    """Load movement summaries and export pre/post effects and plots."""
+
+    config = config or AlphaMovementAnalysisConfig()
+    movement_rows = load_alpha_movement_rows(movement_summary_path)
+    effect_rows = analyze_alpha_movement_windows(movement_rows, config)
+    summary_rows = summarize_alpha_movement_effects(effect_rows, config)
+    write_csv_rows(effect_rows, effect_output_path)
+    write_csv_rows(summary_rows, condition_summary_output_path)
+    if plots_dir:
+        write_alpha_movement_plots(
+            movement_rows, plots_dir, plot_labels=config.plot_labels
+        )
+    return effect_rows, summary_rows

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -16,6 +16,12 @@ from .alpha_metrics import (
     DEFAULT_TIME_WINDOW,
     AlphaMetricConfig,
 )
+from .alpha_movement_analysis import (
+    DEFAULT_POST_WINDOW,
+    DEFAULT_PRE_WINDOW,
+    AlphaMovementAnalysisConfig,
+    export_alpha_movement_analysis,
+)
 from .cross_validation import cross_validate_single_dataset
 from .model_transfer import evaluate_model_transfer
 
@@ -170,13 +176,93 @@ def transfer(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     return 0
 
 
+def _build_alpha_movement_results_parser(
+    prog: str | None = None,
+) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog, description="Analyze exported alpha movement summaries."
+    )
+    parser.add_argument(
+        "--movement-summary",
+        required=True,
+        help="Input CSV from analyze_alpha_movement.py --summary-output.",
+    )
+    parser.add_argument(
+        "--effect-output",
+        required=True,
+        help="Output CSV for participant/condition pre-post effects.",
+    )
+    parser.add_argument(
+        "--condition-summary-output",
+        required=True,
+        help="Output CSV for condition-level effect summaries.",
+    )
+    parser.add_argument(
+        "--plots-dir",
+        default=None,
+        help="Optional output directory for condition-level PNG plots.",
+    )
+    parser.add_argument(
+        "--pre-window",
+        type=parse_range,
+        default=DEFAULT_PRE_WINDOW,
+        help="Pre-stimulus window as start,stop in seconds.",
+    )
+    parser.add_argument(
+        "--post-window",
+        type=parse_range,
+        default=DEFAULT_POST_WINDOW,
+        help="Post-stimulus window as start,stop in seconds.",
+    )
+    parser.add_argument(
+        "--plot-labels",
+        nargs="*",
+        default=None,
+        help="Optional condition labels to include in plots.",
+    )
+    return parser
+
+
+def alpha_movement_results(
+    argv: Sequence[str] | None = None, prog: str | None = None
+) -> int:
+    parser = _build_alpha_movement_results_parser(prog=prog)
+    args = parser.parse_args(argv)
+    config = AlphaMovementAnalysisConfig(
+        pre_window=args.pre_window,
+        post_window=args.post_window,
+        plot_labels=(
+            None
+            if args.plot_labels is None
+            else tuple(str(label) for label in args.plot_labels)
+        ),
+    )
+    effect_rows, summary_rows = export_alpha_movement_analysis(
+        args.movement_summary,
+        args.effect_output,
+        args.condition_summary_output,
+        plots_dir=args.plots_dir,
+        config=config,
+    )
+    print(
+        f"Wrote {len(effect_rows)} participant-condition rows to {args.effect_output}"
+    )
+    print(
+        f"Wrote {len(summary_rows)} condition summary rows to "
+        f"{args.condition_summary_output}"
+    )
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
 
     parser = argparse.ArgumentParser(description="PyMEGDec command-line interface.")
     parser.add_argument(
-        "command", choices=["cross-validate", "transfer"], help="Workflow to run."
+        "command",
+        choices=["cross-validate", "transfer", "alpha-movement-results"],
+        help="Workflow to run.",
     )
 
     if not argv or argv[0] in {"-h", "--help"}:
@@ -188,6 +274,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return cross_validate(remaining, prog="pymegdec cross-validate")
     if command == "transfer":
         return transfer(remaining, prog="pymegdec transfer")
+    if command == "alpha-movement-results":
+        return alpha_movement_results(remaining, prog="pymegdec alpha-movement-results")
     parser.error(f"Unsupported command: {command}")
     return 2
 

--- a/tests/test_alpha_movement_analysis.py
+++ b/tests/test_alpha_movement_analysis.py
@@ -1,0 +1,124 @@
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+from pymegdec.alpha_movement_analysis import (
+    AlphaMovementAnalysisConfig,
+    analyze_alpha_movement_windows,
+    export_alpha_movement_analysis,
+    summarize_alpha_movement_effects,
+    write_alpha_movement_plots,
+    write_csv_rows,
+)
+
+
+def _summary_rows():
+    rows = []
+    for participant in (1, 2):
+        for trial_label, offset in (("1", 0.0), ("2", 4.0)):
+            for time_s, post in (
+                (-0.2, False),
+                (-0.1, False),
+                (0.1, True),
+                (0.2, True),
+            ):
+                x_value = offset + (10.0 if post else 0.0) + participant
+                rows.append(
+                    {
+                        "participant": participant,
+                        "dataset": "main",
+                        "trial_label": trial_label,
+                        "time_s": time_s,
+                        "n_trials": 3,
+                        "mean_alpha_power": 100.0 + x_value,
+                        "spatial_concentration": 0.2 + (0.1 if post else 0.0),
+                        "centroid_x_mm": x_value,
+                        "centroid_y_mm": 0.0,
+                        "centroid_z_mm": 0.0,
+                        "projected_x_mm": x_value,
+                        "projected_y_mm": 0.0,
+                        "displacement_mm": x_value,
+                        "speed_mm_per_s": 20.0 + x_value,
+                        "projected_speed_mm_per_s": 30.0 + x_value,
+                    }
+                )
+    return rows
+
+
+class TestAlphaMovementAnalysis(unittest.TestCase):
+    def setUp(self):
+        self.rows = _summary_rows()
+        self.config = AlphaMovementAnalysisConfig(
+            pre_window=(-0.25, 0.0),
+            post_window=(0.0, 0.25),
+        )
+
+    def test_analyze_alpha_movement_windows_computes_pre_post_shifts(self):
+        effect_rows = analyze_alpha_movement_windows(self.rows, self.config)
+
+        self.assertEqual(len(effect_rows), 4)
+        first = effect_rows[0]
+        self.assertEqual(first["participant"], "1")
+        self.assertEqual(first["trial_label"], "1")
+        self.assertEqual(first["n_pre_points"], 2)
+        self.assertEqual(first["n_post_points"], 2)
+        self.assertAlmostEqual(first["centroid_shift_mm"], 10.0)
+        self.assertAlmostEqual(first["projected_shift_mm"], 10.0)
+        self.assertAlmostEqual(first["post_minus_pre_speed_mm_per_s"], 10.0)
+        self.assertAlmostEqual(first["post_minus_pre_spatial_concentration"], 0.1)
+
+    def test_summarize_alpha_movement_effects_groups_by_condition(self):
+        effect_rows = analyze_alpha_movement_windows(self.rows, self.config)
+
+        summary_rows = summarize_alpha_movement_effects(effect_rows, self.config)
+
+        self.assertEqual(len(summary_rows), 2)
+        self.assertEqual(summary_rows[0]["trial_label"], "1")
+        self.assertEqual(summary_rows[0]["n_participants"], 2)
+        self.assertAlmostEqual(summary_rows[0]["projected_shift_mm_mean"], 10.0)
+        self.assertAlmostEqual(summary_rows[0]["post_minus_pre_alpha_power_mean"], 10.0)
+
+    def test_export_alpha_movement_analysis_writes_csvs_and_plots(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            input_path = temp_path / "summary.csv"
+            effect_path = temp_path / "effects.csv"
+            condition_path = temp_path / "conditions.csv"
+            plots_dir = temp_path / "plots"
+            write_csv_rows(self.rows, input_path)
+
+            effect_rows, summary_rows = export_alpha_movement_analysis(
+                input_path,
+                effect_path,
+                condition_path,
+                plots_dir=plots_dir,
+                config=self.config,
+            )
+
+            with effect_path.open(newline="", encoding="utf-8") as handle:
+                loaded_effects = list(csv.DictReader(handle))
+            with condition_path.open(newline="", encoding="utf-8") as handle:
+                loaded_summary = list(csv.DictReader(handle))
+
+            self.assertEqual(len(effect_rows), len(loaded_effects))
+            self.assertEqual(len(summary_rows), len(loaded_summary))
+            self.assertTrue(
+                (plots_dir / "alpha_movement_projected_trajectories.png").exists()
+            )
+            self.assertTrue((plots_dir / "alpha_movement_projected_speed.png").exists())
+            self.assertTrue((plots_dir / "alpha_movement_displacement.png").exists())
+
+    def test_write_alpha_movement_plots_can_filter_labels(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+
+            write_alpha_movement_plots(self.rows, output_dir, plot_labels=("2",))
+
+            self.assertTrue(
+                (output_dir / "alpha_movement_projected_trajectories.png").exists()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `alpha_movement_analysis` utilities for pre/post stimulus movement effects from exported alpha movement summaries.
- Add `analyze_alpha_movement_results.py` and a `pymegdec alpha-movement-results` CLI command.
- Export participant-condition effect rows, condition-level summaries, and optional PNG plots for projected trajectories, speed, and displacement.
- Document the follow-up movement analysis workflow and add unit coverage for effects, summaries, plotting, and CSV export.

## Scientific scope
The analysis compares sensor-level alpha-topography centroids before and after stimulus onset. It still operates on MEG sensor-space trajectories, not source-localized brain motion.

## Validation
- `PYTHONPATH=src python -m unittest`
- `PYTHONPATH=src python -m mypy src`
- `PYTHONPATH=src python -m pylint src analyze_alpha_movement.py analyze_alpha_movement_results.py analyze_alpha_reaction_time.py export_alpha_metrics.py script_bootstrap.py`
- `PYTHONPATH=src python -m ruff check .`
- `python -m black --check .`
- `python -m isort --check-only --profile black src\pymegdec\alpha_movement_analysis.py analyze_alpha_movement_results.py tests\test_alpha_movement_analysis.py src\pymegdec\cli.py src\pymegdec\__init__.py`
- `python -m flake8 src\pymegdec\alpha_movement_analysis.py analyze_alpha_movement_results.py tests\test_alpha_movement_analysis.py src\pymegdec\cli.py src\pymegdec\__init__.py --max-line-length=88`
- `npx.cmd --yes jscpd --gitignore --reporters console --threshold 0 --pattern **/*.py .`
- Smoke-tested participant 2 movement summary: wrote 16 participant-condition effect rows, 16 condition summary rows, and 3 PNG plots.