### PR TITLE
Add peak diagnostics for stimulus decoding

### DIFF
--- a/.github/workflows/stimulus-decoding.yml
+++ b/.github/workflows/stimulus-decoding.yml
@@ -43,6 +43,11 @@ on:
         required: true
         default: "0.025"
         type: string
+      diagnostic_window_centers:
+        description: Comma-separated window centers for confusion and per-stimulus diagnostics. Leave empty to disable.
+        required: false
+        default: "0.15,0.2,0.25"
+        type: string
       window_size:
         description: Window size in seconds.
         required: true
@@ -145,6 +150,7 @@ jobs:
       data_dir: ${{ steps.validate.outputs.data_dir }}
       time_window: ${{ steps.validate.outputs.time_window }}
       window_step_s: ${{ steps.validate.outputs.window_step_s }}
+      diagnostic_window_centers: ${{ steps.validate.outputs.diagnostic_window_centers }}
       window_size: ${{ steps.validate.outputs.window_size }}
       classifier: ${{ steps.validate.outputs.classifier }}
       classifier_param: ${{ steps.validate.outputs.classifier_param }}
@@ -183,6 +189,7 @@ jobs:
               "participant_batches": "1-4;6,8,9,10;13-16;17-20;21;22;23;24;25;26;27",
               "time_window": "-0.4,0.8",
               "window_step_s": "0.025",
+              "diagnostic_window_centers": "0.15,0.2,0.25",
               "window_size": "0.1",
               "classifier": "multiclass-svm",
               "classifier_param": "",
@@ -219,7 +226,7 @@ jobs:
               if value is None:
                   value = DEFAULTS[name]
               value = str(value).strip()
-              if value == "" and name not in {"participants", "participant_batches", "classifier_param"}:
+              if value == "" and name not in {"participants", "participant_batches", "classifier_param", "diagnostic_window_centers"}:
                   value = DEFAULTS[name]
               if any(char in value for char in "\x00\n\r"):
                   raise SystemExit(f"Input {name!r} may not contain control characters or newlines.")
@@ -270,6 +277,26 @@ jobs:
                   raise SystemExit("Input 'time_window' must stay within [-10, 10] seconds.")
               return f"{start:.12g},{stop:.12g}"
 
+          def normalize_float_list(name: str, *, minimum: float | None = None, maximum: float | None = None) -> str:
+              value = raw_value(name).replace(" ", "")
+              if value == "":
+                  return ""
+              if len(value) > 256:
+                  raise SystemExit(f"Input {name!r} is too long.")
+              values = []
+              for token in value.split(","):
+                  if not token:
+                      raise SystemExit(f"Input {name!r} has an empty item.")
+                  if not re.fullmatch(r"[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?", token):
+                      raise SystemExit(f"Input {name!r} must contain only finite comma-separated numbers.")
+                  parsed = float(token)
+                  if minimum is not None and parsed < minimum:
+                      raise SystemExit(f"Input {name!r} values must be >= {minimum}.")
+                  if maximum is not None and parsed > maximum:
+                      raise SystemExit(f"Input {name!r} values must be <= {maximum}.")
+                  values.append(format(parsed, ".12g"))
+              return ",".join(values)
+
           def normalize_data_dir() -> str:
               value = require_match("data_dir", r"[A-Za-z0-9._/-]+", max_len=160)
               path = PurePosixPath(value)
@@ -304,6 +331,7 @@ jobs:
               "participant_batches": normalize_participant_spec("participant_batches", allow_semicolon=True),
               "time_window": normalize_time_window(),
               "window_step_s": normalize_float("window_step_s", minimum=0.001),
+              "diagnostic_window_centers": normalize_float_list("diagnostic_window_centers", minimum=-10.0, maximum=10.0),
               "window_size": normalize_float("window_size", minimum=0.001),
               "classifier": require_match("classifier", r"[A-Za-z0-9_-]+", max_len=64),
               "classifier_param": normalize_classifier_param(),
@@ -363,6 +391,7 @@ jobs:
       INSTALL_EXTRA: ${{ needs.prepare-inputs.outputs.install_extra }}
       TIME_WINDOW: ${{ needs.prepare-inputs.outputs.time_window }}
       WINDOW_STEP_S: ${{ needs.prepare-inputs.outputs.window_step_s }}
+      DIAGNOSTIC_WINDOW_CENTERS: ${{ needs.prepare-inputs.outputs.diagnostic_window_centers }}
       WINDOW_SIZE: ${{ needs.prepare-inputs.outputs.window_size }}
       CLASSIFIER: ${{ needs.prepare-inputs.outputs.classifier }}
       CLASSIFIER_PARAM: ${{ needs.prepare-inputs.outputs.classifier_param }}
@@ -486,6 +515,10 @@ jobs:
           output_prefix="${OUTPUT_PREFIX}_${BATCH_ID}"
           output_csv="outputs/${output_prefix}.csv"
           summary_csv="outputs/${output_prefix}_summary.csv"
