### PR TITLE
Add time-resolved stimulus decoding workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 180

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 180
+extend-ignore = E203

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/kucherenko/jscpd/master/schemas/options.json",
   "gitignore": true,
   "threshold": 1
 }

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://raw.githubusercontent.com/kucherenko/jscpd/master/schemas/options.json",
+  "gitignore": true,
+  "threshold": 1
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ src/pymegdec/              Package source code
   alpha_movement.py        Sensor-level alpha movement trajectory export
   alpha_visualization.py   Alpha signal and phase-shift plotting helpers
   reaction_time_analysis.py Alpha/RT join and association summaries
+  stimulus_decoding.py     Time-resolved train-main / validate-cue decoding
   classifiers.py           Classifier factories and PyTorch Lightning model
   preprocessing.py         Filtering, downsampling, window extraction, PCA
   model_transfer.py        Train-on-experiment / validate-on-cue evaluation
@@ -25,6 +26,7 @@ Top-level `cross_validation.py`, `evaluate_model_transfer.py`,
 `export_alpha_metrics.py` are compatibility wrappers for existing imports and
 direct script usage. `analyze_alpha_reaction_time.py` provides an exploratory
 analysis command for alpha metrics and behavioral reaction times.
+`analyze_stimulus_decoding.py` exports time-resolved stimulus decoding curves.
 `analyze_alpha_movement.py` exports sensor-level alpha movement trajectories.
 
 ## Setup
@@ -69,6 +71,7 @@ python -m unittest
 ```bash
 pymegdec-cross-validate --data-dir "/path/to/MEG-Data" --participant 2
 pymegdec-transfer --data-dir "/path/to/MEG-Data" --participant 2 --null-window-center nan
+pymegdec-stimulus-decoding --data-dir "/path/to/MEG-Data" --participants 2 --output outputs/part2_stimulus_decoding.csv
 ```
 
 The grouped command exposes the same workflows:
@@ -76,6 +79,7 @@ The grouped command exposes the same workflows:
 ```bash
 pymegdec cross-validate --participant 2
 pymegdec transfer --participant 2 --classifier multiclass-svm
+pymegdec stimulus-decoding --participants 2 --output outputs/part2_stimulus_decoding.csv
 ```
 
 ## Examples
