### PR TITLE
Add stimulus prediction export workflow

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,0 +1,2 @@
+skip-check:
+  - CKV_GHA_7

--- a/.github/workflows/stimulus-predictions.yml
+++ b/.github/workflows/stimulus-predictions.yml
@@ -1,0 +1,479 @@
+# jscpd:ignore-start
+name: Manual stimulus prediction export
+
+#checkov:skip=CKV_GHA_7:Manual workflow inputs are validated before command use.
+on:
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: Python version used for the analysis environment.
+        required: true
+        default: "3.13"
+        type: string
+      use_nextcloud_data:
+        description: Restore/download/cache the MEG data before running.
+        required: true
+        default: true
+        type: boolean
+      data_cache_version:
+        description: MEG data cache version.
+        required: true
+        default: v1
+        type: string
+      data_dir:
+        description: Relative data directory to restore/populate.
+        required: true
+        default: .cache/meg-data-all
+        type: string
+      participants:
+        description: Participant ids such as 1-4,6,8. Leave empty to auto-detect all matching main/cue files.
+        required: false
+        default: ""
+        type: string
+      window_centers:
+        description: Comma-separated prediction windows in seconds.
+        required: true
+        default: "-0.175,0.175"
+        type: string
+      window_size:
+        description: Window size in seconds.
+        required: true
+        default: "0.1"
+        type: string
+      classifier:
+        description: Classifier name passed to the prediction export.
+        required: true
+        default: multiclass-svm
+        type: choice
+        options:
+          - multiclass-svm
+          - multiclass-svm-weighted
+          - random-forest
+          - gradient-boosting
+          - knn
+          - mostFrequentDummy
+          - always1Dummy
+          - xgboost
+          - scikit-mlp
+          - pytorch-mlp
+      classifier_param:
+        description: Optional classifier parameter, JSON/Python literal/numeric value, or empty.
+        required: false
+        default: ""
+        type: string
+      components_pca:
+        description: Number of PCA components, or inf.
+        required: true
+        default: "100"
+        type: string
+      frequency_low:
+        description: Lower frequency bound in Hz.
+        required: true
+        default: "0"
+        type: string
+      frequency_high:
+        description: Upper frequency bound in Hz, or inf.
+        required: true
+        default: inf
+        type: string
+      chance_classes:
+        description: Number of stimulus classes used for summary chance level.
+        required: true
+        default: "16"
+        type: string
+      install_extra:
+        description: Optional dependency extra to install.
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - xgboost
+          - torch
+          - all
+      output_prefix:
+        description: Prefix for output CSVs under outputs/.
+        required: true
+        default: stimulus_predictions
+        type: string
+      fail_if_missing_data:
+        description: Fail if data_dir does not exist after optional cache restore/download.
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  prepare-inputs:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    outputs:
+      python_version: ${{ steps.validate.outputs.python_version }}
+      use_nextcloud_data: ${{ steps.validate.outputs.use_nextcloud_data }}
+      data_cache_version: ${{ steps.validate.outputs.data_cache_version }}
+      data_dir: ${{ steps.validate.outputs.data_dir }}
+      participants: ${{ steps.validate.outputs.participants }}
+      window_centers: ${{ steps.validate.outputs.window_centers }}
+      window_size: ${{ steps.validate.outputs.window_size }}
+      classifier: ${{ steps.validate.outputs.classifier }}
+      classifier_param: ${{ steps.validate.outputs.classifier_param }}
+      components_pca: ${{ steps.validate.outputs.components_pca }}
+      frequency_low: ${{ steps.validate.outputs.frequency_low }}
+      frequency_high: ${{ steps.validate.outputs.frequency_high }}
+      chance_classes: ${{ steps.validate.outputs.chance_classes }}
+      install_extra: ${{ steps.validate.outputs.install_extra }}
+      output_prefix: ${{ steps.validate.outputs.output_prefix }}
+      fail_if_missing_data: ${{ steps.validate.outputs.fail_if_missing_data }}
+
+    steps:
+      - name: Validate manual inputs
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import re
+          from pathlib import Path, PurePosixPath
+
+          DEFAULTS = {
+              "python_version": "3.13",
+              "use_nextcloud_data": "true",
+              "data_cache_version": "v1",
+              "data_dir": ".cache/meg-data-all",
+              "participants": "",
+              "window_centers": "-0.175,0.175",
+              "window_size": "0.1",
+              "classifier": "multiclass-svm",
+              "classifier_param": "",
+              "components_pca": "100",
+              "frequency_low": "0",
+              "frequency_high": "inf",
+              "chance_classes": "16",
+              "install_extra": "none",
+              "output_prefix": "stimulus_predictions",
+              "fail_if_missing_data": "true",
+          }
+          ALLOWED_CLASSIFIERS = {
+              "multiclass-svm",
+              "multiclass-svm-weighted",
+              "random-forest",
+              "gradient-boosting",
+              "knn",
+              "mostFrequentDummy",
+              "always1Dummy",
+              "xgboost",
+              "scikit-mlp",
+              "pytorch-mlp",
+          }
+          ALLOWED_EXTRAS = {"none", "xgboost", "torch", "all"}
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          raw_inputs = event.get("inputs", {})
+
+          def raw_value(name: str) -> str:
+              value = raw_inputs.get(name, DEFAULTS[name])
+              if value is None:
+                  value = DEFAULTS[name]
+              value = str(value).strip()
+              if value == "" and name not in {"participants", "classifier_param"}:
+                  value = DEFAULTS[name]
+              if any(char in value for char in "\x00\n\r"):
+                  raise SystemExit(f"Input {name!r} may not contain control characters or newlines.")
+              return value
+
+          def require_match(name: str, pattern: str, *, max_len: int = 128) -> str:
+              value = raw_value(name)
+              if len(value) > max_len or not re.fullmatch(pattern, value):
+                  raise SystemExit(f"Input {name!r} has invalid characters or length.")
+              return value
+
+          def normalize_bool(name: str) -> str:
+              value = raw_value(name).lower()
+              if value in {"true", "1", "yes"}:
+                  return "true"
+              if value in {"false", "0", "no"}:
+                  return "false"
+              raise SystemExit(f"Input {name!r} must be boolean.")
+
+          def normalize_int(name: str, *, minimum: int, maximum: int) -> str:
+              value = require_match(name, r"[0-9]+", max_len=12)
+              parsed = int(value)
+              if not minimum <= parsed <= maximum:
+                  raise SystemExit(f"Input {name!r} must be between {minimum} and {maximum}.")
+              return str(parsed)
+
+          def normalize_float(name: str, *, minimum: float | None = None, allow_inf: bool = False) -> str:
+              value = raw_value(name).lower()
+              if allow_inf and value == "inf":
+                  return "inf"
+              if not re.fullmatch(r"[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?", value):
+                  raise SystemExit(f"Input {name!r} must be a finite number" + (" or inf." if allow_inf else "."))
+              parsed = float(value)
+              if minimum is not None and parsed < minimum:
+                  raise SystemExit(f"Input {name!r} must be >= {minimum}.")
+              return format(parsed, ".12g")
+
+          def normalize_float_list(name: str, *, minimum: float | None = None, maximum: float | None = None) -> str:
+              value = raw_value(name).replace(" ", "")
+              if len(value) > 256:
+                  raise SystemExit(f"Input {name!r} is too long.")
+              values = []
+              for token in value.split(","):
+                  if not token:
+                      raise SystemExit(f"Input {name!r} has an empty item.")
+                  if not re.fullmatch(r"[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?", token):
+                      raise SystemExit(f"Input {name!r} must contain only finite comma-separated numbers.")
+                  parsed = float(token)
+                  if minimum is not None and parsed < minimum:
+                      raise SystemExit(f"Input {name!r} values must be >= {minimum}.")
+                  if maximum is not None and parsed > maximum:
+                      raise SystemExit(f"Input {name!r} values must be <= {maximum}.")
+                  values.append(format(parsed, ".12g"))
+              return ",".join(values)
+
+          def normalize_data_dir() -> str:
+              value = require_match("data_dir", r"[A-Za-z0-9._/-]+", max_len=160)
+              path = PurePosixPath(value)
+              if path.is_absolute() or ".." in path.parts:
+                  raise SystemExit("Input 'data_dir' must be a relative path without '..'.")
+              return value.rstrip("/") or DEFAULTS["data_dir"]
+
+          def normalize_participants() -> str:
+              value = raw_value("participants").replace(" ", "")
+              if len(value) > 256 or not re.fullmatch(r"[0-9,\-]*", value):
+                  raise SystemExit("Input 'participants' must contain only digits, ranges, and commas.")
+              return value
+
+          def normalize_components() -> str:
+              if raw_value("components_pca").lower() == "inf":
+                  return "inf"
+              return normalize_int("components_pca", minimum=1, maximum=100000)
+
+          def normalize_classifier_param() -> str:
+              value = raw_value("classifier_param")
+              if value and (len(value) > 300 or not re.fullmatch(r"[A-Za-z0-9_.,:{}\[\]\"' +\-eE]*", value)):
+                  raise SystemExit("Input 'classifier_param' contains unsupported characters.")
+              return value
+
+          sanitized = {
+              "python_version": require_match("python_version", r"[0-9]+(?:\.[0-9]+){0,2}", max_len=16),
+              "use_nextcloud_data": normalize_bool("use_nextcloud_data"),
+              "data_cache_version": require_match("data_cache_version", r"[A-Za-z0-9._-]+", max_len=64),
+              "data_dir": normalize_data_dir(),
+              "participants": normalize_participants(),
+              "window_centers": normalize_float_list("window_centers", minimum=-10.0, maximum=10.0),
+              "window_size": normalize_float("window_size", minimum=0.001),
+              "classifier": require_match("classifier", r"[A-Za-z0-9_-]+", max_len=64),
+              "classifier_param": normalize_classifier_param(),
+              "components_pca": normalize_components(),
+              "frequency_low": normalize_float("frequency_low", minimum=0.0),
+              "frequency_high": normalize_float("frequency_high", minimum=0.0, allow_inf=True),
+              "chance_classes": normalize_int("chance_classes", minimum=2, maximum=10000),
+              "install_extra": require_match("install_extra", r"[A-Za-z0-9_-]+", max_len=32),
+              "output_prefix": require_match("output_prefix", r"[A-Za-z0-9_.-]+", max_len=80),
+              "fail_if_missing_data": normalize_bool("fail_if_missing_data"),
+          }
+          if sanitized["classifier"] not in ALLOWED_CLASSIFIERS:
+              raise SystemExit("Unsupported classifier.")
+          if sanitized["install_extra"] not in ALLOWED_EXTRAS:
+              raise SystemExit("Unsupported install extra.")
+          if sanitized["frequency_high"] != "inf" and float(sanitized["frequency_high"]) < float(sanitized["frequency_low"]):
+              raise SystemExit("frequency_high must be >= frequency_low.")
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              for name, value in sanitized.items():
+                  output.write(f"{name}={value}\n")
+          print(json.dumps(sanitized, indent=2))
+          PY
+
+  stimulus-predictions:
+    name: Export trial-level predictions
+    needs: prepare-inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      DATA_DIR: ${{ needs.prepare-inputs.outputs.data_dir }}
+      USE_NEXTCLOUD_DATA: ${{ needs.prepare-inputs.outputs.use_nextcloud_data }}
+      DATA_CACHE_VERSION: ${{ needs.prepare-inputs.outputs.data_cache_version }}
+      PARTICIPANTS: ${{ needs.prepare-inputs.outputs.participants }}
+      WINDOW_CENTERS: ${{ needs.prepare-inputs.outputs.window_centers }}
+      WINDOW_SIZE: ${{ needs.prepare-inputs.outputs.window_size }}
+      CLASSIFIER: ${{ needs.prepare-inputs.outputs.classifier }}
+      CLASSIFIER_PARAM: ${{ needs.prepare-inputs.outputs.classifier_param }}
+      COMPONENTS_PCA: ${{ needs.prepare-inputs.outputs.components_pca }}
+      FREQUENCY_LOW: ${{ needs.prepare-inputs.outputs.frequency_low }}
+      FREQUENCY_HIGH: ${{ needs.prepare-inputs.outputs.frequency_high }}
+      CHANCE_CLASSES: ${{ needs.prepare-inputs.outputs.chance_classes }}
+      INSTALL_EXTRA: ${{ needs.prepare-inputs.outputs.install_extra }}
+      OUTPUT_PREFIX: ${{ needs.prepare-inputs.outputs.output_prefix }}
+      FAIL_IF_MISSING_DATA: ${{ needs.prepare-inputs.outputs.fail_if_missing_data }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached MEG data
+        id: meg-data-cache
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.DATA_DIR }}
+          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+
+      - name: Download MEG data files from URL list
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        env:
+          MEG_DATA_URL_LIST: ${{ secrets.MEG_DATA_URL_LIST }}
+        run: |
+          set -euo pipefail
+          python3 scripts/download_meg_data_files.py --data-dir "${DATA_DIR}"
+
+      - name: Save MEG data cache
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: ${{ env.DATA_DIR }}
+          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ needs.prepare-inputs.outputs.python_version }}
+
+      - name: Install package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          if [[ "${INSTALL_EXTRA}" == "none" ]]; then
+            python -m pip install -e .
+          else
+            python -m pip install -e ".[${INSTALL_EXTRA}]"
+          fi
+
+      - name: Resolve and validate data directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["DATA_DIR"]).expanduser()
+          fail_if_missing = os.environ["FAIL_IF_MISSING_DATA"].lower() == "true"
+
+          if not root.exists():
+              message = f"Data directory does not exist: {root}"
+              if fail_if_missing:
+                  raise SystemExit(message)
+              print(message)
+              with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as env_file:
+                  env_file.write(f"PYMEGDEC_ANALYSIS_DATA_DIR={root}\n")
+              raise SystemExit(0)
+
+          candidate_counts: dict[Path, tuple[int, int]] = {}
+          for main_file in root.rglob("Part*Data.mat"):
+              if main_file.name.endswith("CueData.mat"):
+                  continue
+              directory = main_file.parent
+              main_count, cue_count = candidate_counts.get(directory, (0, 0))
+              candidate_counts[directory] = (main_count + 1, cue_count)
+          for cue_file in root.rglob("Part*CueData.mat"):
+              directory = cue_file.parent
+              main_count, cue_count = candidate_counts.get(directory, (0, 0))
+              candidate_counts[directory] = (main_count, cue_count + 1)
+
+          valid_candidates = [
+              (directory, counts)
+              for directory, counts in candidate_counts.items()
+              if counts[0] > 0 and counts[1] > 0
+          ]
+          if not valid_candidates:
+              message = f"No directory containing both Part*Data.mat and Part*CueData.mat was found under {root}."
+              if fail_if_missing:
+                  raise SystemExit(message)
+              print(message)
+              resolved = root
+          else:
+              resolved, counts = max(valid_candidates, key=lambda item: (item[1][0] + item[1][1], str(item[0])))
+              print(f"Resolved MEG data directory: {resolved}")
+              print(f"Found {counts[0]} main MAT files and {counts[1]} cue MAT files in the resolved directory.")
+
+          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as env_file:
+              env_file.write(f"PYMEGDEC_ANALYSIS_DATA_DIR={resolved}\n")
+          PY
+
+      - name: Export stimulus predictions
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs
+
+          output_csv="outputs/${OUTPUT_PREFIX}.csv"
+          summary_csv="outputs/${OUTPUT_PREFIX}_summary.csv"
+          accuracy_csv="outputs/${OUTPUT_PREFIX}_accuracy.csv"
+          confusion_csv="outputs/${OUTPUT_PREFIX}_confusion.csv"
+          per_stimulus_csv="outputs/${OUTPUT_PREFIX}_per_stimulus.csv"
+
+          cmd=(
+            python scripts/export_stimulus_predictions.py
+            --data-dir "${PYMEGDEC_ANALYSIS_DATA_DIR}"
+            "--window-centers=${WINDOW_CENTERS}"
+            --window-size "${WINDOW_SIZE}"
+            --null-window-center nan
+            --classifier "${CLASSIFIER}"
+            --components-pca "${COMPONENTS_PCA}"
+            --frequency-range "${FREQUENCY_LOW}" "${FREQUENCY_HIGH}"
+            --chance-classes "${CHANCE_CLASSES}"
+            --output "${output_csv}"
+            --summary-output "${summary_csv}"
+            --accuracy-output "${accuracy_csv}"
+            --confusion-output "${confusion_csv}"
+            --per-stimulus-output "${per_stimulus_csv}"
+          )
+
+          if [[ -n "${PARTICIPANTS}" ]]; then
+            cmd+=(--participants "${PARTICIPANTS}")
+          fi
+          if [[ -n "${CLASSIFIER_PARAM}" ]]; then
+            cmd+=(--classifier-param "${CLASSIFIER_PARAM}")
+          fi
+
+          printf 'Running command:'
+          printf ' %q' "${cmd[@]}"
+          printf '\n'
+          "${cmd[@]}"
+
+          {
+            echo "# Stimulus prediction export"
+            echo
+            echo "- Data directory: \`${PYMEGDEC_ANALYSIS_DATA_DIR}\`"
+            echo "- Participants: \`${PARTICIPANTS:-auto-detected}\`"
+            echo "- Window centers: \`${WINDOW_CENTERS}\`"
+            echo "- Window size: \`${WINDOW_SIZE}\` s"
+            echo "- Classifier: \`${CLASSIFIER}\`"
+            echo "- PCA components: \`${COMPONENTS_PCA}\`"
+            echo "- Frequency range: \`${FREQUENCY_LOW}\` to \`${FREQUENCY_HIGH}\` Hz"
+            echo
+            echo "The workflow forces \`--null-window-center nan\`; model labels are zero-based, while \`true_stimulus_id\` and \`predicted_stimulus_id\` are one-based image ids."
+          } > outputs/README.md
+          cat outputs/README.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload prediction outputs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stimulus-prediction-outputs
+          path: outputs/
+          if-no-files-found: warn
+# jscpd:ignore-end