+          predictions_csv="outputs/${output_prefix}_predictions.csv"
+          confusion_csv="outputs/${output_prefix}_confusion.csv"
+          per_stimulus_csv="outputs/${output_prefix}_per_stimulus.csv"
+          participant_peaks_csv="outputs/${output_prefix}_participant_peaks.csv"
           plots_dir="outputs/${output_prefix}_plots"
 
           cmd=(
@@ -493,6 +526,7 @@ jobs:
             --data-dir "${PYMEGDEC_ANALYSIS_DATA_DIR}"
             --output "${output_csv}"
             --summary-output "${summary_csv}"
+            --participant-peaks-output "${participant_peaks_csv}"
             --plots-dir "${plots_dir}"
             "--time-window=${TIME_WINDOW}"
             --window-step-s "${WINDOW_STEP_S}"
@@ -506,6 +540,14 @@ jobs:
             --permutation-seed "${PERMUTATION_SEED}"
           )
 
+          if [[ -n "${DIAGNOSTIC_WINDOW_CENTERS}" ]]; then
+            cmd+=(
+              --diagnostic-window-centers "${DIAGNOSTIC_WINDOW_CENTERS}"
+              --predictions-output "${predictions_csv}"
+              --confusion-output "${confusion_csv}"
+              --per-stimulus-output "${per_stimulus_csv}"
+            )
+          fi
           if [[ -n "${BATCH_PARTICIPANTS}" ]]; then
             cmd+=(--participants "${BATCH_PARTICIPANTS}")
           fi
@@ -526,6 +568,7 @@ jobs:
             echo "- Participants: \`${BATCH_PARTICIPANTS:-auto-detected}\`"
             echo "- Time-window centers: \`${TIME_WINDOW}\`"
             echo "- Window step: \`${WINDOW_STEP_S}\` s"
+            echo "- Diagnostic window centers: \`${DIAGNOSTIC_WINDOW_CENTERS:-disabled}\`"
             echo "- Window size: \`${WINDOW_SIZE}\` s"
             echo "- Classifier: \`${CLASSIFIER}\`"
             echo "- PCA components: \`${COMPONENTS_PCA}\`"
@@ -583,14 +626,28 @@ jobs:
           combined_dir = Path("outputs_combined")
           combined_dir.mkdir(parents=True, exist_ok=True)
 
-          raw_files = []
-          summary_files = []
+          file_groups = {
+              "raw": [],
+              "summary": [],
+              "predictions": [],
+              "confusion": [],
+              "per_stimulus": [],
+              "participant_peaks": [],
+          }
           if root.exists():
               for path in root.rglob("*.csv"):
                   if path.name.endswith("_summary.csv"):
-                      summary_files.append(path)
+                      file_groups["summary"].append(path)
+                  elif path.name.endswith("_predictions.csv"):
+                      file_groups["predictions"].append(path)
+                  elif path.name.endswith("_confusion.csv"):
+                      file_groups["confusion"].append(path)
+                  elif path.name.endswith("_per_stimulus.csv"):
+                      file_groups["per_stimulus"].append(path)
+                  elif path.name.endswith("_participant_peaks.csv"):
+                      file_groups["participant_peaks"].append(path)
                   else:
-                      raw_files.append(path)
+                      file_groups["raw"].append(path)
 
           def read_csv(path: Path) -> list[dict[str, str]]:
               with path.open("r", encoding="utf-8", newline="") as handle:
@@ -602,23 +659,26 @@ jobs:
               except (TypeError, ValueError):
                   return math.nan
 
+          def write_rows(path: Path, rows: list[dict[str, object]]) -> None:
+              if not rows:
+                  return
+              fieldnames: list[str] = []
+              for row in rows:
+                  for field in row:
+                      if field not in fieldnames:
+                          fieldnames.append(field)
+              with path.open("w", encoding="utf-8", newline="") as handle:
+                  writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+                  writer.writeheader()
+                  writer.writerows(rows)
+
           raw_rows: list[dict[str, str]] = []
-          raw_fieldnames: list[str] = []
-          for path in sorted(raw_files):
+          for path in sorted(file_groups["raw"]):
               rows = read_csv(path)
               for row in rows:
                   row["source_file"] = str(path)
                   raw_rows.append(row)
-              for field in (rows[0].keys() if rows else []):
-                  if field not in raw_fieldnames:
-                      raw_fieldnames.append(field)
-          if raw_rows:
-              if "source_file" not in raw_fieldnames:
-                  raw_fieldnames.append("source_file")
-              with (combined_dir / f"{output_prefix}.csv").open("w", encoding="utf-8", newline="") as handle:
-                  writer = csv.DictWriter(handle, fieldnames=raw_fieldnames, extrasaction="ignore")
-                  writer.writeheader()
-                  writer.writerows(raw_rows)
+          write_rows(combined_dir / f"{output_prefix}.csv", raw_rows)
 
           grouped: dict[tuple[str, str], list[dict[str, str]]] = defaultdict(list)
           for row in raw_rows:
@@ -668,18 +728,104 @@ jobs:
               "n_significant_p_0.05", "n_significant_p_0.01",
           ]
           if summary_rows:
-              with (combined_dir / f"{output_prefix}_summary.csv").open("w", encoding="utf-8", newline="") as handle:
-                  writer = csv.DictWriter(handle, fieldnames=fields)
-                  writer.writeheader()
-                  writer.writerows(summary_rows)
+              write_rows(combined_dir / f"{output_prefix}_summary.csv", summary_rows)
+
+          prediction_rows: list[dict[str, str]] = []
+          for path in sorted(file_groups["predictions"]):
+              rows = read_csv(path)
+              for row in rows:
+                  row["source_file"] = str(path)
+                  prediction_rows.append(row)
+          write_rows(combined_dir / f"{output_prefix}_predictions.csv", prediction_rows)
+
+          confusion_counts: dict[tuple[str, str, str, str], int] = defaultdict(int)
+          per_stimulus_counts: dict[tuple[str, str, str], dict[str, object]] = defaultdict(
+              lambda: {"n_trials": 0, "n_correct": 0, "participants": set()}
+          )
+          for row in prediction_rows:
+              confusion_counts[
+                  (
+                      row.get("variant", ""),
+                      row.get("window_center_s", ""),
+                      row.get("true_stimulus", ""),
+                      row.get("predicted_stimulus", ""),
+                  )
+              ] += 1
+              key = (row.get("variant", ""), row.get("window_center_s", ""), row.get("true_stimulus", ""))
+              per_stimulus_counts[key]["n_trials"] += 1
+              per_stimulus_counts[key]["n_correct"] += int(str(row.get("correct", "")).lower() == "true")
+              per_stimulus_counts[key]["participants"].add(row.get("participant", ""))
+
+          combined_confusion = [
+              {
+                  "variant": variant,
+                  "window_center_s": window_center,
+                  "true_stimulus": true_stimulus,
+                  "predicted_stimulus": predicted_stimulus,
+                  "count": count,
+              }
+              for (variant, window_center, true_stimulus, predicted_stimulus), count in sorted(
+                  confusion_counts.items(),
+                  key=lambda item: (item[0][0], to_float(item[0][1]), to_float(item[0][2]), to_float(item[0][3])),
+              )
+          ]
+          write_rows(combined_dir / f"{output_prefix}_confusion.csv", combined_confusion)
+
+          combined_per_stimulus = []
+          for (variant, window_center, true_stimulus), values in sorted(
+              per_stimulus_counts.items(),
+              key=lambda item: (item[0][0], to_float(item[0][1]), to_float(item[0][2])),
+          ):
+              n_trials = int(values["n_trials"])
+              n_correct = int(values["n_correct"])
+              accuracy = n_correct / n_trials if n_trials else math.nan
+              combined_per_stimulus.append(
+                  {
+                      "variant": variant,
+                      "window_center_s": window_center,
+                      "true_stimulus": true_stimulus,
+                      "n_participants": len(values["participants"]),
+                      "n_trials": n_trials,
+                      "n_correct": n_correct,
+                      "accuracy": accuracy,
+                      "percent": 100.0 * accuracy if math.isfinite(accuracy) else math.nan,
+                  }
+              )
+          write_rows(combined_dir / f"{output_prefix}_per_stimulus.csv", combined_per_stimulus)
+
+          peak_groups: dict[tuple[str, str], list[dict[str, str]]] = defaultdict(list)
+          for row in raw_rows:
+              peak_groups[(row.get("variant", ""), row.get("participant", ""))].append(row)
+          participant_peaks = []
+          for (variant, participant), rows in sorted(peak_groups.items(), key=lambda item: (item[0][0], to_float(item[0][1]))):
+              peak = max(rows, key=lambda row: (to_float(row.get("accuracy")), -abs(to_float(row.get("window_center_s")))))
+              participant_peaks.append(
+                  {
+                      "participant": participant,
+                      "variant": variant,
+                      "peak_window_center_s": peak.get("window_center_s", ""),
+                      "peak_window_start_s": peak.get("window_start_s", ""),
+                      "peak_window_stop_s": peak.get("window_stop_s", ""),
+                      "peak_accuracy": peak.get("accuracy", ""),
+                      "peak_percent": peak.get("percent", ""),
+                      "chance_accuracy": peak.get("chance_accuracy", ""),
+                      "chance_percent": peak.get("chance_percent", ""),
+                  }
+              )
+          write_rows(combined_dir / f"{output_prefix}_participant_peaks.csv", participant_peaks)
 
           report = [
               "# Combined stimulus decoding outputs",
               "",
-              f"- Raw shard CSV files found: `{len(raw_files)}`",
-              f"- Shard summary CSV files found: `{len(summary_files)}`",
+              f"- Raw shard CSV files found: `{len(file_groups['raw'])}`",
+              f"- Shard summary CSV files found: `{len(file_groups['summary'])}`",
+              f"- Prediction CSV files found: `{len(file_groups['predictions'])}`",
               f"- Combined participant/window rows: `{len(raw_rows)}`",
               f"- Combined summary rows: `{len(summary_rows)}`",
+              f"- Combined prediction rows: `{len(prediction_rows)}`",
+              f"- Combined confusion rows: `{len(combined_confusion)}`",
+              f"- Combined per-stimulus rows: `{len(combined_per_stimulus)}`",
+              f"- Combined participant peak rows: `{len(participant_peaks)}`",
           ]
           (combined_dir / "README.md").write_text("\n".join(report) + "\n", encoding="utf-8")
           print("\n".join(report))

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ step). Summary CSV adds `n_significant_p_0.05` and `n_significant_p_0.01` and
 python analyze_stimulus_decoding.py --participants 2 --time-window=-0.2,0.6 --window-step-s 0.05 --permutations 200 --permutation-seed 42 --output outputs\part2_stimulus_decoding.csv --summary-output outputs\part2_stimulus_decoding_summary.csv --plots-dir outputs\part2_stimulus_decoding_plots
 ```
 
+Peak-window diagnostics can be exported for selected windows. These write
+trial-level predictions, confusion counts, per-stimulus accuracy, and
+participant-level peak timing/accuracy.
+
+```powershell
+python analyze_stimulus_decoding.py --participants 2 --time-window=-0.2,0.6 --window-step-s 0.05 --diagnostic-window-centers 0.15,0.2,0.25 --predictions-output outputs\part2_stimulus_predictions.csv --confusion-output outputs\part2_stimulus_confusion.csv --per-stimulus-output outputs\part2_stimulus_per_stimulus.csv --participant-peaks-output outputs\part2_stimulus_participant_peaks.csv --output outputs\part2_stimulus_decoding.csv --summary-output outputs\part2_stimulus_decoding_summary.csv --plots-dir outputs\part2_stimulus_decoding_plots
+```
+
 The summary CSV and plot aggregate the curve across participants.
 
 ## Tests

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -32,8 +32,11 @@ from pymegdec.reaction_time_analysis import (
 )
 from pymegdec.stimulus_decoding import (
     StimulusDecodingConfig,
+    evaluate_participant_stimulus_decoding_diagnostics,
     evaluate_time_resolved_stimulus_transfer,
     export_time_resolved_stimulus_decoding,
+    summarize_stimulus_decoding_peaks,
+    summarize_stimulus_prediction_diagnostics,
     summarize_stimulus_decoding,
 )
 
@@ -54,6 +57,7 @@ __all__ = [
     "compute_alpha_movement",
     "compute_alpha_metrics",
     "cross_validate_single_dataset",
+    "evaluate_participant_stimulus_decoding_diagnostics",
     "evaluate_model_transfer",
     "evaluate_time_resolved_stimulus_transfer",
     "export_alpha_movement",
@@ -66,5 +70,7 @@ __all__ = [
     "join_alpha_reaction_times",
     "resolve_data_folder",
     "summarize_stimulus_decoding",
+    "summarize_stimulus_decoding_peaks",
+    "summarize_stimulus_prediction_diagnostics",
     "summarize_alpha_movement_effects",
 ]

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -182,6 +182,26 @@ def _build_stimulus_decoding_parser(
         help="Optional output CSV summarized across participants by time window.",
     )
     parser.add_argument(
+        "--predictions-output",
+        default=None,
+        help="Optional trial-level prediction CSV for selected diagnostic windows.",
+    )
+    parser.add_argument(
+        "--confusion-output",
+        default=None,
+        help="Optional confusion-count CSV for selected diagnostic windows.",
+    )
+    parser.add_argument(
+        "--per-stimulus-output",
+        default=None,
+        help="Optional per-stimulus accuracy CSV for selected diagnostic windows.",
+    )
+    parser.add_argument(
+        "--participant-peaks-output",
+        default=None,
+        help="Optional CSV with each participant's peak decoding window.",
+    )
+    parser.add_argument(
         "--plots-dir",
         default=None,
         help="Optional directory for group-level stimulus decoding plots.",
@@ -197,6 +217,12 @@ def _build_stimulus_decoding_parser(
         type=_parse_float_list,
         default=None,
         help=("Explicit comma-separated window centers in seconds. Overrides " "--time-window."),
+    )
+    parser.add_argument(
+        "--diagnostic-window-centers",
+        type=_parse_float_list,
+        default=None,
+        help="Comma-separated window centers for trial prediction diagnostics.",
     )
     parser.add_argument(
         "--window-step-s",
@@ -305,6 +331,15 @@ def stimulus_decoding(argv: Sequence[str] | None = None, prog: str | None = None
     window_centers = args.window_centers
     if window_centers is None:
         window_centers = window_centers_from_range(args.time_window, args.window_step_s)
+    diagnostic_requested = any(
+        (
+            args.predictions_output,
+            args.confusion_output,
+            args.per_stimulus_output,
+        )
+    )
+    if diagnostic_requested and not args.diagnostic_window_centers:
+        parser.error("--diagnostic-window-centers is required for prediction, confusion, or per-stimulus outputs.")
 
     config = StimulusDecodingConfig(
         window_centers=window_centers,
@@ -325,6 +360,11 @@ def stimulus_decoding(argv: Sequence[str] | None = None, prog: str | None = None
         participants,
         args.output,
         summary_output_path=args.summary_output,
+        predictions_output_path=args.predictions_output,
+        confusion_output_path=args.confusion_output,
+        per_stimulus_output_path=args.per_stimulus_output,
+        participant_peaks_output_path=args.participant_peaks_output,
+        diagnostic_window_centers=args.diagnostic_window_centers,
         plots_dir=args.plots_dir,
         config=config,
         progress=print,
@@ -332,6 +372,10 @@ def stimulus_decoding(argv: Sequence[str] | None = None, prog: str | None = None
     print(f"Wrote {len(rows)} participant/window rows to {args.output}")
     if args.summary_output:
         print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+    if args.participant_peaks_output:
+        print(f"Wrote participant peaks to {args.participant_peaks_output}")
+    if args.diagnostic_window_centers:
+        print(f"Wrote diagnostics for windows {args.diagnostic_window_centers}")
     if args.plots_dir:
         print(f"Wrote plots to {args.plots_dir}")
     return 0

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -99,6 +99,39 @@ def evaluate_participant_time_resolved_stimulus_transfer(
 ):
     """Evaluate one participant's stimulus transfer accuracy across window centers."""
 
+    rows, _ = _evaluate_participant_time_resolved_stimulus_transfer(
+        data_folder,
+        participant,
+        config=config,
+        diagnostic_window_centers=(),
+    )
+    return rows
+
+
+def evaluate_participant_stimulus_decoding_diagnostics(
+    data_folder,
+    participant,
+    *,
+    config=None,
+    diagnostic_window_centers=None,
+):
+    """Evaluate one participant and return accuracy rows plus prediction diagnostics."""
+
+    return _evaluate_participant_time_resolved_stimulus_transfer(
+        data_folder,
+        participant,
+        config=config,
+        diagnostic_window_centers=diagnostic_window_centers,
+    )
+
+
+def _evaluate_participant_time_resolved_stimulus_transfer(
+    data_folder,
+    participant,
+    *,
+    config=None,
+    diagnostic_window_centers=None,
+):
     config = config or StimulusDecodingConfig()
     classifier_param = config.classifier_param
     if should_use_default_classifier_param(classifier_param):
@@ -120,10 +153,13 @@ def evaluate_participant_time_resolved_stimulus_transfer(
     train_data = _prepare_data(train_data, config)
     validation_data = _prepare_data(validation_data, config)
     permutation_rng = np.random.default_rng(config.permutation_seed)
+    diagnostic_centers = _window_center_set(diagnostic_window_centers or ())
 
     rows = []
+    prediction_rows = []
     for window_center in config.window_centers:
-        rows.append(
+        include_predictions = _window_center_key(window_center) in diagnostic_centers
+        result = (
             _evaluate_window(
                 train_data,
                 validation_data,
@@ -134,9 +170,16 @@ def evaluate_participant_time_resolved_stimulus_transfer(
                 classifier_param,
                 config,
                 permutation_rng=permutation_rng,
+                include_predictions=include_predictions,
             )
         )
-    return rows
+        if include_predictions:
+            row, window_prediction_rows = result
+            rows.append(row)
+            prediction_rows.extend(window_prediction_rows)
+        else:
+            rows.append(result)
+    return rows, prediction_rows
 
 
 def summarize_stimulus_decoding(rows):
@@ -181,6 +224,87 @@ def summarize_stimulus_decoding(rows):
     return summary_rows
 
 
+def summarize_stimulus_decoding_peaks(rows):
+    """Return the best decoding window per participant and variant."""
+
+    grouped = defaultdict(list)
+    for row in rows:
+        grouped[(row["variant"], row["participant"])].append(row)
+
+    peak_rows = []
+    for (variant, participant), group_rows in sorted(grouped.items(), key=lambda item: (item[0][0], _to_float(item[0][1]))):
+        peak = max(group_rows, key=lambda row: (_to_float(row["accuracy"]), -abs(_to_float(row["window_center_s"]))))
+        peak_rows.append(
+            {
+                "participant": participant,
+                "variant": variant,
+                "peak_window_center_s": peak["window_center_s"],
+                "peak_window_start_s": peak["window_start_s"],
+                "peak_window_stop_s": peak["window_stop_s"],
+                "peak_accuracy": peak["accuracy"],
+                "peak_percent": peak["percent"],
+                "chance_accuracy": peak["chance_accuracy"],
+                "chance_percent": peak["chance_percent"],
+            }
+        )
+    return peak_rows
+
+
+def summarize_stimulus_prediction_diagnostics(prediction_rows):
+    """Summarize trial-level prediction diagnostics."""
+
+    confusion = defaultdict(int)
+    per_stimulus = defaultdict(lambda: {"n_trials": 0, "n_correct": 0, "participants": set()})
+    for row in prediction_rows:
+        confusion[
+            (
+                row["variant"],
+                row["window_center_s"],
+                row["true_stimulus"],
+                row["predicted_stimulus"],
+            )
+        ] += 1
+        key = (row["variant"], row["window_center_s"], row["true_stimulus"])
+        per_stimulus[key]["n_trials"] += 1
+        per_stimulus[key]["n_correct"] += int(bool(row["correct"]))
+        per_stimulus[key]["participants"].add(row["participant"])
+
+    confusion_rows = [
+        {
+            "variant": variant,
+            "window_center_s": window_center,
+            "true_stimulus": true_stimulus,
+            "predicted_stimulus": predicted_stimulus,
+            "count": count,
+        }
+        for (variant, window_center, true_stimulus, predicted_stimulus), count in sorted(
+            confusion.items(),
+            key=lambda item: (item[0][0], _to_float(item[0][1]), int(item[0][2]), int(item[0][3])),
+        )
+    ]
+    per_stimulus_rows = []
+    for (variant, window_center, true_stimulus), values in sorted(
+        per_stimulus.items(),
+        key=lambda item: (item[0][0], _to_float(item[0][1]), int(item[0][2])),
+    ):
+        n_trials = values["n_trials"]
+        n_correct = values["n_correct"]
+        accuracy = n_correct / n_trials if n_trials else np.nan
+        per_stimulus_rows.append(
+            {
+                "variant": variant,
+                "window_center_s": window_center,
+                "true_stimulus": true_stimulus,
+                "n_participants": len(values["participants"]),
+                "n_trials": n_trials,
+                "n_correct": n_correct,
+                "accuracy": accuracy,
+                "percent": 100.0 * accuracy,
+            }
+        )
+    return confusion_rows, per_stimulus_rows
+
+
 def write_stimulus_decoding_plots(summary_rows, output_dir):
     """Write group-level stimulus decoding plots."""
 
@@ -195,6 +319,11 @@ def export_time_resolved_stimulus_decoding(
     output_path,
     *,
     summary_output_path=None,
+    predictions_output_path=None,
+    confusion_output_path=None,
+    per_stimulus_output_path=None,
+    participant_peaks_output_path=None,
+    diagnostic_window_centers=None,
     plots_dir=None,
     config=None,
     progress=None,
@@ -202,16 +331,36 @@ def export_time_resolved_stimulus_decoding(
     """Run time-resolved stimulus decoding and write CSV/plot artifacts."""
 
     config = config or StimulusDecodingConfig()
-    rows = evaluate_time_resolved_stimulus_transfer(
-        data_folder,
-        participants,
-        config=config,
-        progress=progress,
-    )
+    data_folder = resolve_data_folder(data_folder)
+    rows = []
+    prediction_rows = []
+    for participant in participants:
+        if progress is not None:
+            progress(f"START participant={participant}")
+        participant_rows, participant_prediction_rows = _evaluate_participant_time_resolved_stimulus_transfer(
+            data_folder,
+            participant,
+            config=config,
+            diagnostic_window_centers=diagnostic_window_centers,
+        )
+        rows.extend(participant_rows)
+        prediction_rows.extend(participant_prediction_rows)
+        if progress is not None:
+            progress(f"DONE participant={participant}")
     write_alpha_metrics_csv(rows, output_path)
     summary_rows = summarize_stimulus_decoding(rows)
     if summary_output_path:
         write_alpha_metrics_csv(summary_rows, summary_output_path)
+    if participant_peaks_output_path:
+        write_alpha_metrics_csv(summarize_stimulus_decoding_peaks(rows), participant_peaks_output_path)
+    if predictions_output_path and prediction_rows:
+        write_alpha_metrics_csv(prediction_rows, predictions_output_path)
+    if (confusion_output_path or per_stimulus_output_path) and prediction_rows:
+        confusion_rows, per_stimulus_rows = summarize_stimulus_prediction_diagnostics(prediction_rows)
+        if confusion_output_path:
+            write_alpha_metrics_csv(confusion_rows, confusion_output_path)
+        if per_stimulus_output_path:
+            write_alpha_metrics_csv(per_stimulus_rows, per_stimulus_output_path)
     if plots_dir:
         write_stimulus_decoding_plots(summary_rows, plots_dir)
     return rows, summary_rows
@@ -247,6 +396,7 @@ def _evaluate_window(
     classifier_param,
     config,
     permutation_rng=None,
+    include_predictions=False,
 ):
     train_window = _centered_window(window_center, config.window_size)
     null_window = _null_window(config)
@@ -294,7 +444,7 @@ def _evaluate_window(
     variant = "without_null" if np.isnan(config.null_window_center) else "with_null"
     null_prediction_rate = float(np.mean(predictions == 0)) if variant == "with_null" else np.nan
 
-    return {
+    row = {
         "participant": participant,
         "variant": variant,
         "window_center_s": window_center,
@@ -325,6 +475,54 @@ def _evaluate_window(
         "frequency_high_hz": config.frequency_range[1],
     }
 
+    if include_predictions:
+        return row, _stimulus_prediction_rows(
+            participant,
+            variant,
+            window_center,
+            labels_validation,
+            predictions,
+            config,
+        )
+    return row
+
+
+def _stimulus_prediction_rows(
+    participant,
+    variant,
+    window_center,
+    labels_validation,
+    predictions,
+    config,
+):
+    rows = []
+    for trial_idx, (true_label, predicted_label) in enumerate(zip(labels_validation, predictions)):
+        true_stimulus = _display_stimulus_label(true_label, variant)
+        predicted_stimulus = _display_stimulus_label(predicted_label, variant)
+        rows.append(
+            {
+                "participant": participant,
+                "variant": variant,
+                "window_center_s": window_center,
+                "trial": trial_idx,
+                "true_label": int(true_label),
+                "predicted_label": int(predicted_label),
+                "true_stimulus": true_stimulus,
+                "predicted_stimulus": predicted_stimulus,
+                "correct": bool(predicted_label == true_label),
+                "classifier": config.classifier,
+                "components_pca": config.components_pca,
+            }
+        )
+    return rows
+
+
+def _display_stimulus_label(label, variant):
+    label = int(label)
+    if variant == "without_null":
+        return label + 1
+    return label
+
 
 def _centered_window(center, size):
     return center - size / 2, center + size / 2
@@ -340,6 +538,14 @@ def _actual_pca_components(components_pca, features):
     if components_pca == float("inf"):
         return features.shape[1]
     return min(int(components_pca), features.shape[0], features.shape[1])
+
+
+def _window_center_key(value):
+    return float(np.round(float(value), 10))
+
+
+def _window_center_set(values):
+    return {_window_center_key(value) for value in values}
 
 
 def _to_float(value):

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.io as sio
+
 from pymegdec.alpha_metrics import write_alpha_metrics_csv
 from pymegdec.classifiers import (
     get_default_classifier_param,
@@ -159,19 +160,17 @@ def _evaluate_participant_time_resolved_stimulus_transfer(
     prediction_rows = []
     for window_center in config.window_centers:
         include_predictions = _window_center_key(window_center) in diagnostic_centers
-        result = (
-            _evaluate_window(
-                train_data,
-                validation_data,
-                labels_train,
-                labels_validation,
-                participant,
-                float(window_center),
-                classifier_param,
-                config,
-                permutation_rng=permutation_rng,
-                include_predictions=include_predictions,
-            )
+        result = _evaluate_window(
+            train_data,
+            validation_data,
+            labels_train,
+            labels_validation,
+            participant,
+            float(window_center),
+            classifier_param,
+            config,
+            permutation_rng=permutation_rng,
+            include_predictions=include_predictions,
         )
         if include_predictions:
             row, window_prediction_rows = result
@@ -253,8 +252,10 @@ def summarize_stimulus_decoding_peaks(rows):
 def summarize_stimulus_prediction_diagnostics(prediction_rows):
     """Summarize trial-level prediction diagnostics."""
 
-    confusion = defaultdict(int)
-    per_stimulus = defaultdict(lambda: {"n_trials": 0, "n_correct": 0, "participants": set()})
+    confusion: dict[tuple[object, object, object, object], int] = defaultdict(int)
+    per_stimulus_trials: dict[tuple[object, object, object], int] = defaultdict(int)
+    per_stimulus_correct: dict[tuple[object, object, object], int] = defaultdict(int)
+    per_stimulus_participants: dict[tuple[object, object, object], set[object]] = defaultdict(set)
     for row in prediction_rows:
         confusion[
             (
@@ -265,9 +266,9 @@ def summarize_stimulus_prediction_diagnostics(prediction_rows):
             )
         ] += 1
         key = (row["variant"], row["window_center_s"], row["true_stimulus"])
-        per_stimulus[key]["n_trials"] += 1
-        per_stimulus[key]["n_correct"] += int(bool(row["correct"]))
-        per_stimulus[key]["participants"].add(row["participant"])
+        per_stimulus_trials[key] += 1
+        per_stimulus_correct[key] += int(bool(row["correct"]))
+        per_stimulus_participants[key].add(row["participant"])
 
     confusion_rows = [
         {
@@ -279,23 +280,24 @@ def summarize_stimulus_prediction_diagnostics(prediction_rows):
         }
         for (variant, window_center, true_stimulus, predicted_stimulus), count in sorted(
             confusion.items(),
-            key=lambda item: (item[0][0], _to_float(item[0][1]), int(item[0][2]), int(item[0][3])),
+            key=lambda item: (item[0][0], _to_float(item[0][1]), _to_float(item[0][2]), _to_float(item[0][3])),
         )
     ]
     per_stimulus_rows = []
-    for (variant, window_center, true_stimulus), values in sorted(
-        per_stimulus.items(),
-        key=lambda item: (item[0][0], _to_float(item[0][1]), int(item[0][2])),
+    for variant, window_center, true_stimulus in sorted(
+        per_stimulus_trials,
+        key=lambda item: (item[0], _to_float(item[1]), _to_float(item[2])),
     ):
-        n_trials = values["n_trials"]
-        n_correct = values["n_correct"]
+        key = (variant, window_center, true_stimulus)
+        n_trials = per_stimulus_trials[key]
+        n_correct = per_stimulus_correct[key]
         accuracy = n_correct / n_trials if n_trials else np.nan
         per_stimulus_rows.append(
             {
                 "variant": variant,
                 "window_center_s": window_center,
                 "true_stimulus": true_stimulus,
-                "n_participants": len(values["participants"]),
+                "n_participants": len(per_stimulus_participants[key]),
                 "n_trials": n_trials,
                 "n_correct": n_correct,
                 "accuracy": accuracy,
@@ -313,6 +315,7 @@ def write_stimulus_decoding_plots(summary_rows, output_dir):
     _plot_group_accuracy(summary_rows, output_dir / "stimulus_decoding_accuracy.png")
 
 
+# pylint: disable-next=too-many-arguments,too-many-positional-arguments
 def export_time_resolved_stimulus_decoding(
     data_folder,
     participants,
@@ -386,6 +389,7 @@ def _prepare_data(data, config):
     return data
 
 
+# pylint: disable-next=too-many-arguments,too-many-positional-arguments,too-many-locals
 def _evaluate_window(
     train_data,
     validation_data,

--- a/tests/test_stimulus_decoding.py
+++ b/tests/test_stimulus_decoding.py
@@ -2,12 +2,13 @@ import unittest
 from unittest.mock import patch
 
 import numpy as np
+
 from pymegdec.stimulus_decoding import (
     StimulusDecodingConfig,
     evaluate_participant_stimulus_decoding_diagnostics,
     evaluate_participant_time_resolved_stimulus_transfer,
-    summarize_stimulus_decoding_peaks,
     summarize_stimulus_decoding,
+    summarize_stimulus_decoding_peaks,
     summarize_stimulus_prediction_diagnostics,
     window_centers_from_range,
 )

--- a/tests/test_stimulus_decoding.py
+++ b/tests/test_stimulus_decoding.py
@@ -4,8 +4,11 @@ from unittest.mock import patch
 import numpy as np
 from pymegdec.stimulus_decoding import (
     StimulusDecodingConfig,
+    evaluate_participant_stimulus_decoding_diagnostics,
     evaluate_participant_time_resolved_stimulus_transfer,
+    summarize_stimulus_decoding_peaks,
     summarize_stimulus_decoding,
+    summarize_stimulus_prediction_diagnostics,
     window_centers_from_range,
 )
 from tests.matlab_fixtures import cell_array
@@ -52,6 +55,37 @@ class TestStimulusDecoding(unittest.TestCase):
         self.assertEqual(rows[0]["variant"], "without_null")
         self.assertEqual(rows[0]["accuracy"], 1.0)
         self.assertEqual(rows[0]["chance_accuracy"], 0.5)
+
+    def test_evaluate_participant_stimulus_decoding_diagnostics(self):
+        labels = [1, 2, 1, 2]
+        train_data = _mat_data(labels, [-2.0, 2.0, -1.0, 1.0], [-0.1, 0.0])
+        validation_data = _mat_data(labels, [-1.5, 1.5, -0.5, 0.5], [-0.1, 0.0])
+        config = StimulusDecodingConfig(
+            window_centers=(0.0, 0.1),
+            window_size=0.0,
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch(
+            "pymegdec.stimulus_decoding.sio.loadmat",
+            side_effect=[
+                {"data": np.array([train_data], dtype=object)},
+                {"data": np.array([validation_data], dtype=object)},
+            ],
+        ):
+            rows, prediction_rows = evaluate_participant_stimulus_decoding_diagnostics(
+                "unused",
+                1,
+                config=config,
+                diagnostic_window_centers=(0.0,),
+            )
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(len(prediction_rows), 4)
+        self.assertEqual({row["window_center_s"] for row in prediction_rows}, {0.0})
+        self.assertEqual([row["true_stimulus"] for row in prediction_rows], labels)
+        self.assertTrue(all(row["correct"] for row in prediction_rows))
 
     def test_evaluate_participant_time_resolved_stimulus_transfer_with_permutations(
         self,
@@ -121,6 +155,66 @@ class TestStimulusDecoding(unittest.TestCase):
         self.assertEqual(summary[0]["n_with_permutation"], 2)
         self.assertEqual(summary[0]["n_significant_p_0.05"], 2)
         self.assertEqual(summary[0]["n_significant_p_0.01"], 1)
+
+    def test_summarize_stimulus_decoding_peaks(self):
+        rows = [
+            {
+                "participant": 1,
+                "variant": "without_null",
+                "window_center_s": 0.1,
+                "window_start_s": 0.05,
+                "window_stop_s": 0.15,
+                "accuracy": 0.2,
+                "percent": 20.0,
+                "chance_accuracy": 0.0625,
+                "chance_percent": 6.25,
+            },
+            {
+                "participant": 1,
+                "variant": "without_null",
+                "window_center_s": 0.2,
+                "window_start_s": 0.15,
+                "window_stop_s": 0.25,
+                "accuracy": 0.3,
+                "percent": 30.0,
+                "chance_accuracy": 0.0625,
+                "chance_percent": 6.25,
+            },
+        ]
+
+        peaks = summarize_stimulus_decoding_peaks(rows)
+
+        self.assertEqual(len(peaks), 1)
+        self.assertEqual(peaks[0]["peak_window_center_s"], 0.2)
+        self.assertEqual(peaks[0]["peak_accuracy"], 0.3)
+
+    def test_summarize_stimulus_prediction_diagnostics(self):
+        prediction_rows = [
+            {
+                "participant": 1,
+                "variant": "without_null",
+                "window_center_s": 0.2,
+                "true_stimulus": 1,
+                "predicted_stimulus": 1,
+                "correct": True,
+            },
+            {
+                "participant": 1,
+                "variant": "without_null",
+                "window_center_s": 0.2,
+                "true_stimulus": 1,
+                "predicted_stimulus": 2,
+                "correct": False,
+            },
+        ]
+
+        confusion, per_stimulus = summarize_stimulus_prediction_diagnostics(prediction_rows)
+
+        self.assertEqual(len(confusion), 2)
+        self.assertEqual(per_stimulus[0]["true_stimulus"], 1)
+        self.assertEqual(per_stimulus[0]["n_trials"], 2)
+        self.assertEqual(per_stimulus[0]["n_correct"], 1)
+        self.assertEqual(per_stimulus[0]["accuracy"], 0.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add selected-window prediction diagnostics for stimulus decoding.
- Export trial-level predictions, confusion counts, per-stimulus accuracy, and participant peak windows.
- Add CLI outputs for diagnostics and participant peaks.
- Update the manual stimulus-decoding workflow to pass diagnostic windows and aggregate diagnostic artifacts separately.
- Add focused unit tests for diagnostics summaries.

## Validation
- PYTHONPATH=src python -m unittest tests.test_stimulus_decoding -v
- PYTHONPATH=src python -m ruff check src/pymegdec/stimulus_decoding.py src/pymegdec/cli.py tests/test_stimulus_decoding.py
- Parsed .github/workflows/stimulus-decoding.yml with PyYAML