### PR TITLE
Add validated manual inputs to stimulus decoding workflow

### DIFF
--- a/.github/workflows/stimulus-decoding.yml
+++ b/.github/workflows/stimulus-decoding.yml
@@ -2,42 +2,155 @@ name: Manual stimulus decoding
 
 on:
   workflow_dispatch:
+    inputs:
+      python_version:
+        description: Python version used for the analysis environment.
+        required: true
+        default: "3.13"
+        type: string
+      use_nextcloud_data:
+        description: Restore/download/cache the MEG data before running.
+        required: true
+        default: true
+        type: boolean
+      data_cache_version:
+        description: MEG data cache version. Bump to force a fresh cache.
+        required: true
+        default: v1
+        type: string
+      data_dir:
+        description: Relative data directory to restore/populate.
+        required: true
+        default: .cache/meg-data-all
+        type: string
+      participants:
+        description: Participant ids for a single unsharded run. Ignored when participant_batches is non-empty.
+        required: false
+        default: ""
+        type: string
+      participant_batches:
+        description: Semicolon-separated participant batches.
+        required: false
+        default: "1-4;6,8,9,10;13-16;17-20;21;22;23;24;25;26;27"
+        type: string
+      time_window:
+        description: Window-center range as start,stop in seconds.
+        required: true
+        default: "-0.4,0.8"
+        type: string
+      window_step_s:
+        description: Step between time-window centers in seconds.
+        required: true
+        default: "0.025"
+        type: string
+      window_size:
+        description: Window size in seconds.
+        required: true
+        default: "0.1"
+        type: string
+      classifier:
+        description: Classifier name passed to pymegdec-stimulus-decoding.
+        required: true
+        default: multiclass-svm
+        type: choice
+        options:
+          - multiclass-svm
+          - multiclass-svm-weighted
+          - random-forest
+          - gradient-boosting
+          - knn
+          - mostFrequentDummy
+          - always1Dummy
+          - xgboost
+          - scikit-mlp
+          - pytorch-mlp
+      classifier_param:
+        description: Optional classifier parameter, JSON/Python literal/numeric value, or empty.
+        required: false
+        default: ""
+        type: string
+      components_pca:
+        description: Number of PCA components, or inf.
+        required: true
+        default: "100"
+        type: string
+      frequency_low:
+        description: Lower frequency bound in Hz.
+        required: true
+        default: "0"
+        type: string
+      frequency_high:
+        description: Upper frequency bound in Hz, or inf.
+        required: true
+        default: inf
+        type: string
+      chance_classes:
+        description: Number of stimulus classes used for the chance line.
+        required: true
+        default: "16"
+        type: string
+      permutations:
+        description: Number of label shuffles per participant/window for permutation p-values.
+        required: true
+        default: "1000"
+        type: string
+      permutation_seed:
+        description: Seed for permutation label shuffles.
+        required: true
+        default: "42"
+        type: string
+      install_extra:
+        description: Optional dependency extra to install.
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - xgboost
+          - torch
+          - all
+      output_prefix:
+        description: Prefix for output CSVs and plot directory under outputs/.
+        required: true
+        default: stimulus_decoding
+        type: string
+      fail_if_missing_data:
+        description: Fail if data_dir does not exist after optional cache restore/download.
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
 
-env:
-  PYTHON_VERSION: "3.13"
-  USE_NEXTCLOUD_DATA: "true"
-  DATA_CACHE_VERSION: v1
-  DATA_DIR: .cache/meg-data-all
-  PARTICIPANTS: ""
-  PARTICIPANT_BATCHES: "1-4;6,8,9,10;13-16;17-20;21;22;23;24;25;26;27"
-  TIME_WINDOW: "-0.4,0.8"
-  WINDOW_STEP_S: "0.025"
-  WINDOW_SIZE: "0.1"
-  CLASSIFIER: multiclass-svm
-  CLASSIFIER_PARAM: ""
-  COMPONENTS_PCA: "100"
-  FREQUENCY_LOW: "0"
-  FREQUENCY_HIGH: inf
-  CHANCE_CLASSES: "16"
-  PERMUTATIONS: "1000"
-  PERMUTATION_SEED: "42"
-  INSTALL_EXTRA: none
-  OUTPUT_PREFIX: stimulus_decoding
-  FAIL_IF_MISSING_DATA: "true"
-
 jobs:
-  prepare-batches:
-    name: Prepare participant batches
+  prepare-inputs:
+    name: Validate inputs and prepare participant batches
     runs-on: ubuntu-latest
     outputs:
-      batches: ${{ steps.batches.outputs.batches }}
+      batches: ${{ steps.validate.outputs.batches }}
+      python_version: ${{ steps.validate.outputs.python_version }}
+      use_nextcloud_data: ${{ steps.validate.outputs.use_nextcloud_data }}
+      data_cache_version: ${{ steps.validate.outputs.data_cache_version }}
+      data_dir: ${{ steps.validate.outputs.data_dir }}
+      time_window: ${{ steps.validate.outputs.time_window }}
+      window_step_s: ${{ steps.validate.outputs.window_step_s }}
+      window_size: ${{ steps.validate.outputs.window_size }}
+      classifier: ${{ steps.validate.outputs.classifier }}
+      classifier_param: ${{ steps.validate.outputs.classifier_param }}
+      components_pca: ${{ steps.validate.outputs.components_pca }}
+      frequency_low: ${{ steps.validate.outputs.frequency_low }}
+      frequency_high: ${{ steps.validate.outputs.frequency_high }}
+      chance_classes: ${{ steps.validate.outputs.chance_classes }}
+      permutations: ${{ steps.validate.outputs.permutations }}
+      permutation_seed: ${{ steps.validate.outputs.permutation_seed }}
+      install_extra: ${{ steps.validate.outputs.install_extra }}
+      output_prefix: ${{ steps.validate.outputs.output_prefix }}
+      fail_if_missing_data: ${{ steps.validate.outputs.fail_if_missing_data }}
 
     steps:
-      - name: Build batch matrix
-        id: batches
+      - name: Validate manual inputs
+        id: validate
         shell: bash
         run: |
           set -euo pipefail
@@ -45,16 +158,168 @@ jobs:
           from __future__ import annotations
 
           import json
+          import math
           import os
           import re
-          from pathlib import Path
+          from pathlib import Path, PurePosixPath
 