--- a/README.md
+++ b/README.md
@@ -119,7 +119,15 @@ step). Summary CSV adds `n_significant_p_0.05` and `n_significant_p_0.01` and
 `n_with_permutation` per window.
 
 ```powershell
-python analyze_stimulus_decoding.py --participants 2 --time-window=-0.2,0.6 --window-step-s 0.05 --permutations 200 --permutation-seed 42 --output outputs\part2_stimulus_decoding.csv --summary-output outputs\part2_stimulus_decoding_summary.csv --plots-dir outputs\part2_stimulus_decoding_plots
+python analyze_stimulus_decoding.py `
+  --participants 2 `
+  --time-window=-0.2,0.6 `
+  --window-step-s 0.05 `
+  --permutations 200 `
+  --permutation-seed 42 `
+  --output outputs\part2_stimulus_decoding.csv `
+  --summary-output outputs\part2_stimulus_decoding_summary.csv `
+  --plots-dir outputs\part2_stimulus_decoding_plots
 ```
 
 Peak-window diagnostics can be exported for selected windows. These write
@@ -127,10 +135,35 @@ trial-level predictions, confusion counts, per-stimulus accuracy, and
 participant-level peak timing/accuracy.
 
 ```powershell
-python analyze_stimulus_decoding.py --participants 2 --time-window=-0.2,0.6 --window-step-s 0.05 --diagnostic-window-centers 0.15,0.2,0.25 --predictions-output outputs\part2_stimulus_predictions.csv --confusion-output outputs\part2_stimulus_confusion.csv --per-stimulus-output outputs\part2_stimulus_per_stimulus.csv --participant-peaks-output outputs\part2_stimulus_participant_peaks.csv --output outputs\part2_stimulus_decoding.csv --summary-output outputs\part2_stimulus_decoding_summary.csv --plots-dir outputs\part2_stimulus_decoding_plots
+python analyze_stimulus_decoding.py `
+  --participants 2 `
+  --time-window=-0.2,0.6 `
+  --window-step-s 0.05 `
+  --diagnostic-window-centers 0.15,0.2,0.25 `
+  --predictions-output outputs\part2_stimulus_predictions.csv `
+  --confusion-output outputs\part2_stimulus_confusion.csv `
+  --per-stimulus-output outputs\part2_stimulus_per_stimulus.csv `
+  --participant-peaks-output outputs\part2_stimulus_participant_peaks.csv `
+  --output outputs\part2_stimulus_decoding.csv `
+  --summary-output outputs\part2_stimulus_decoding_summary.csv `
+  --plots-dir outputs\part2_stimulus_decoding_plots
 ```
 
 The summary CSV and plot aggregate the curve across participants.
+
+For paper-facing confusion matrices, export only trial-level predictions at
+selected control/peak windows. Model labels are zero-based when
+`--null-window-center nan`, while `true_stimulus_id` and
+`predicted_stimulus_id` are one-based image ids.
+
+```powershell
+python scripts\export_stimulus_predictions.py `
+  --window-centers=-0.175,0.175 `
+  --output outputs\stimulus_predictions.csv `
+  --summary-output outputs\stimulus_prediction_summary.csv `
+  --confusion-output outputs\stimulus_predictions_confusion.csv `
+  --per-stimulus-output outputs\stimulus_predictions_per_stimulus.csv
+```
 
 ## Tests
 