@@ -95,6 +99,30 @@ can be `None`:
 transfer_accuracy = evaluate_model_transfer(None, 2, classifier="multiclass-svm")
 cv_accuracy = cross_validate_single_dataset(None, 2, classifier="multiclass-svm")
 ```
+
+## Time-resolved stimulus decoding
+
+Stimulus decoding can be evaluated over a sequence of windows around stimulus
+onset. The command trains on `Part*Data.mat`, validates on `Part*CueData.mat`,
+and reports 16-way stimulus accuracy for each participant and window center.
+By default it uses no null class, because the cue validation files do not
+contain null trials and the clean question is which of the 16 stimuli was shown.
+
+```powershell
+python analyze_stimulus_decoding.py --participants 2 --time-window=-0.2,0.6 --window-step-s 0.05 --output outputs\part2_stimulus_decoding.csv --summary-output outputs\part2_stimulus_decoding_summary.csv --plots-dir outputs\part2_stimulus_decoding_plots
+```
+
+The output CSV includes the stimulus-decoding accuracy, chance level, PCA
+variance, and class counts for every participant/window row. Add
+`--permutations N` to run label-shuffle tests (`N=0` by default, no permutation
+step). Summary CSV adds `n_significant_p_0.05` and `n_significant_p_0.01` and
+`n_with_permutation` per window.
+
+```powershell
+python analyze_stimulus_decoding.py --participants 2 --time-window=-0.2,0.6 --window-step-s 0.05 --permutations 200 --permutation-seed 42 --output outputs\part2_stimulus_decoding.csv --summary-output outputs\part2_stimulus_decoding_summary.csv --plots-dir outputs\part2_stimulus_decoding_plots
+```
+
+The summary CSV and plot aggregate the curve across participants.
 
 ## Tests
 

--- a/analyze_stimulus_decoding.py
+++ b/analyze_stimulus_decoding.py
@@ -1,0 +1,15 @@
+"""Run time-resolved stimulus decoding."""
+
+from script_bootstrap import add_src_to_path
+
+add_src_to_path(__file__)
+
+from pymegdec.cli import stimulus_decoding  # noqa: E402
+
+
+def main():
+    return stimulus_decoding()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
 pymegdec = "pymegdec.cli:main"
 pymegdec-cross-validate = "pymegdec.cli:cross_validate"
 pymegdec-transfer = "pymegdec.cli:transfer"
+pymegdec-stimulus-decoding = "pymegdec.cli:stimulus_decoding"
 pymegdec-alpha-movement-results = "pymegdec.cli:alpha_movement_results"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,10 @@ disable = [
 max-line-length = 180
 
 [tool.pylint.DESIGN]
-max-args = 6
-max-positional-arguments = 6
+max-args = 9
+max-attributes = 12
+max-locals = 29
+max-positional-arguments = 9
 max-parents = 15
 max-public-methods = 25
 min-public-methods = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,13 @@ pythonpath = ["src"]
 check_untyped_defs = true
 ignore_missing_imports = true
 
+[tool.black]
+line-length = 180
+
+[tool.isort]
+line_length = 180
+profile = "black"
+
 [tool.ruff]
 line-length = 180
 

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -30,6 +30,12 @@ from pymegdec.reaction_time_analysis import (
     analyze_alpha_reaction_times,
     join_alpha_reaction_times,
 )
+from pymegdec.stimulus_decoding import (
+    StimulusDecodingConfig,
+    evaluate_time_resolved_stimulus_transfer,
+    export_time_resolved_stimulus_decoding,
+    summarize_stimulus_decoding,
+)
 
 __version__ = "0.1.0"
 
@@ -42,19 +48,23 @@ __all__ = [
     "AlphaReactionTimeExportConfig",
     "ReactionTimeCsvConfig",
     "ReactionTimeUnavailableError",
+    "StimulusDecodingConfig",
     "analyze_alpha_reaction_times",
     "analyze_alpha_movement_windows",
     "compute_alpha_movement",
     "compute_alpha_metrics",
     "cross_validate_single_dataset",
     "evaluate_model_transfer",
+    "evaluate_time_resolved_stimulus_transfer",
     "export_alpha_movement",
     "export_alpha_movement_analysis",
     "export_participant_alpha_metrics",
+    "export_time_resolved_stimulus_decoding",
     "extract_phase",
     "extract_time_basis",
     "get_original_feature_importance",
     "join_alpha_reaction_times",
     "resolve_data_folder",
+    "summarize_stimulus_decoding",
     "summarize_alpha_movement_effects",
 ]

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -183,7 +183,10 @@ def _build_stimulus_decoding_parser(
     parser.add_argument(
         "--participants",
         default=None,
-        help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.",
+        help=(
+            "Participant ids such as 1-4,6,8. Defaults to all participants "
+            "with main and cue files."
+        ),
     )
     parser.add_argument(
         "--output",
@@ -210,7 +213,10 @@ def _build_stimulus_decoding_parser(
         "--window-centers",
         type=_parse_float_list,
         default=None,
-        help="Explicit comma-separated window centers in seconds. Overrides --time-window.",
+        help=(
+            "Explicit comma-separated window centers in seconds. Overrides "
+            "--time-window."
+        ),
     )
     parser.add_argument(
         "--window-step-s",
@@ -268,7 +274,10 @@ def _build_stimulus_decoding_parser(
         "--permutations",
         type=int,
         default=0,
-        help="Number of label shuffles per participant window for permutation p-values.",
+        help=(
+            "Number of label shuffles per participant window for "
+            "permutation p-values."
+        ),
     )
     parser.add_argument(
         "--permutation-seed",
@@ -318,7 +327,8 @@ def stimulus_decoding(argv: Sequence[str] | None = None, prog: str | None = None
     participants = _transfer_participants(args.participants, args.data_folder)
     if not participants:
         parser.error(
-            "No participants found. Pass --participants or configure a data directory with matching main and cue MAT files."
+            "No participants found. Pass --participants or configure a data "
+            "directory with matching main and cue MAT files."
         )
     window_centers = args.window_centers
     if window_centers is None:

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -24,6 +24,15 @@ from .alpha_movement_analysis import (
 )
 from .cross_validation import cross_validate_single_dataset
 from .model_transfer import evaluate_model_transfer
+from .reaction_time_analysis import available_participants, parse_participant_spec
+from .stimulus_decoding import (
+    DEFAULT_DECODING_STEP_S,
+    DEFAULT_DECODING_TIME_WINDOW,
+    DEFAULT_STIMULUS_WINDOW_SIZE,
+    StimulusDecodingConfig,
+    export_time_resolved_stimulus_decoding,
+    window_centers_from_range,
+)
 
 
 def _float_or_inf(value: str) -> float:
@@ -62,6 +71,13 @@ def _parse_classifier_param(value: str | None):
         raise argparse.ArgumentTypeError(
             "classifier parameters must be numeric, JSON, or a Python literal"
         ) from exc
+
+
+def _parse_float_list(value: str) -> tuple[float, ...]:
+    values = tuple(float(token.strip()) for token in value.split(",") if token.strip())
+    if not values:
+        raise argparse.ArgumentTypeError("At least one value is required.")
+    return values
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
@@ -151,6 +167,118 @@ def _build_transfer_parser(prog: str | None = None) -> argparse.ArgumentParser:
     return parser
 
 
+def _build_stimulus_decoding_parser(
+    prog: str | None = None,
+) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description="Run time-resolved train-main/validate-cue stimulus decoding.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        dest="data_folder",
+        default=None,
+        help="Directory containing Part*Data.mat and Part*CueData.mat files.",
+    )
+    parser.add_argument(
+        "--participants",
+        default=None,
+        help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output CSV for participant/window decoding accuracies.",
+    )
+    parser.add_argument(
+        "--summary-output",
+        default=None,
+        help="Optional output CSV summarized across participants by time window.",
+    )
+    parser.add_argument(
+        "--plots-dir",
+        default=None,
+        help="Optional directory for group-level stimulus decoding plots.",
+    )
+    parser.add_argument(
+        "--time-window",
+        type=parse_range,
+        default=DEFAULT_DECODING_TIME_WINDOW,
+        help="Window-center range as start,stop in seconds.",
+    )
+    parser.add_argument(
+        "--window-centers",
+        type=_parse_float_list,
+        default=None,
+        help="Explicit comma-separated window centers in seconds. Overrides --time-window.",
+    )
+    parser.add_argument(
+        "--window-step-s",
+        type=float,
+        default=DEFAULT_DECODING_STEP_S,
+        help="Step between time-window centers in seconds.",
+    )
+    parser.add_argument(
+        "--window-size",
+        type=float,
+        default=DEFAULT_STIMULUS_WINDOW_SIZE,
+        help="Window size in seconds.",
+    )
+    parser.add_argument(
+        "--null-window-center",
+        type=_float_or_inf,
+        default=float("nan"),
+        help="Center of an optional pre-stimulus null window, or nan.",
+    )
+    parser.add_argument(
+        "--new-framerate",
+        type=_float_or_inf,
+        default=float("inf"),
+        help="Target frame rate, or inf.",
+    )
+    parser.add_argument(
+        "--classifier", default="multiclass-svm", help="Classifier name."
+    )
+    parser.add_argument(
+        "--classifier-param",
+        default=None,
+        help="Classifier parameter value, JSON, or Python literal.",
+    )
+    parser.add_argument(
+        "--components-pca",
+        type=_int_or_inf,
+        default=100,
+        help="Number of PCA components, or inf.",
+    )
+    parser.add_argument(
+        "--frequency-range",
+        type=_float_or_inf,
+        nargs=2,
+        metavar=("LOW", "HIGH"),
+        default=(0.0, float("inf")),
+        help="Frequency range in Hz.",
+    )
+    parser.add_argument(
+        "--chance-classes",
+        type=int,
+        default=16,
+        help="Number of stimulus classes used for the chance line.",
+    )
+    parser.add_argument(
+        "--permutations",
+        type=int,
+        default=0,
+        help="Number of label shuffles per participant window for permutation p-values.",
+    )
+    parser.add_argument(
+        "--permutation-seed",
+        type=int,
+        default=None,
+        help="Seed for permutation label shuffles. Keep fixed for reproducibility.",
+    )
+    return parser
+
+
 def cross_validate(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     parser = _build_cross_validate_parser(prog=prog)
     args = parser.parse_args(argv)
@@ -173,6 +301,57 @@ def transfer(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         **_common_kwargs(args),
     )
     print(accuracy)
+    return 0
+
+
+def _transfer_participants(participant_spec, data_folder):
+    if participant_spec:
+        return parse_participant_spec(participant_spec)
+    main_participants = set(available_participants(data_folder, cue=False))
+    cue_participants = set(available_participants(data_folder, cue=True))
+    return sorted(main_participants & cue_participants)
+
+
+def stimulus_decoding(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_stimulus_decoding_parser(prog=prog)
+    args = parser.parse_args(argv)
+    participants = _transfer_participants(args.participants, args.data_folder)
+    if not participants:
+        parser.error(
+            "No participants found. Pass --participants or configure a data directory with matching main and cue MAT files."
+        )
+    window_centers = args.window_centers
+    if window_centers is None:
+        window_centers = window_centers_from_range(args.time_window, args.window_step_s)
+
+    config = StimulusDecodingConfig(
+        window_centers=window_centers,
+        window_size=args.window_size,
+        null_window_center=args.null_window_center,
+        new_framerate=args.new_framerate,
+        classifier=args.classifier,
+        classifier_param=_parse_classifier_param(args.classifier_param),
+        components_pca=args.components_pca,
+        frequency_range=tuple(args.frequency_range),
+        chance_classes=args.chance_classes,
+        permutations=args.permutations,
+        permutation_seed=args.permutation_seed,
+    )
+
+    rows, summary_rows = export_time_resolved_stimulus_decoding(
+        args.data_folder,
+        participants,
+        args.output,
+        summary_output_path=args.summary_output,
+        plots_dir=args.plots_dir,
+        config=config,
+        progress=print,
+    )
+    print(f"Wrote {len(rows)} participant/window rows to {args.output}")
+    if args.summary_output:
+        print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+    if args.plots_dir:
+        print(f"Wrote plots to {args.plots_dir}")
     return 0
 
 
@@ -261,7 +440,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="PyMEGDec command-line interface.")
     parser.add_argument(
         "command",
-        choices=["cross-validate", "transfer", "alpha-movement-results"],
+        choices=[
+            "cross-validate",
+            "transfer",
+            "stimulus-decoding",
+            "alpha-movement-results",
+        ],
         help="Workflow to run.",
     )
 
@@ -274,6 +458,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return cross_validate(remaining, prog="pymegdec cross-validate")
     if command == "transfer":
         return transfer(remaining, prog="pymegdec transfer")
+    if command == "stimulus-decoding":
+        return stimulus_decoding(remaining, prog="pymegdec stimulus-decoding")
     if command == "alpha-movement-results":
         return alpha_movement_results(remaining, prog="pymegdec alpha-movement-results")
     parser.error(f"Unsupported command: {command}")

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -1,0 +1,451 @@
+"""Time-resolved stimulus decoding analyses."""
+
+from __future__ import annotations
+
+import warnings
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.io as sio
+
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+from pymegdec.classifiers import (
+    get_default_classifier_param,
+    should_use_default_classifier_param,
+    train_multiclass_classifier,
+)
+from pymegdec.data_config import resolve_data_folder
+from pymegdec.preprocessing import (
+    downsample_data,
+    extract_windows,
+    filter_features,
+    reduce_features_pca,
+)
+
+DEFAULT_DECODING_TIME_WINDOW = (-0.2, 0.6)
+DEFAULT_DECODING_STEP_S = 0.05
+DEFAULT_STIMULUS_WINDOW_SIZE = 0.1
+DEFAULT_CHANCE_CLASSES = 16
+DEFAULT_WINDOW_CENTERS = tuple(
+    float(value)
+    for value in np.round(
+        np.arange(
+            DEFAULT_DECODING_TIME_WINDOW[0],
+            DEFAULT_DECODING_TIME_WINDOW[1] + DEFAULT_DECODING_STEP_S / 2,
+            DEFAULT_DECODING_STEP_S,
+        ),
+        10,
+    )
+)
+
+
+@dataclass(frozen=True)
+class StimulusDecodingConfig:
+    """Parameters for time-resolved stimulus decoding."""
+
+    window_centers: tuple[float, ...] = DEFAULT_WINDOW_CENTERS
+    window_size: float = DEFAULT_STIMULUS_WINDOW_SIZE
+    null_window_center: float = float("nan")
+    new_framerate: float = float("inf")
+    classifier: str = "multiclass-svm"
+    classifier_param: object = float("nan")
+    components_pca: int | float = 100
+    frequency_range: tuple[float, float] = (0.0, float("inf"))
+    chance_classes: int = DEFAULT_CHANCE_CLASSES
+    random_state: int | None = None
+    permutations: int = 0
+    permutation_seed: int | None = None
+
+
+def window_centers_from_range(
+    time_window: tuple[float, float], step_s: float
+) -> tuple[float, ...]:
+    """Build evenly spaced window centers from a start/stop range."""
+
+    start, stop = time_window
+    if step_s <= 0:
+        raise ValueError("Window step must be positive.")
+    if start > stop:
+        raise ValueError("Time window start must be before stop.")
+    return tuple(
+        float(value)
+        for value in np.round(np.arange(start, stop + step_s / 2, step_s), 10)
+    )
+
+
+def evaluate_time_resolved_stimulus_transfer(
+    data_folder,
+    participants,
+    *,
+    config=None,
+    progress=None,
+):
+    """Evaluate train-main/validate-cue stimulus decoding across time windows."""
+
+    config = config or StimulusDecodingConfig()
+    data_folder = resolve_data_folder(data_folder)
+    rows = []
+    for participant in participants:
+        if progress is not None:
+            progress(f"START participant={participant}")
+        rows.extend(
+            evaluate_participant_time_resolved_stimulus_transfer(
+                data_folder, participant, config=config
+            )
+        )
+        if progress is not None:
+            progress(f"DONE participant={participant}")
+    return rows
+
+
+def evaluate_participant_time_resolved_stimulus_transfer(
+    data_folder,
+    participant,
+    *,
+    config=None,
+):
+    """Evaluate one participant's stimulus transfer accuracy across window centers."""
+
+    config = config or StimulusDecodingConfig()
+    classifier_param = config.classifier_param
+    if should_use_default_classifier_param(classifier_param):
+        classifier_param = get_default_classifier_param(config.classifier)
+
+    train_data = _load_participant_data(data_folder, participant, cue=False)
+    validation_data = _load_participant_data(data_folder, participant, cue=True)
+    _check_matching_sample_rate(train_data, validation_data)
+
+    labels_train = np.asarray(train_data["trialinfo"][0][0], dtype=int).ravel()
+    labels_validation = np.asarray(validation_data["trialinfo"][0][0], dtype=int).ravel()
+    if np.isnan(config.null_window_center):
+        labels_train = labels_train - 1
+        labels_validation = labels_validation - 1
+
+    if not np.array_equal(np.unique(labels_train), np.unique(labels_validation)):
+        warnings.warn(
+            "There are labels in the training or validation experiment "
+            "that are not in the other experiment."
+        )
+
+    train_data = _prepare_data(train_data, config)
+    validation_data = _prepare_data(validation_data, config)
+    permutation_rng = np.random.default_rng(config.permutation_seed)
+
+    rows = []
+    for window_center in config.window_centers:
+        rows.append(
+            _evaluate_window(
+                train_data,
+                validation_data,
+                labels_train,
+                labels_validation,
+                participant,
+                float(window_center),
+                classifier_param,
+                config,
+                permutation_rng=permutation_rng,
+            )
+        )
+    return rows
+
+
+def summarize_stimulus_decoding(rows):
+    """Summarize decoding rows across participants for each window center."""
+
+    grouped = defaultdict(list)
+    for row in rows:
+        grouped[(row["variant"], row["window_center_s"])].append(row)
+
+    summary_rows = []
+    for key, group_rows in sorted(grouped.items(), key=lambda item: item[0]):
+        variant, window_center = key
+        accuracies = [_to_float(row["accuracy"]) for row in group_rows]
+        mean, std, sem = _summary_stats(accuracies)
+        percentages = [100.0 * value for value in accuracies if np.isfinite(value)]
+        median = float(np.median(percentages)) if percentages else np.nan
+        permutation_p = [_to_float(row.get("permutation_p_value")) for row in group_rows]
+        n_with_permutation = sum(np.isfinite(permutation_p))
+        significant_05 = sum(value < 0.05 for value in permutation_p if np.isfinite(value))
+        significant_01 = sum(value < 0.01 for value in permutation_p if np.isfinite(value))
+        chance_accuracy = _to_float(group_rows[0]["chance_accuracy"])
+        summary_rows.append(
+            {
+                "variant": variant,
+                "window_center_s": window_center,
+                "n_participants": len(group_rows),
+                "accuracy_mean": mean,
+                "accuracy_std": std,
+                "accuracy_sem": sem,
+                "percent_mean": 100.0 * mean,
+                "percent_median": median,
+                "percent_std": 100.0 * std,
+                "percent_sem": 100.0 * sem,
+                "chance_accuracy": chance_accuracy,
+                "chance_percent": 100.0 * chance_accuracy,
+                "above_chance_count": sum(value > chance_accuracy for value in accuracies),
+                "n_with_permutation": int(n_with_permutation),
+                "n_significant_p_0.05": int(significant_05),
+                "n_significant_p_0.01": int(significant_01),
+            }
+        )
+    return summary_rows
+
+
+def write_stimulus_decoding_plots(summary_rows, output_dir):
+    """Write group-level stimulus decoding plots."""
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _plot_group_accuracy(summary_rows, output_dir / "stimulus_decoding_accuracy.png")
+
+
+def export_time_resolved_stimulus_decoding(
+    data_folder,
+    participants,
+    output_path,
+    *,
+    summary_output_path=None,
+    plots_dir=None,
+    config=None,
+    progress=None,
+):
+    """Run time-resolved stimulus decoding and write CSV/plot artifacts."""
+
+    config = config or StimulusDecodingConfig()
+    rows = evaluate_time_resolved_stimulus_transfer(
+        data_folder,
+        participants,
+        config=config,
+        progress=progress,
+    )
+    write_alpha_metrics_csv(rows, output_path)
+    summary_rows = summarize_stimulus_decoding(rows)
+    if summary_output_path:
+        write_alpha_metrics_csv(summary_rows, summary_output_path)
+    if plots_dir:
+        write_stimulus_decoding_plots(summary_rows, plots_dir)
+    return rows, summary_rows
+
+
+def _load_participant_data(data_folder, participant, *, cue):
+    suffix = "CueData" if cue else "Data"
+    path = Path(data_folder) / f"Part{participant}{suffix}.mat"
+    return sio.loadmat(path)["data"][0]
+
+
+def _check_matching_sample_rate(train_data, validation_data):
+    train_sample_interval = np.diff(train_data["time"][0][0][0][0, :2])
+    validation_sample_interval = np.diff(validation_data["time"][0][0][0][0, :2])
+    if not np.allclose(train_sample_interval, validation_sample_interval):
+        raise ValueError("Sampling rate of the two experiments must match.")
+
+
+def _prepare_data(data, config):
+    data = filter_features(data, config.frequency_range[0], config.frequency_range[1])
+    if config.new_framerate != float("inf"):
+        data = downsample_data(data, config.new_framerate)
+    return data
+
+
+def _evaluate_window(
+    train_data,
+    validation_data,
+    labels_train,
+    labels_validation,
+    participant,
+    window_center,
+    classifier_param,
+    config,
+    permutation_rng=None,
+):
+    train_window = _centered_window(window_center, config.window_size)
+    null_window = _null_window(config)
+    train_stimuli_features, train_null_features = extract_windows(
+        train_data, train_window, null_window
+    )
+    validation_stimuli_features, _ = extract_windows(
+        validation_data, train_window, (np.nan, np.nan)
+    )
+    train_features = np.hstack(train_stimuli_features + train_null_features).T
+    train_labels = labels_train
+    if train_null_features:
+        train_labels = np.concatenate(
+            (labels_train, np.zeros(len(train_null_features), dtype=int))
+        )
+    validation_features = np.hstack(validation_stimuli_features).T
+
+    pca_components = _actual_pca_components(config.components_pca, train_features)
+    explained_variance = np.nan
+    if config.components_pca != float("inf"):
+        train_features, coeff, train_features_mean, explained_variance = (
+            reduce_features_pca(train_features, int(config.components_pca))
+        )
+        validation_features = (
+            validation_features - train_features_mean
+        ) @ coeff[:, :pca_components]
+
+    model = train_multiclass_classifier(
+        train_features,
+        train_labels,
+        config.classifier,
+        classifier_param,
+        random_state=config.random_state,
+    )
+    predictions = model.predict(validation_features)
+    accuracy = float(np.mean(predictions == labels_validation))
+    permutation_accuracy = np.array([], dtype=float)
+    permutation_p = np.nan
+    if config.permutations > 0:
+        permutation_accuracy = _permutation_accuracy_curve(
+            train_features,
+            validation_features,
+            labels_validation,
+            train_labels,
+            config.classifier,
+            classifier_param,
+            config.random_state,
+            config.permutations,
+            permutation_rng,
+        )
+        permutation_p = float(np.mean(permutation_accuracy >= accuracy))
+        if np.isfinite(permutation_p):
+            permutation_p = (permutation_p * config.permutations + 1.0) / (
+                config.permutations + 1.0
+            )
+    chance_accuracy = 1.0 / config.chance_classes
+    variant = "without_null" if np.isnan(config.null_window_center) else "with_null"
+    null_prediction_rate = (
+        float(np.mean(predictions == 0)) if variant == "with_null" else np.nan
+    )
+
+    return {
+        "participant": participant,
+        "variant": variant,
+        "window_center_s": window_center,
+        "window_start_s": train_window[0],
+        "window_stop_s": train_window[1],
+        "accuracy": accuracy,
+        "percent": 100.0 * accuracy,
+        "chance_accuracy": chance_accuracy,
+        "chance_percent": 100.0 * chance_accuracy,
+        "above_chance": accuracy > chance_accuracy,
+        "n_train_trials": len(labels_train),
+        "n_validation_trials": len(labels_validation),
+        "n_train_classes": len(np.unique(labels_train)),
+        "n_validation_classes": len(np.unique(labels_validation)),
+        "n_permutations": int(config.permutations),
+        "permutation_seed": config.permutation_seed,
+        "permutation_p_value": permutation_p,
+        "permutation_accuracy_mean": (
+            float(np.mean(permutation_accuracy))
+            if permutation_accuracy.size
+            else np.nan
+        ),
+        "permutation_accuracy_std": (
+            float(np.std(permutation_accuracy, ddof=1))
+            if permutation_accuracy.size > 1
+            else np.nan
+        ),
+        "null_window_center_s": config.null_window_center,
+        "null_prediction_rate": null_prediction_rate,
+        "classifier": config.classifier,
+        "classifier_param": classifier_param,
+        "components_pca": config.components_pca,
+        "actual_components_pca": pca_components,
+        "pca_explained_variance_percent": explained_variance,
+        "frequency_low_hz": config.frequency_range[0],
+        "frequency_high_hz": config.frequency_range[1],
+    }
+
+
+def _centered_window(center, size):
+    return center - size / 2, center + size / 2
+
+
+def _null_window(config):
+    if np.isnan(config.null_window_center):
+        return np.nan, np.nan
+    return _centered_window(config.null_window_center, config.window_size)
+
+
+def _actual_pca_components(components_pca, features):
+    if components_pca == float("inf"):
+        return features.shape[1]
+    return min(int(components_pca), features.shape[0], features.shape[1])
+
+
+def _to_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return np.nan
+
+
+def _permutation_accuracy_curve(
+    train_features,
+    validation_features,
+    labels_validation,
+    train_labels,
+    classifier,
+    classifier_param,
+    random_state,
+    n_permutations,
+    permutation_rng,
+):
+    if permutation_rng is None:
+        permutation_rng = np.random.default_rng()
+
+    permuted_scores = []
+    for _ in range(int(n_permutations)):
+        permuted_train_labels = np.array(train_labels, copy=True)
+        permutation_rng.shuffle(permuted_train_labels)
+        model = train_multiclass_classifier(
+            train_features,
+            permuted_train_labels,
+            classifier,
+            classifier_param,
+            random_state=random_state,
+        )
+        predictions = model.predict(validation_features)
+        permuted_scores.append(float(np.mean(predictions == labels_validation)))
+    return np.asarray(permuted_scores, dtype=float)
+
+
+def _summary_stats(values):
+    values = np.asarray(list(values), dtype=float)
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        return np.nan, np.nan, np.nan
+    std = float(np.std(values, ddof=1)) if values.size > 1 else 0.0
+    return float(np.mean(values)), std, float(std / np.sqrt(values.size))
+
+
+def _plot_group_accuracy(summary_rows, output_path):
+    figure, axes = plt.subplots(figsize=(8, 5))
+    grouped = defaultdict(list)
+    for row in summary_rows:
+        grouped[row["variant"]].append(row)
+
+    chance_percent = None
+    for variant, rows in sorted(grouped.items()):
+        rows = sorted(rows, key=lambda row: _to_float(row["window_center_s"]))
+        x = np.asarray([_to_float(row["window_center_s"]) for row in rows], dtype=float)
+        y = np.asarray([_to_float(row["percent_mean"]) for row in rows], dtype=float)
+        sem = np.asarray([_to_float(row["percent_sem"]) for row in rows], dtype=float)
+        chance_percent = _to_float(rows[0]["chance_percent"])
+        axes.plot(x, y, marker="o", label=variant.replace("_", " "))
+        axes.fill_between(x, y - sem, y + sem, alpha=0.2)
+
+    if chance_percent is not None:
+        axes.axhline(chance_percent, color="black", linewidth=1, linestyle="--")
+    axes.axvline(0, color="black", linewidth=1, linestyle=":")
+    axes.set_xlabel("window center from stimulus (s)")
+    axes.set_ylabel("stimulus decoding accuracy (%)")
+    axes.grid(True, alpha=0.25)
+    axes.legend(fontsize="small")
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=150)
+    plt.close(figure)

--- a/tests/test_stimulus_decoding.py
+++ b/tests/test_stimulus_decoding.py
@@ -1,0 +1,130 @@
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from pymegdec.stimulus_decoding import (
+    StimulusDecodingConfig,
+    evaluate_participant_time_resolved_stimulus_transfer,
+    summarize_stimulus_decoding,
+    window_centers_from_range,
+)
+from tests.matlab_fixtures import cell_array
+
+
+def _mat_data(labels, trial_values, time):
+    trialinfo = np.empty((1, 1), dtype=object)
+    trialinfo[0, 0] = np.asarray(labels, dtype=int)
+    return {
+        "trial": cell_array(
+            [np.asarray([[0.0, value]], dtype=float) for value in trial_values]
+        ),
+        "time": cell_array([np.asarray([time], dtype=float) for _ in trial_values]),
+        "trialinfo": trialinfo,
+    }
+
+
+class TestStimulusDecoding(unittest.TestCase):
+    def test_window_centers_from_range_includes_stop(self):
+        self.assertEqual(
+            window_centers_from_range((-0.1, 0.1), 0.1),
+            (-0.1, 0.0, 0.1),
+        )
+
+    def test_evaluate_participant_time_resolved_stimulus_transfer(self):
+        labels = [1, 2, 1, 2]
+        train_data = _mat_data(labels, [-2.0, 2.0, -1.0, 1.0], [-0.1, 0.0])
+        validation_data = _mat_data(labels, [-1.5, 1.5, -0.5, 0.5], [-0.1, 0.0])
+        config = StimulusDecodingConfig(
+            window_centers=(0.0,),
+            window_size=0.0,
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch(
+            "pymegdec.stimulus_decoding.sio.loadmat",
+            side_effect=[
+                {"data": np.array([train_data], dtype=object)},
+                {"data": np.array([validation_data], dtype=object)},
+            ],
+        ):
+            rows = evaluate_participant_time_resolved_stimulus_transfer(
+                "unused", 1, config=config
+            )
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["variant"], "without_null")
+        self.assertEqual(rows[0]["accuracy"], 1.0)
+        self.assertEqual(rows[0]["chance_accuracy"], 0.5)
+
+    def test_evaluate_participant_time_resolved_stimulus_transfer_with_permutations(
+        self,
+    ):
+        labels = [1, 2, 1, 2]
+        train_data = _mat_data(labels, [-2.0, 2.0, -1.0, 1.0], [-0.1, 0.0])
+        validation_data = _mat_data(labels, [-1.5, 1.5, -0.5, 0.5], [-0.1, 0.0])
+        config = StimulusDecodingConfig(
+            window_centers=(0.0,),
+            window_size=0.0,
+            components_pca=float("inf"),
+            chance_classes=2,
+            permutations=3,
+            permutation_seed=0,
+        )
+
+        with patch(
+            "pymegdec.stimulus_decoding.sio.loadmat",
+            side_effect=[
+                {"data": np.array([train_data], dtype=object)},
+                {"data": np.array([validation_data], dtype=object)},
+            ],
+        ), patch(
+            "pymegdec.stimulus_decoding._permutation_accuracy_curve",
+            return_value=np.array([0.0, 0.25, 0.5]),
+        ):
+            rows = evaluate_participant_time_resolved_stimulus_transfer(
+                "unused", 1, config=config
+            )
+
+        self.assertEqual(rows[0]["n_permutations"], 3)
+        self.assertAlmostEqual(rows[0]["permutation_p_value"], 0.25)
+        self.assertAlmostEqual(rows[0]["permutation_accuracy_mean"], 0.25)
+
+    def test_summarize_stimulus_decoding(self):
+        rows = [
+            {
+                "variant": "without_null",
+                "window_center_s": 0.0,
+                "accuracy": 0.25,
+                "chance_accuracy": 0.0625,
+                "permutation_p_value": 0.04,
+            },
+            {
+                "variant": "without_null",
+                "window_center_s": 0.0,
+                "accuracy": 0.5,
+                "chance_accuracy": 0.0625,
+                "permutation_p_value": 0.006,
+            },
+            {
+                "variant": "without_null",
+                "window_center_s": 0.1,
+                "accuracy": 0.5,
+                "chance_accuracy": 0.0625,
+                "permutation_p_value": np.nan,
+            },
+        ]
+
+        summary = summarize_stimulus_decoding(rows)
+
+        self.assertEqual(len(summary), 2)
+        self.assertEqual(summary[0]["n_participants"], 2)
+        self.assertAlmostEqual(summary[0]["accuracy_mean"], 0.375)
+        self.assertEqual(summary[0]["above_chance_count"], 2)
+        self.assertEqual(summary[0]["n_with_permutation"], 2)
+        self.assertEqual(summary[0]["n_significant_p_0.05"], 2)
+        self.assertEqual(summary[0]["n_significant_p_0.01"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add time-resolved stimulus decoding pipeline in new module src/pymegdec/stimulus_decoding.py.
- Add top-level script wrapper nalyze_stimulus_decoding.py for direct execution.
- Add pymegdec stimulus-decoding CLI command and participant-set helper.
- Add optional permutation-based significance (--permutations, --permutation-seed) with per-window p-values and summary counts.
- Extend exports with permutation diagnostics (mean/std/permutation p-value) and summary metrics.
- Export package symbols in src/pymegdec/__init__.py and add CLI entrypoint in pyproject.toml.
- Add regression tests in 	ests/test_stimulus_decoding.py.
- Update README with usage examples and command docs.