-          raw_batches = os.environ.get("PARTICIPANT_BATCHES", "").strip()
-          fallback = os.environ.get("PARTICIPANTS", "").strip()
+          DEFAULTS = {
+              "python_version": "3.13",
+              "use_nextcloud_data": "true",
+              "data_cache_version": "v1",
+              "data_dir": ".cache/meg-data-all",
+              "participants": "",
+              "participant_batches": "1-4;6,8,9,10;13-16;17-20;21;22;23;24;25;26;27",
+              "time_window": "-0.4,0.8",
+              "window_step_s": "0.025",
+              "window_size": "0.1",
+              "classifier": "multiclass-svm",
+              "classifier_param": "",
+              "components_pca": "100",
+              "frequency_low": "0",
+              "frequency_high": "inf",
+              "chance_classes": "16",
+              "permutations": "1000",
+              "permutation_seed": "42",
+              "install_extra": "none",
+              "output_prefix": "stimulus_decoding",
+              "fail_if_missing_data": "true",
+          }
+          ALLOWED_CLASSIFIERS = {
+              "multiclass-svm",
+              "multiclass-svm-weighted",
+              "random-forest",
+              "gradient-boosting",
+              "knn",
+              "mostFrequentDummy",
+              "always1Dummy",
+              "xgboost",
+              "scikit-mlp",
+              "pytorch-mlp",
+          }
+          ALLOWED_EXTRAS = {"none", "xgboost", "torch", "all"}
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          raw_inputs = event.get("inputs", {})
+
+          def raw_value(name: str) -> str:
+              value = raw_inputs.get(name, DEFAULTS[name])
+              if value is None:
+                  value = DEFAULTS[name]
+              value = str(value).strip()
+              if value == "" and name not in {"participants", "participant_batches", "classifier_param"}:
+                  value = DEFAULTS[name]
+              if any(char in value for char in "\x00\n\r"):
+                  raise SystemExit(f"Input {name!r} may not contain control characters or newlines.")
+              return value
+
+          def normalize_bool(name: str) -> str:
+              value = raw_value(name).lower()
+              if value in {"true", "1", "yes"}:
+                  return "true"
+              if value in {"false", "0", "no"}:
+                  return "false"
+              raise SystemExit(f"Input {name!r} must be boolean.")
+
+          def require_match(name: str, pattern: str, *, max_len: int = 128) -> str:
+              value = raw_value(name)
+              if len(value) > max_len or not re.fullmatch(pattern, value):
+                  raise SystemExit(f"Input {name!r} has invalid characters or length.")
+              return value
+
+          def normalize_int(name: str, *, minimum: int, maximum: int) -> str:
+              value = require_match(name, r"[0-9]+", max_len=12)
+              integer = int(value)
+              if not minimum <= integer <= maximum:
+                  raise SystemExit(f"Input {name!r} must be between {minimum} and {maximum}.")
+              return str(integer)
+
+          def normalize_float(name: str, *, minimum: float | None = None, allow_inf: bool = False) -> str:
+              value = raw_value(name).lower()
+              if allow_inf and value == "inf":
+                  return "inf"
+              if not re.fullmatch(r"[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?", value):
+                  raise SystemExit(f"Input {name!r} must be a finite number" + (" or inf." if allow_inf else "."))
+              number = float(value)
+              if minimum is not None and number < minimum:
+                  raise SystemExit(f"Input {name!r} must be >= {minimum}.")
+              return format(number, ".12g")
+
+          def normalize_time_window() -> str:
+              value = raw_value("time_window")
+              match = re.fullmatch(r"\s*([-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?)\s*,\s*([-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?)\s*", value)
+              if not match:
+                  raise SystemExit("Input 'time_window' must have the form start,stop.")
+              start = float(match.group(1))
+              stop = float(match.group(2))
+              if not start < stop:
+                  raise SystemExit("Input 'time_window' start must be smaller than stop.")
+              if start < -10 or stop > 10:
+                  raise SystemExit("Input 'time_window' must stay within [-10, 10] seconds.")
+              return f"{start:.12g},{stop:.12g}"
+
+          def normalize_data_dir() -> str:
+              value = require_match("data_dir", r"[A-Za-z0-9._/-]+", max_len=160)
+              path = PurePosixPath(value)
+              if path.is_absolute() or ".." in path.parts:
+                  raise SystemExit("Input 'data_dir' must be a relative path without '..'.")
+              return value.rstrip("/") or DEFAULTS["data_dir"]
+
+          def normalize_participant_spec(name: str, *, allow_semicolon: bool) -> str:
+              value = raw_value(name).replace(" ", "")
+              pattern = r"[0-9,;\-]*" if allow_semicolon else r"[0-9,\-]*"
+              if len(value) > 256 or not re.fullmatch(pattern, value):
+                  raise SystemExit(f"Input {name!r} must contain only digits, ranges, commas" + (", and semicolons." if allow_semicolon else "."))
+              return value
+
+          def normalize_components() -> str:
+              value = raw_value("components_pca").lower()
+              if value == "inf":
+                  return "inf"
+              return normalize_int("components_pca", minimum=1, maximum=100000)
+
+          def normalize_classifier_param() -> str:
+              value = raw_value("classifier_param")
+              if value == "":
+                  return value
+              if len(value) > 300 or not re.fullmatch(r"[A-Za-z0-9_.,:{}\[\]\"' +\-eE]*", value):
+                  raise SystemExit("Input 'classifier_param' contains unsupported characters.")
+              return value
+
+          sanitized = {
+              "python_version": require_match("python_version", r"[0-9]+(?:\.[0-9]+){0,2}", max_len=16),
+              "use_nextcloud_data": normalize_bool("use_nextcloud_data"),
+              "data_cache_version": require_match("data_cache_version", r"[A-Za-z0-9._-]+", max_len=64),
+              "data_dir": normalize_data_dir(),
+              "participants": normalize_participant_spec("participants", allow_semicolon=False),
+              "participant_batches": normalize_participant_spec("participant_batches", allow_semicolon=True),
+              "time_window": normalize_time_window(),
+              "window_step_s": normalize_float("window_step_s", minimum=0.001),
+              "window_size": normalize_float("window_size", minimum=0.001),
+              "classifier": require_match("classifier", r"[A-Za-z0-9_-]+", max_len=64),
+              "classifier_param": normalize_classifier_param(),
+              "components_pca": normalize_components(),
+              "frequency_low": normalize_float("frequency_low", minimum=0.0),
+              "frequency_high": normalize_float("frequency_high", minimum=0.0, allow_inf=True),
+              "chance_classes": normalize_int("chance_classes", minimum=2, maximum=10000),
+              "permutations": normalize_int("permutations", minimum=0, maximum=100000),
+              "permutation_seed": normalize_int("permutation_seed", minimum=0, maximum=2147483647),
+              "install_extra": require_match("install_extra", r"[A-Za-z0-9_-]+", max_len=32),
+              "output_prefix": require_match("output_prefix", r"[A-Za-z0-9_.-]+", max_len=80),
+              "fail_if_missing_data": normalize_bool("fail_if_missing_data"),
+          }
+          if sanitized["classifier"] not in ALLOWED_CLASSIFIERS:
+              raise SystemExit("Unsupported classifier.")
+          if sanitized["install_extra"] not in ALLOWED_EXTRAS:
+              raise SystemExit("Unsupported install extra.")
+          if sanitized["frequency_high"] != "inf" and float(sanitized["frequency_high"]) < float(sanitized["frequency_low"]):
+              raise SystemExit("frequency_high must be >= frequency_low.")
+
+          raw_batches = sanitized["participant_batches"]
           if raw_batches:
-              chunks = [chunk.strip() for chunk in re.split(r"[;\n]+", raw_batches) if chunk.strip()]
-          elif fallback:
-              chunks = [fallback]
+              chunks = [chunk for chunk in raw_batches.split(";") if chunk]
+          elif sanitized["participants"]:
+              chunks = [sanitized["participants"]]
           else:
               chunks = [""]
 
@@ -65,20 +330,40 @@ jobs:
               batches.append({"batch_id": f"{index:02d}-{slug[:48]}", "participants": participants})
 
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              for name, value in sanitized.items():
+                  output.write(f"{name}={value}\n")
               output.write(f"batches={json.dumps(batches)}\n")
-          print(json.dumps(batches, indent=2))
+          print(json.dumps({"batches": batches, **sanitized}, indent=2))
           PY
 
   stimulus-decoding:
     name: Run stimulus decoding (${{ matrix.batch_id }})
-    needs: prepare-batches
+    needs: prepare-inputs
     runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
-        include: ${{ fromJSON(needs.prepare-batches.outputs.batches) }}
+        include: ${{ fromJSON(needs.prepare-inputs.outputs.batches) }}
+    env:
+      DATA_DIR: ${{ needs.prepare-inputs.outputs.data_dir }}
+      USE_NEXTCLOUD_DATA: ${{ needs.prepare-inputs.outputs.use_nextcloud_data }}
+      DATA_CACHE_VERSION: ${{ needs.prepare-inputs.outputs.data_cache_version }}
+      INSTALL_EXTRA: ${{ needs.prepare-inputs.outputs.install_extra }}
+      TIME_WINDOW: ${{ needs.prepare-inputs.outputs.time_window }}
+      WINDOW_STEP_S: ${{ needs.prepare-inputs.outputs.window_step_s }}
+      WINDOW_SIZE: ${{ needs.prepare-inputs.outputs.window_size }}
+      CLASSIFIER: ${{ needs.prepare-inputs.outputs.classifier }}
+      CLASSIFIER_PARAM: ${{ needs.prepare-inputs.outputs.classifier_param }}
+      COMPONENTS_PCA: ${{ needs.prepare-inputs.outputs.components_pca }}
+      FREQUENCY_LOW: ${{ needs.prepare-inputs.outputs.frequency_low }}
+      FREQUENCY_HIGH: ${{ needs.prepare-inputs.outputs.frequency_high }}
+      CHANCE_CLASSES: ${{ needs.prepare-inputs.outputs.chance_classes }}
+      PERMUTATIONS: ${{ needs.prepare-inputs.outputs.permutations }}
+      PERMUTATION_SEED: ${{ needs.prepare-inputs.outputs.permutation_seed }}
+      OUTPUT_PREFIX: ${{ needs.prepare-inputs.outputs.output_prefix }}
+      FAIL_IF_MISSING_DATA: ${{ needs.prepare-inputs.outputs.fail_if_missing_data }}
 
     steps:
       - name: Check out repository
@@ -92,68 +377,14 @@ jobs:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
 
-      - name: Install rclone
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y rclone
-
-      - name: Download MEG data from bwSync&Share via WebDAV
+      - name: Download MEG data files from URL list
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
         shell: bash
         env:
-          MEG_DATA_ALL: ${{ secrets.MEG_DATA_ALL }}
+          MEG_DATA_URL_LIST: ${{ secrets.MEG_DATA_URL_LIST }}
         run: |
           set -euo pipefail