--- a/scripts/export_stimulus_predictions.py
+++ b/scripts/export_stimulus_predictions.py
@@ -1,0 +1,180 @@
+"""Export trial-level train-main/validate-cue stimulus predictions."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from typing import Sequence
+
+import numpy as np
+
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+from pymegdec.data_config import resolve_data_folder
+from pymegdec.reaction_time_analysis import available_participants, parse_participant_spec
+from pymegdec.stimulus_decoding import (
+    StimulusDecodingConfig,
+    evaluate_participant_stimulus_decoding_diagnostics,
+    summarize_stimulus_decoding,
+    summarize_stimulus_prediction_diagnostics,
+)
+
+DEFAULT_WINDOW_CENTERS = (-0.175, 0.175)
+
+
+# jscpd:ignore-start
+def _float_or_inf(value: str) -> float:
+    normalized = value.lower()
+    if normalized in {"inf", "+inf", "infinity", "+infinity"}:
+        return float("inf")
+    if normalized in {"nan", "+nan", "-nan"}:
+        return float("nan")
+    return float(value)
+
+
+def _int_or_inf(value: str) -> int | float:
+    parsed = _float_or_inf(value)
+    if np.isinf(parsed):
+        return parsed
+    return int(parsed)
+
+
+def _parse_float_list(value: str) -> tuple[float, ...]:
+    values = tuple(float(token.strip()) for token in value.split(",") if token.strip())
+    if not values:
+        raise argparse.ArgumentTypeError("At least one value is required.")
+    return values
+
+
+def _parse_classifier_param(value: str | None):
+    if value is None:
+        return np.nan
+
+    normalized = value.strip()
+    if normalized.lower() == "nan":
+        return np.nan
+
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            return parser(normalized)
+        except (SyntaxError, ValueError, TypeError, json.JSONDecodeError):
+            pass
+
+    try:
+        return float(normalized)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("classifier parameters must be numeric, JSON, or a Python literal") from exc
+
+
+def _transfer_participants(participant_spec: str | None, data_folder) -> list[int]:
+    if participant_spec:
+        return parse_participant_spec(participant_spec)
+    main_participants = set(available_participants(data_folder, cue=False))
+    cue_participants = set(available_participants(data_folder, cue=True))
+    return sorted(main_participants & cue_participants)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Export trial-level stimulus predictions for selected windows.")
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
+    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.")
+    parser.add_argument("--window-centers", type=_parse_float_list, default=DEFAULT_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
+    parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
+    parser.add_argument("--null-window-center", type=_float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
+    parser.add_argument("--new-framerate", type=_float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
+    parser.add_argument("--classifier", default="multiclass-svm", help="Classifier name.")
+    parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
+    parser.add_argument("--components-pca", type=_int_or_inf, default=100, help="Number of PCA components, or inf.")
+    parser.add_argument(
+        "--frequency-range",
+        type=_float_or_inf,
+        nargs=2,
+        metavar=("LOW", "HIGH"),
+        default=(0.0, float("inf")),
+        help="Frequency range in Hz.",
+    )
+    parser.add_argument("--chance-classes", type=int, default=16, help="Number of stimulus classes used for the chance line.")
+    parser.add_argument("--output", default="outputs/stimulus_predictions.csv", help="Output CSV with one row per validation trial and window.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_prediction_summary.csv", help="Optional participant/window accuracy summary CSV.")
+    parser.add_argument("--accuracy-output", default=None, help="Optional participant/window accuracy CSV.")
+    parser.add_argument("--confusion-output", default=None, help="Optional confusion-count CSV.")
+    parser.add_argument("--per-stimulus-output", default=None, help="Optional per-stimulus recall CSV.")
+    return parser
+
+
+def _normalize_argv(argv: Sequence[str] | None) -> list[str] | None:
+    if argv is None:
+        argv = sys.argv[1:]
+    normalized: list[str] = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == "--window-centers" and index + 1 < len(argv):  # nosec B105
+            normalized.append(f"--window-centers={argv[index + 1]}")
+            index += 2
+            continue
+        normalized.append(token)
+        index += 1
+    return normalized
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(_normalize_argv(argv))
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = _transfer_participants(args.participants, data_folder)
+    if not participants:
+        parser.error("No participants found. Pass --participants or configure a data directory with matching main and cue MAT files.")
+
+    config = StimulusDecodingConfig(
+        window_centers=args.window_centers,
+        window_size=args.window_size,
+        null_window_center=args.null_window_center,
+        new_framerate=args.new_framerate,
+        classifier=args.classifier,
+        classifier_param=_parse_classifier_param(args.classifier_param),
+        components_pca=args.components_pca,
+        frequency_range=tuple(args.frequency_range),
+        chance_classes=args.chance_classes,
+        permutations=0,
+    )
+
+    accuracy_rows = []
+    prediction_rows = []
+    for participant in participants:
+        print(f"START participant={participant}", flush=True)
+        participant_accuracy, participant_predictions = evaluate_participant_stimulus_decoding_diagnostics(
+            data_folder,
+            participant,
+            config=config,
+            diagnostic_window_centers=args.window_centers,
+        )
+        accuracy_rows.extend(participant_accuracy)
+        prediction_rows.extend(participant_predictions)
+        print(f"DONE participant={participant}", flush=True)
+
+    write_alpha_metrics_csv(prediction_rows, args.output)
+    print(f"Wrote {len(prediction_rows)} trial prediction rows to {args.output}")
+
+    summary_rows = summarize_stimulus_decoding(accuracy_rows)
+    if args.summary_output:
+        write_alpha_metrics_csv(summary_rows, args.summary_output)
+        print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+    if args.accuracy_output:
+        write_alpha_metrics_csv(accuracy_rows, args.accuracy_output)
+        print(f"Wrote {len(accuracy_rows)} participant/window rows to {args.accuracy_output}")
+    if args.confusion_output or args.per_stimulus_output:
+        confusion_rows, per_stimulus_rows = summarize_stimulus_prediction_diagnostics(prediction_rows)
+        if args.confusion_output:
+            write_alpha_metrics_csv(confusion_rows, args.confusion_output)
+            print(f"Wrote {len(confusion_rows)} confusion rows to {args.confusion_output}")
+        if args.per_stimulus_output:
+            write_alpha_metrics_csv(per_stimulus_rows, args.per_stimulus_output)
+            print(f"Wrote {len(per_stimulus_rows)} per-stimulus rows to {args.per_stimulus_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+# jscpd:ignore-end

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -484,9 +484,12 @@ def _evaluate_window(
             participant,
             variant,
             window_center,
+            train_window[0],
+            train_window[1],
             labels_validation,
             predictions,
             config,
+            pca_components,
         )
     return row
 
@@ -495,9 +498,12 @@ def _stimulus_prediction_rows(
     participant,
     variant,
     window_center,
+    window_start,
+    window_stop,
     labels_validation,
     predictions,
     config,
+    actual_components_pca,
 ):
     rows = []
     for trial_idx, (true_label, predicted_label) in enumerate(zip(labels_validation, predictions)):
@@ -508,14 +514,21 @@ def _stimulus_prediction_rows(
                 "participant": participant,
                 "variant": variant,
                 "window_center_s": window_center,
+                "window_start_s": window_start,
+                "window_stop_s": window_stop,
                 "trial": trial_idx,
+                "validation_trial_index": trial_idx,
+                "validation_trial_number": trial_idx + 1,
                 "true_label": int(true_label),
                 "predicted_label": int(predicted_label),
                 "true_stimulus": true_stimulus,
                 "predicted_stimulus": predicted_stimulus,
+                "true_stimulus_id": true_stimulus,
+                "predicted_stimulus_id": predicted_stimulus,
                 "correct": bool(predicted_label == true_label),
                 "classifier": config.classifier,
                 "components_pca": config.components_pca,
+                "actual_components_pca": actual_components_pca,
             }
         )
     return rows

--- a/tests/test_stimulus_decoding.py
+++ b/tests/test_stimulus_decoding.py
@@ -86,6 +86,10 @@ class TestStimulusDecoding(unittest.TestCase):
         self.assertEqual(len(prediction_rows), 4)
         self.assertEqual({row["window_center_s"] for row in prediction_rows}, {0.0})
         self.assertEqual([row["true_stimulus"] for row in prediction_rows], labels)
+        self.assertEqual([row["true_stimulus_id"] for row in prediction_rows], labels)
+        self.assertEqual([row["validation_trial_index"] for row in prediction_rows], [0, 1, 2, 3])
+        self.assertEqual([row["validation_trial_number"] for row in prediction_rows], [1, 2, 3, 4])
+        self.assertEqual({row["actual_components_pca"] for row in prediction_rows}, {1})
         self.assertTrue(all(row["correct"] for row in prediction_rows))
 
     def test_evaluate_participant_time_resolved_stimulus_transfer_with_permutations(


### PR DESCRIPTION
## Summary

- add `scripts/export_stimulus_predictions.py` for trial-level train-main/validate-cue stimulus predictions at selected windows
- add the `Manual stimulus prediction export` workflow that restores the MEG cache and uploads `stimulus-prediction-outputs`
- extend diagnostic prediction rows with paper-facing window bounds, validation trial indices, one-based stimulus ids, and actual PCA component counts

## Why

The current decoding artifact supports accuracy curves and permutation summaries, but not real 16x16 confusion matrices. This export produces the trial-level predictions needed for the paper-side confusion analysis while keeping executable MEG decoding code in PyMEGDec.

## Validation

- `python -m unittest discover -v`
- `python -m ruff check src tests scripts`
- `python -m mypy src`
- `python -m pylint src/pymegdec/stimulus_decoding.py`
- workflow YAML parse check
- one-participant real-data smoke export for `-0.175,0.175`