-
-          if [[ -z "${MEG_DATA_ALL:-}" ]]; then
-            echo "The MEG_DATA_ALL repository secret is empty or unavailable." >&2
-            exit 1
-          fi
-
-          python3 - <<'PY' > /tmp/nextcloud-share.env
-          import os
-          from urllib.parse import urlparse
-
-          url = os.environ["MEG_DATA_ALL"].rstrip("/")
-          parsed = urlparse(url)
-          parts = parsed.path.strip("/").split("/")
-
-          if "s" not in parts:
-              raise SystemExit("Expected a Nextcloud-style public share URL containing /s/<token>")
-
-          token_index = parts.index("s") + 1
-          if token_index >= len(parts) or not parts[token_index]:
-              raise SystemExit("Expected a Nextcloud-style public share URL containing /s/<token>")
-
-          host = f"{parsed.scheme}://{parsed.netloc}"
-          token = parts[token_index]
-
-          with open("/tmp/nextcloud-share.env", "w", encoding="utf-8") as handle:
-              handle.write(f"HOST={host}\n")
-              handle.write(f"TOKEN={token}\n")
-          PY
-
-          source /tmp/nextcloud-share.env
-          rm -rf "${DATA_DIR}"
-          mkdir -p "${DATA_DIR}"
-
-          rclone copy \
-            --webdav-url "${HOST}/public.php/webdav/" \
-            --webdav-user "${TOKEN}" \
-            --webdav-pass "" \
-            --webdav-vendor nextcloud \
-            :webdav: "${DATA_DIR}" \
-            --transfers 4 \
-            --checkers 8 \
-            --retries 10 \
-            --low-level-retries 20 \
-            --stats 30s \
-            --create-empty-src-dirs
-
-          rm -f /tmp/nextcloud-share.env
+          python3 scripts/download_meg_data_files.py --data-dir "${DATA_DIR}"
 
       - name: Save MEG data cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
@@ -166,7 +397,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ needs.prepare-inputs.outputs.python_version }}
 
       - name: Install package
         shell: bash
@@ -268,7 +499,6 @@ jobs:
           if [[ -n "${BATCH_PARTICIPANTS}" ]]; then
             cmd+=(--participants "${BATCH_PARTICIPANTS}")
           fi
-
           if [[ -n "${CLASSIFIER_PARAM}" ]]; then
             cmd+=(--classifier-param "${CLASSIFIER_PARAM}")
           fi
@@ -301,22 +531,26 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ env.OUTPUT_PREFIX }}-${{ matrix.batch_id }}-outputs
+          name: ${{ needs.prepare-inputs.outputs.output_prefix }}-${{ matrix.batch_id }}-outputs
           path: outputs/
           if-no-files-found: warn
 
   aggregate-outputs:
     name: Aggregate decoding outputs
-    needs: stimulus-decoding
+    needs:
+      - prepare-inputs
+      - stimulus-decoding
     if: always()
     runs-on: ubuntu-latest
+    env:
+      OUTPUT_PREFIX: ${{ needs.prepare-inputs.outputs.output_prefix }}
 
     steps:
       - name: Download shard artifacts
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          pattern: ${{ env.OUTPUT_PREFIX }}-*-outputs
+          pattern: ${{ needs.prepare-inputs.outputs.output_prefix }}-*-outputs
           path: shard-artifacts
           merge-multiple: false
 
@@ -463,6 +697,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ env.OUTPUT_PREFIX }}-combined-outputs
+          name: ${{ needs.prepare-inputs.outputs.output_prefix }}-combined-outputs
           path: outputs_combined/
           if-no-files-found: warn


### PR DESCRIPTION
## Summary

This PR restores editable `workflow_dispatch` inputs for the manual stimulus decoding workflow while keeping the MegaLinter/security hardening approach.

Instead of using raw GitHub expression values directly in shell commands, the workflow now:

- reads manual inputs from `GITHUB_EVENT_PATH` in a dedicated `prepare-inputs` job,
- validates and normalizes all values in Python,
- exposes only sanitized values as job outputs,
- uses those sanitized outputs in downstream matrix jobs,
- keeps sharded participant batches and combined aggregation outputs.

## Editable inputs restored

The GitHub UI can now change, among others:

- `participant_batches`
- `participants`
- `time_window`
- `window_step_s`
- `window_size`
- `permutations`
- `data_cache_version`
- `classifier`
- `components_pca`

The default participant split is changed to avoid the long final shard timeout:

```text
1-4;6,8,9,10;13-16;17-20;21-23;24-27
```

## Security notes

The validation step rejects newlines/control characters and restricts inputs to tight allow-lists or numeric/path patterns. Shell steps use sanitized environment variables rather than direct `github.event.inputs.*` interpolation.

## Data path

On a cache miss, the workflow now uses the existing `scripts/download_meg_data_files.py` URL-list downloader with `MEG_DATA_URL_LIST`, matching the working data-cache workflow path.