### PR TITLE
Add stimulus robustness controls

### DIFF
--- a/.github/workflows/stimulus-decoding.yml
+++ b/.github/workflows/stimulus-decoding.yml
@@ -53,6 +53,14 @@ on:
         required: true
         default: "0.1"
         type: string
+      transfer_direction:
+        description: Train/validation dataset direction.
+        required: true
+        default: main-to-cue
+        type: choice
+        options:
+          - main-to-cue
+          - cue-to-main
       classifier:
         description: Classifier name passed to pymegdec-stimulus-decoding.
         required: true
@@ -152,6 +160,7 @@ jobs:
       window_step_s: ${{ steps.validate.outputs.window_step_s }}
       diagnostic_window_centers: ${{ steps.validate.outputs.diagnostic_window_centers }}
       window_size: ${{ steps.validate.outputs.window_size }}
+      transfer_direction: ${{ steps.validate.outputs.transfer_direction }}
       classifier: ${{ steps.validate.outputs.classifier }}
       classifier_param: ${{ steps.validate.outputs.classifier_param }}
       components_pca: ${{ steps.validate.outputs.components_pca }}
@@ -191,6 +200,7 @@ jobs:
               "window_step_s": "0.025",
               "diagnostic_window_centers": "0.15,0.2,0.25",
               "window_size": "0.1",
+              "transfer_direction": "main-to-cue",
               "classifier": "multiclass-svm",
               "classifier_param": "",
               "components_pca": "100",
@@ -217,6 +227,7 @@ jobs:
               "pytorch-mlp",
           }
           ALLOWED_EXTRAS = {"none", "xgboost", "torch", "all"}
+          ALLOWED_TRANSFER_DIRECTIONS = {"main-to-cue", "cue-to-main"}
 
           event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
           raw_inputs = event.get("inputs", {})
@@ -333,6 +344,7 @@ jobs:
               "window_step_s": normalize_float("window_step_s", minimum=0.001),
               "diagnostic_window_centers": normalize_float_list("diagnostic_window_centers", minimum=-10.0, maximum=10.0),
               "window_size": normalize_float("window_size", minimum=0.001),
+              "transfer_direction": require_match("transfer_direction", r"[A-Za-z0-9_-]+", max_len=32),
               "classifier": require_match("classifier", r"[A-Za-z0-9_-]+", max_len=64),
               "classifier_param": normalize_classifier_param(),
               "components_pca": normalize_components(),
@@ -348,6 +360,8 @@ jobs:
           }
           if sanitized["classifier"] not in ALLOWED_CLASSIFIERS:
               raise SystemExit("Unsupported classifier.")
+          if sanitized["transfer_direction"] not in ALLOWED_TRANSFER_DIRECTIONS:
+              raise SystemExit("Unsupported transfer direction.")
           if sanitized["install_extra"] not in ALLOWED_EXTRAS:
               raise SystemExit("Unsupported install extra.")
           if sanitized["frequency_high"] != "inf" and float(sanitized["frequency_high"]) < float(sanitized["frequency_low"]):
@@ -393,6 +407,7 @@ jobs:
       WINDOW_STEP_S: ${{ needs.prepare-inputs.outputs.window_step_s }}
       DIAGNOSTIC_WINDOW_CENTERS: ${{ needs.prepare-inputs.outputs.diagnostic_window_centers }}
       WINDOW_SIZE: ${{ needs.prepare-inputs.outputs.window_size }}
+      TRANSFER_DIRECTION: ${{ needs.prepare-inputs.outputs.transfer_direction }}
       CLASSIFIER: ${{ needs.prepare-inputs.outputs.classifier }}
       CLASSIFIER_PARAM: ${{ needs.prepare-inputs.outputs.classifier_param }}
       COMPONENTS_PCA: ${{ needs.prepare-inputs.outputs.components_pca }}
@@ -532,6 +547,7 @@ jobs:
             --window-step-s "${WINDOW_STEP_S}"
             --window-size "${WINDOW_SIZE}"
             --null-window-center nan
+            --transfer-direction "${TRANSFER_DIRECTION}"
             --classifier "${CLASSIFIER}"
             --components-pca "${COMPONENTS_PCA}"
             --frequency-range "${FREQUENCY_LOW}" "${FREQUENCY_HIGH}"

--- a/.github/workflows/stimulus-predictions.yml
+++ b/.github/workflows/stimulus-predictions.yml
@@ -40,6 +40,14 @@ on:
         required: true
         default: "0.1"
         type: string
+      transfer_direction:
+        description: Train/validation dataset direction.
+        required: true
+        default: main-to-cue
+        type: choice
+        options:
+          - main-to-cue
+          - cue-to-main
       classifier:
         description: Classifier name passed to the prediction export.
         required: true
@@ -117,6 +125,7 @@ jobs:
       participants: ${{ steps.validate.outputs.participants }}
       window_centers: ${{ steps.validate.outputs.window_centers }}
       window_size: ${{ steps.validate.outputs.window_size }}
+      transfer_direction: ${{ steps.validate.outputs.transfer_direction }}
       classifier: ${{ steps.validate.outputs.classifier }}
       classifier_param: ${{ steps.validate.outputs.classifier_param }}
       components_pca: ${{ steps.validate.outputs.components_pca }}
@@ -149,6 +158,7 @@ jobs:
               "participants": "",
               "window_centers": "-0.175,0.175",
               "window_size": "0.1",
+              "transfer_direction": "main-to-cue",
               "classifier": "multiclass-svm",
               "classifier_param": "",
               "components_pca": "100",
@@ -172,6 +182,7 @@ jobs:
               "pytorch-mlp",
           }
           ALLOWED_EXTRAS = {"none", "xgboost", "torch", "all"}
+          ALLOWED_TRANSFER_DIRECTIONS = {"main-to-cue", "cue-to-main"}
 
           event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
           raw_inputs = event.get("inputs", {})
@@ -269,6 +280,7 @@ jobs:
               "participants": normalize_participants(),
               "window_centers": normalize_float_list("window_centers", minimum=-10.0, maximum=10.0),
               "window_size": normalize_float("window_size", minimum=0.001),
+              "transfer_direction": require_match("transfer_direction", r"[A-Za-z0-9_-]+", max_len=32),
               "classifier": require_match("classifier", r"[A-Za-z0-9_-]+", max_len=64),
               "classifier_param": normalize_classifier_param(),
               "components_pca": normalize_components(),
@@ -281,6 +293,8 @@ jobs:
           }
           if sanitized["classifier"] not in ALLOWED_CLASSIFIERS:
               raise SystemExit("Unsupported classifier.")
+          if sanitized["transfer_direction"] not in ALLOWED_TRANSFER_DIRECTIONS:
+              raise SystemExit("Unsupported transfer direction.")
           if sanitized["install_extra"] not in ALLOWED_EXTRAS:
               raise SystemExit("Unsupported install extra.")
           if sanitized["frequency_high"] != "inf" and float(sanitized["frequency_high"]) < float(sanitized["frequency_low"]):
@@ -304,6 +318,7 @@ jobs:
       PARTICIPANTS: ${{ needs.prepare-inputs.outputs.participants }}
       WINDOW_CENTERS: ${{ needs.prepare-inputs.outputs.window_centers }}
       WINDOW_SIZE: ${{ needs.prepare-inputs.outputs.window_size }}
+      TRANSFER_DIRECTION: ${{ needs.prepare-inputs.outputs.transfer_direction }}
       CLASSIFIER: ${{ needs.prepare-inputs.outputs.classifier }}
       CLASSIFIER_PARAM: ${{ needs.prepare-inputs.outputs.classifier_param }}
       COMPONENTS_PCA: ${{ needs.prepare-inputs.outputs.components_pca }}
@@ -431,6 +446,7 @@ jobs:
             "--window-centers=${WINDOW_CENTERS}"
             --window-size "${WINDOW_SIZE}"
             --null-window-center nan
+            --transfer-direction "${TRANSFER_DIRECTION}"
             --classifier "${CLASSIFIER}"
             --components-pca "${COMPONENTS_PCA}"
             --frequency-range "${FREQUENCY_LOW}" "${FREQUENCY_HIGH}"
@@ -461,6 +477,7 @@ jobs:
             echo "- Participants: \`${PARTICIPANTS:-auto-detected}\`"
             echo "- Window centers: \`${WINDOW_CENTERS}\`"
             echo "- Window size: \`${WINDOW_SIZE}\` s"
+            echo "- Transfer direction: \`${TRANSFER_DIRECTION}\`"
             echo "- Classifier: \`${CLASSIFIER}\`"
             echo "- PCA components: \`${COMPONENTS_PCA}\`"
             echo "- Frequency range: \`${FREQUENCY_LOW}\` to \`${FREQUENCY_HIGH}\` Hz"

--- a/.github/workflows/stimulus-robustness.yml
+++ b/.github/workflows/stimulus-robustness.yml
@@ -1,0 +1,104 @@
+name: Manual stimulus robustness export
+
+#checkov:skip=CKV_GHA_7:Manual workflow inputs are constrained to analysis parameters and used only after shell quoting.
+on:
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: Python version used for the analysis environment.
+        required: true
+        default: "3.13"
+        type: string
+      data_cache_version:
+        description: MEG data cache version.
+        required: true
+        default: v1
+        type: string
+      data_dir:
+        description: Relative data directory to restore.
+        required: true
+        default: .cache/meg-data-all
+        type: string
+      participants:
+        description: Participant ids for the robustness export.
+        required: true
+        default: "1-4,6,8,9,10,13-27"
+        type: string
+      output_prefix:
+        description: Prefix for output CSVs under outputs/.
+        required: true
+        default: stimulus_robustness
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  export-robustness:
+    name: Export robustness controls
+    runs-on: ubuntu-latest
+    env:
+      DATA_DIR: ${{ inputs.data_dir }}
+      PARTICIPANTS: ${{ inputs.participants }}
+      OUTPUT_PREFIX: ${{ inputs.output_prefix }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached MEG data
+        id: meg-data-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ inputs.data_dir }}
+          key: meg-data-all-${{ runner.os }}-${{ inputs.data_cache_version }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install package
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Validate restored data
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.meg-data-cache.outputs.cache-hit }}" != "true" ]]; then
+            echo "MEG cache miss for ${DATA_DIR}" >&2
+            exit 1
+          fi
+          if [[ ! -d "${DATA_DIR}" ]]; then
+            echo "Data directory does not exist: ${DATA_DIR}" >&2
+            exit 1
+          fi
+          main_count=$(find "${DATA_DIR}" -maxdepth 1 -type f -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l)
+          cue_count=$(find "${DATA_DIR}" -maxdepth 1 -type f -name 'Part*CueData.mat' | wc -l)
+          echo "Found ${main_count} main MAT files and ${cue_count} cue MAT files."
+          test "${main_count}" -gt 0
+          test "${cue_count}" -gt 0
+
+      - name: Export stimulus robustness controls
+        run: |
+          set -euo pipefail
+          mkdir -p outputs
+          python scripts/export_stimulus_robustness.py \
+            --data-dir "${DATA_DIR}" \
+            --participants "${PARTICIPANTS}" \
+            --predictions-output "outputs/${OUTPUT_PREFIX}_predictions.csv" \
+            --accuracy-output "outputs/${OUTPUT_PREFIX}_accuracy.csv" \
+            --summary-output "outputs/${OUTPUT_PREFIX}_summary.csv"
+
+      - name: Upload robustness outputs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stimulus-robustness-outputs
+          path: |
+            outputs/${{ inputs.output_prefix }}_predictions.csv
+            outputs/${{ inputs.output_prefix }}_accuracy.csv
+            outputs/${{ inputs.output_prefix }}_summary.csv
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ cv_accuracy = cross_validate_single_dataset(None, 2, classifier="multiclass-svm"
 Stimulus decoding can be evaluated over a sequence of windows around stimulus
 onset. The command trains on `Part*Data.mat`, validates on `Part*CueData.mat`,
 and reports 16-way stimulus accuracy for each participant and window center.
+Pass `--transfer-direction cue-to-main` to swap the direction and train on cue
+data while validating on the main experiment data.
 By default it uses no null class, because the cue validation files do not
 contain null trials and the clean question is which of the 16 stimuli was shown.
 
@@ -163,6 +165,16 @@ python scripts\export_stimulus_predictions.py `
   --summary-output outputs\stimulus_prediction_summary.csv `
   --confusion-output outputs\stimulus_predictions_confusion.csv `
   --per-stimulus-output outputs\stimulus_predictions_per_stimulus.csv
+```
+
+For controls-first robustness checks, export the default two-window result plus
+reverse transfer, class-balanced SVM, PCA sensitivity, and 0-30 Hz controls:
+
+```powershell
+python scripts\export_stimulus_robustness.py `
+  --predictions-output outputs\stimulus_robustness_predictions.csv `
+  --accuracy-output outputs\stimulus_robustness_accuracy.csv `
+  --summary-output outputs\stimulus_robustness_summary.csv
 ```
 
 ## Tests

--- a/scripts/export_stimulus_predictions.py
+++ b/scripts/export_stimulus_predictions.py
@@ -15,6 +15,7 @@ from pymegdec.data_config import resolve_data_folder
 from pymegdec.reaction_time_analysis import available_participants, parse_participant_spec
 from pymegdec.stimulus_decoding import (
     StimulusDecodingConfig,
+    TRANSFER_DIRECTIONS,
     evaluate_participant_stimulus_decoding_diagnostics,
     summarize_stimulus_decoding,
     summarize_stimulus_prediction_diagnostics,
@@ -82,6 +83,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--window-centers", type=_parse_float_list, default=DEFAULT_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
     parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
     parser.add_argument("--null-window-center", type=_float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
+    parser.add_argument("--transfer-direction", choices=TRANSFER_DIRECTIONS, default="main-to-cue", help="Train/validation dataset direction.")
     parser.add_argument("--new-framerate", type=_float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
     parser.add_argument("--classifier", default="multiclass-svm", help="Classifier name.")
     parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
@@ -138,6 +140,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         frequency_range=tuple(args.frequency_range),
         chance_classes=args.chance_classes,
         permutations=0,
+        transfer_direction=args.transfer_direction,
     )
 
     accuracy_rows = []

--- a/scripts/export_stimulus_robustness.py
+++ b/scripts/export_stimulus_robustness.py
@@ -27,20 +27,24 @@ DEFAULT_PARTICIPANTS = "1-4,6,8,9,10,13-27"
 DEFAULT_WINDOW_CENTERS = (-0.175, 0.175)
 
 
+# jscpd:ignore-start
 @dataclass(frozen=True)
 class RobustnessControl:
     name: str
     label: str
-    overrides: dict[str, object]
+    transfer_direction: str | None = None
+    classifier: str | None = None
+    components_pca: int | float | None = None
+    frequency_range: tuple[float, float] | None = None
 
 
 ROBUSTNESS_CONTROLS = (
-    RobustnessControl("default", "Main-to-cue SVM, PCA 100, broadband", {}),
-    RobustnessControl("reverse_transfer", "Cue-to-main SVM, PCA 100, broadband", {"transfer_direction": "cue-to-main"}),
-    RobustnessControl("weighted_svm", "Main-to-cue balanced SVM, PCA 100, broadband", {"classifier": "multiclass-svm-weighted"}),
-    RobustnessControl("pca_50", "Main-to-cue SVM, PCA 50, broadband", {"components_pca": 50}),
-    RobustnessControl("pca_200", "Main-to-cue SVM, PCA 200, broadband", {"components_pca": 200}),
-    RobustnessControl("low_frequency", "Main-to-cue SVM, PCA 100, 0-30 Hz", {"frequency_range": (0.0, 30.0)}),
+    RobustnessControl("default", "Main-to-cue SVM, PCA 100, broadband"),
+    RobustnessControl("reverse_transfer", "Cue-to-main SVM, PCA 100, broadband", transfer_direction="cue-to-main"),
+    RobustnessControl("weighted_svm", "Main-to-cue balanced SVM, PCA 100, broadband", classifier="multiclass-svm-weighted"),
+    RobustnessControl("pca_50", "Main-to-cue SVM, PCA 50, broadband", components_pca=50),
+    RobustnessControl("pca_200", "Main-to-cue SVM, PCA 200, broadband", components_pca=200),
+    RobustnessControl("low_frequency", "Main-to-cue SVM, PCA 100, 0-30 Hz", frequency_range=(0.0, 30.0)),
 )
 
 
@@ -84,7 +88,16 @@ def _annotate(rows, control: RobustnessControl):
 
 
 def _control_config(base_config: StimulusDecodingConfig, control: RobustnessControl) -> StimulusDecodingConfig:
-    return replace(base_config, **control.overrides)
+    config = base_config
+    if control.transfer_direction is not None:
+        config = replace(config, transfer_direction=control.transfer_direction)
+    if control.classifier is not None:
+        config = replace(config, classifier=control.classifier)
+    if control.components_pca is not None:
+        config = replace(config, components_pca=control.components_pca)
+    if control.frequency_range is not None:
+        config = replace(config, frequency_range=control.frequency_range)
+    return config
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -138,3 +151,4 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+# jscpd:ignore-end

--- a/scripts/export_stimulus_robustness.py
+++ b/scripts/export_stimulus_robustness.py
@@ -1,0 +1,140 @@
+"""Export two-window stimulus-decoding robustness controls."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, replace
+from typing import Sequence
+
+from export_stimulus_predictions import (
+    _float_or_inf,
+    _int_or_inf,
+    _normalize_argv,
+    _parse_classifier_param,
+    _parse_float_list,
+    _transfer_participants,
+)
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+from pymegdec.data_config import resolve_data_folder
+from pymegdec.stimulus_decoding import (
+    StimulusDecodingConfig,
+    evaluate_participant_stimulus_decoding_diagnostics,
+    summarize_stimulus_decoding,
+)
+
+DEFAULT_PARTICIPANTS = "1-4,6,8,9,10,13-27"
+DEFAULT_WINDOW_CENTERS = (-0.175, 0.175)
+
+
+@dataclass(frozen=True)
+class RobustnessControl:
+    name: str
+    label: str
+    overrides: dict[str, object]
+
+
+ROBUSTNESS_CONTROLS = (
+    RobustnessControl("default", "Main-to-cue SVM, PCA 100, broadband", {}),
+    RobustnessControl("reverse_transfer", "Cue-to-main SVM, PCA 100, broadband", {"transfer_direction": "cue-to-main"}),
+    RobustnessControl("weighted_svm", "Main-to-cue balanced SVM, PCA 100, broadband", {"classifier": "multiclass-svm-weighted"}),
+    RobustnessControl("pca_50", "Main-to-cue SVM, PCA 50, broadband", {"components_pca": 50}),
+    RobustnessControl("pca_200", "Main-to-cue SVM, PCA 200, broadband", {"components_pca": 200}),
+    RobustnessControl("low_frequency", "Main-to-cue SVM, PCA 100, 0-30 Hz", {"frequency_range": (0.0, 30.0)}),
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Export two-window robustness controls for stimulus decoding.")
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
+    parser.add_argument("--participants", default=DEFAULT_PARTICIPANTS, help="Participant ids such as 1-4,6,8. Defaults to the full current analysis set.")
+    parser.add_argument("--window-centers", type=_parse_float_list, default=DEFAULT_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
+    parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
+    parser.add_argument("--null-window-center", type=_float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
+    parser.add_argument("--new-framerate", type=_float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
+    parser.add_argument("--classifier", default="multiclass-svm", help="Base classifier name.")
+    parser.add_argument("--classifier-param", default=None, help="Base classifier parameter value, JSON, Python literal, numeric value, or nan.")
+    parser.add_argument("--components-pca", type=_int_or_inf, default=100, help="Base number of PCA components, or inf.")
+    parser.add_argument(
+        "--frequency-range",
+        type=_float_or_inf,
+        nargs=2,
+        metavar=("LOW", "HIGH"),
+        default=(0.0, float("inf")),
+        help="Base frequency range in Hz.",
+    )
+    parser.add_argument("--chance-classes", type=int, default=16, help="Number of stimulus classes used for the chance line.")
+    parser.add_argument("--predictions-output", default="outputs/stimulus_robustness_predictions.csv", help="Output CSV with one row per validation trial/window/control.")
+    parser.add_argument("--accuracy-output", default="outputs/stimulus_robustness_accuracy.csv", help="Output CSV with one row per participant/window/control.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_robustness_summary.csv", help="Output CSV summarized across participants by window/control.")
+    return parser
+
+
+def _annotate(rows, control: RobustnessControl):
+    annotated = []
+    for row in rows:
+        annotated.append(
+            {
+                "control": control.name,
+                "control_label": control.label,
+                **row,
+            }
+        )
+    return annotated
+
+
+def _control_config(base_config: StimulusDecodingConfig, control: RobustnessControl) -> StimulusDecodingConfig:
+    return replace(base_config, **control.overrides)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(_normalize_argv(argv))
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = _transfer_participants(args.participants, data_folder)
+    if not participants:
+        parser.error("No participants found. Pass --participants or configure a data directory with matching main and cue MAT files.")
+
+    base_config = StimulusDecodingConfig(
+        window_centers=args.window_centers,
+        window_size=args.window_size,
+        null_window_center=args.null_window_center,
+        new_framerate=args.new_framerate,
+        classifier=args.classifier,
+        classifier_param=_parse_classifier_param(args.classifier_param),
+        components_pca=args.components_pca,
+        frequency_range=tuple(args.frequency_range),
+        chance_classes=args.chance_classes,
+        permutations=0,
+    )
+
+    accuracy_rows = []
+    prediction_rows = []
+    for control in ROBUSTNESS_CONTROLS:
+        config = _control_config(base_config, control)
+        print(f"START control={control.name}", flush=True)
+        for participant in participants:
+            print(f"START control={control.name} participant={participant}", flush=True)
+            participant_accuracy, participant_predictions = evaluate_participant_stimulus_decoding_diagnostics(
+                data_folder,
+                participant,
+                config=config,
+                diagnostic_window_centers=args.window_centers,
+            )
+            accuracy_rows.extend(_annotate(participant_accuracy, control))
+            prediction_rows.extend(_annotate(participant_predictions, control))
+            print(f"DONE control={control.name} participant={participant}", flush=True)
+        print(f"DONE control={control.name}", flush=True)
+
+    write_alpha_metrics_csv(prediction_rows, args.predictions_output)
+    print(f"Wrote {len(prediction_rows)} trial prediction rows to {args.predictions_output}")
+    write_alpha_metrics_csv(accuracy_rows, args.accuracy_output)
+    print(f"Wrote {len(accuracy_rows)} participant/window/control rows to {args.accuracy_output}")
+    summary_rows = summarize_stimulus_decoding(accuracy_rows)
+    write_alpha_metrics_csv(summary_rows, args.summary_output)
+    print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -32,6 +32,7 @@ from pymegdec.reaction_time_analysis import (
 )
 from pymegdec.stimulus_decoding import (
     StimulusDecodingConfig,
+    TRANSFER_DIRECTIONS,
     evaluate_participant_stimulus_decoding_diagnostics,
     evaluate_time_resolved_stimulus_transfer,
     export_time_resolved_stimulus_decoding,
@@ -52,6 +53,7 @@ __all__ = [
     "ReactionTimeCsvConfig",
     "ReactionTimeUnavailableError",
     "StimulusDecodingConfig",
+    "TRANSFER_DIRECTIONS",
     "analyze_alpha_reaction_times",
     "analyze_alpha_movement_windows",
     "compute_alpha_movement",

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -30,6 +30,7 @@ from .stimulus_decoding import (
     DEFAULT_DECODING_TIME_WINDOW,
     DEFAULT_STIMULUS_WINDOW_SIZE,
     StimulusDecodingConfig,
+    TRANSFER_DIRECTIONS,
     export_time_resolved_stimulus_decoding,
     window_centers_from_range,
 )
@@ -243,6 +244,12 @@ def _build_stimulus_decoding_parser(
         help="Center of an optional pre-stimulus null window, or nan.",
     )
     parser.add_argument(
+        "--transfer-direction",
+        choices=TRANSFER_DIRECTIONS,
+        default="main-to-cue",
+        help="Train/validation dataset direction for stimulus transfer.",
+    )
+    parser.add_argument(
         "--new-framerate",
         type=_float_or_inf,
         default=float("inf"),
@@ -353,6 +360,7 @@ def stimulus_decoding(argv: Sequence[str] | None = None, prog: str | None = None
         chance_classes=args.chance_classes,
         permutations=args.permutations,
         permutation_seed=args.permutation_seed,
+        transfer_direction=args.transfer_direction,
     )
 
     rows, summary_rows = export_time_resolved_stimulus_decoding(

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -29,6 +29,18 @@ DEFAULT_DECODING_TIME_WINDOW = (-0.2, 0.6)
 DEFAULT_DECODING_STEP_S = 0.05
 DEFAULT_STIMULUS_WINDOW_SIZE = 0.1
 DEFAULT_CHANCE_CLASSES = 16
+TRANSFER_DIRECTIONS = ("main-to-cue", "cue-to-main")
+SUMMARY_GROUP_FIELDS = (
+    "control",
+    "control_label",
+    "transfer_direction",
+    "variant",
+    "window_center_s",
+    "classifier",
+    "components_pca",
+    "frequency_low_hz",
+    "frequency_high_hz",
+)
 DEFAULT_WINDOW_CENTERS = tuple(
     float(value)
     for value in np.round(
@@ -43,6 +55,7 @@ DEFAULT_WINDOW_CENTERS = tuple(
 
 
 @dataclass(frozen=True)
+# pylint: disable-next=too-many-instance-attributes
 class StimulusDecodingConfig:
     """Parameters for time-resolved stimulus decoding."""
 
@@ -58,6 +71,7 @@ class StimulusDecodingConfig:
     random_state: int | None = None
     permutations: int = 0
     permutation_seed: int | None = None
+    transfer_direction: str = "main-to-cue"
 
 
 def window_centers_from_range(time_window: tuple[float, float], step_s: float) -> tuple[float, ...]:
@@ -138,8 +152,9 @@ def _evaluate_participant_time_resolved_stimulus_transfer(
     if should_use_default_classifier_param(classifier_param):
         classifier_param = get_default_classifier_param(config.classifier)
 
-    train_data = _load_participant_data(data_folder, participant, cue=False)
-    validation_data = _load_participant_data(data_folder, participant, cue=True)
+    train_cue, validation_cue = _transfer_direction_cue_flags(config.transfer_direction)
+    train_data = _load_participant_data(data_folder, participant, cue=train_cue)
+    validation_data = _load_participant_data(data_folder, participant, cue=validation_cue)
     _check_matching_sample_rate(train_data, validation_data)
 
     labels_train = np.asarray(train_data["trialinfo"][0][0], dtype=int).ravel()
@@ -184,13 +199,13 @@ def _evaluate_participant_time_resolved_stimulus_transfer(
 def summarize_stimulus_decoding(rows):
     """Summarize decoding rows across participants for each window center."""
 
+    group_fields = _present_group_fields(rows, SUMMARY_GROUP_FIELDS)
     grouped = defaultdict(list)
     for row in rows:
-        grouped[(row["variant"], row["window_center_s"])].append(row)
+        grouped[tuple(row.get(field, "") for field in group_fields)].append(row)
 
     summary_rows = []
     for key, group_rows in sorted(grouped.items(), key=lambda item: item[0]):
-        variant, window_center = key
         accuracies = [_to_float(row["accuracy"]) for row in group_rows]
         mean, std, sem = _summary_stats(accuracies)
         percentages = [100.0 * value for value in accuracies if np.isfinite(value)]
@@ -200,10 +215,9 @@ def summarize_stimulus_decoding(rows):
         significant_05 = sum(value < 0.05 for value in permutation_p if np.isfinite(value))
         significant_01 = sum(value < 0.01 for value in permutation_p if np.isfinite(value))
         chance_accuracy = _to_float(group_rows[0]["chance_accuracy"])
-        summary_rows.append(
+        summary_row = dict(zip(group_fields, key))
+        summary_row.update(
             {
-                "variant": variant,
-                "window_center_s": window_center,
                 "n_participants": len(group_rows),
                 "accuracy_mean": mean,
                 "accuracy_std": std,
@@ -220,23 +234,24 @@ def summarize_stimulus_decoding(rows):
                 "n_significant_p_0.01": int(significant_01),
             }
         )
+        summary_rows.append(summary_row)
     return summary_rows
 
 
 def summarize_stimulus_decoding_peaks(rows):
     """Return the best decoding window per participant and variant."""
 
+    group_fields = _present_group_fields(rows, ("control", "control_label", "transfer_direction", "variant", "participant"))
     grouped = defaultdict(list)
     for row in rows:
-        grouped[(row["variant"], row["participant"])].append(row)
+        grouped[tuple(row.get(field, "") for field in group_fields)].append(row)
 
     peak_rows = []
-    for (variant, participant), group_rows in sorted(grouped.items(), key=lambda item: (item[0][0], _to_float(item[0][1]))):
+    for key, group_rows in sorted(grouped.items(), key=lambda item: item[0]):
         peak = max(group_rows, key=lambda row: (_to_float(row["accuracy"]), -abs(_to_float(row["window_center_s"]))))
-        peak_rows.append(
+        peak_row = dict(zip(group_fields, key))
+        peak_row.update(
             {
-                "participant": participant,
-                "variant": variant,
                 "peak_window_center_s": peak["window_center_s"],
                 "peak_window_start_s": peak["window_start_s"],
                 "peak_window_stop_s": peak["window_stop_s"],
@@ -246,56 +261,47 @@ def summarize_stimulus_decoding_peaks(rows):
                 "chance_percent": peak["chance_percent"],
             }
         )
+        peak_rows.append(peak_row)
     return peak_rows
 
 
 def summarize_stimulus_prediction_diagnostics(prediction_rows):
     """Summarize trial-level prediction diagnostics."""
 
-    confusion: dict[tuple[object, object, object, object], int] = defaultdict(int)
-    per_stimulus_trials: dict[tuple[object, object, object], int] = defaultdict(int)
-    per_stimulus_correct: dict[tuple[object, object, object], int] = defaultdict(int)
-    per_stimulus_participants: dict[tuple[object, object, object], set[object]] = defaultdict(set)
+    group_fields = _present_group_fields(prediction_rows, ("control", "control_label", "transfer_direction", "variant", "window_center_s"))
+    confusion: dict[tuple[object, ...], int] = defaultdict(int)
+    per_stimulus_trials: dict[tuple[object, ...], int] = defaultdict(int)
+    per_stimulus_correct: dict[tuple[object, ...], int] = defaultdict(int)
+    per_stimulus_participants: dict[tuple[object, ...], set[object]] = defaultdict(set)
     for row in prediction_rows:
-        confusion[
-            (
-                row["variant"],
-                row["window_center_s"],
-                row["true_stimulus"],
-                row["predicted_stimulus"],
-            )
-        ] += 1
-        key = (row["variant"], row["window_center_s"], row["true_stimulus"])
-        per_stimulus_trials[key] += 1
-        per_stimulus_correct[key] += int(bool(row["correct"]))
-        per_stimulus_participants[key].add(row["participant"])
+        base_key = tuple(row.get(field, "") for field in group_fields)
+        confusion[base_key + (row["true_stimulus"], row["predicted_stimulus"])] += 1
+        per_stimulus_key = base_key + (row["true_stimulus"],)
+        per_stimulus_trials[per_stimulus_key] += 1
+        per_stimulus_correct[per_stimulus_key] += int(bool(row["correct"]))
+        per_stimulus_participants[per_stimulus_key].add(row["participant"])
 
-    confusion_rows = [
-        {
-            "variant": variant,
-            "window_center_s": window_center,
-            "true_stimulus": true_stimulus,
-            "predicted_stimulus": predicted_stimulus,
-            "count": count,
-        }
-        for (variant, window_center, true_stimulus, predicted_stimulus), count in sorted(
-            confusion.items(),
-            key=lambda item: (item[0][0], _to_float(item[0][1]), _to_float(item[0][2]), _to_float(item[0][3])),
+    confusion_rows = []
+    for key, count in sorted(confusion.items()):
+        true_stimulus, predicted_stimulus = key[-2:]
+        row = dict(zip(group_fields, key[:-2]))
+        row.update(
+            {
+                "true_stimulus": true_stimulus,
+                "predicted_stimulus": predicted_stimulus,
+                "count": count,
+            }
         )
-    ]
+        confusion_rows.append(row)
     per_stimulus_rows = []
-    for variant, window_center, true_stimulus in sorted(
-        per_stimulus_trials,
-        key=lambda item: (item[0], _to_float(item[1]), _to_float(item[2])),
-    ):
-        key = (variant, window_center, true_stimulus)
+    for key in sorted(per_stimulus_trials):
+        true_stimulus = key[-1]
         n_trials = per_stimulus_trials[key]
         n_correct = per_stimulus_correct[key]
         accuracy = n_correct / n_trials if n_trials else np.nan
-        per_stimulus_rows.append(
+        row = dict(zip(group_fields, key[:-1]))
+        row.update(
             {
-                "variant": variant,
-                "window_center_s": window_center,
                 "true_stimulus": true_stimulus,
                 "n_participants": len(per_stimulus_participants[key]),
                 "n_trials": n_trials,
@@ -304,6 +310,7 @@ def summarize_stimulus_prediction_diagnostics(prediction_rows):
                 "percent": 100.0 * accuracy,
             }
         )
+        per_stimulus_rows.append(row)
     return confusion_rows, per_stimulus_rows
 
 
@@ -373,6 +380,15 @@ def _load_participant_data(data_folder, participant, *, cue):
     suffix = "CueData" if cue else "Data"
     path = Path(data_folder) / f"Part{participant}{suffix}.mat"
     return sio.loadmat(path)["data"][0]
+
+
+def _transfer_direction_cue_flags(transfer_direction):
+    if transfer_direction == "main-to-cue":
+        return False, True
+    if transfer_direction == "cue-to-main":
+        return True, False
+    supported = ", ".join(TRANSFER_DIRECTIONS)
+    raise ValueError(f"Unsupported transfer direction: {transfer_direction}. Supported directions: {supported}")
 
 
 def _check_matching_sample_rate(train_data, validation_data):
@@ -451,6 +467,7 @@ def _evaluate_window(
     row = {
         "participant": participant,
         "variant": variant,
+        "transfer_direction": config.transfer_direction,
         "window_center_s": window_center,
         "window_start_s": train_window[0],
         "window_stop_s": train_window[1],
@@ -513,6 +530,7 @@ def _stimulus_prediction_rows(
             {
                 "participant": participant,
                 "variant": variant,
+                "transfer_direction": config.transfer_direction,
                 "window_center_s": window_center,
                 "window_start_s": window_start,
                 "window_stop_s": window_stop,
@@ -609,6 +627,10 @@ def _summary_stats(values):
         return np.nan, np.nan, np.nan
     std = float(np.std(values, ddof=1)) if values.size > 1 else 0.0
     return float(np.mean(values)), std, float(std / np.sqrt(values.size))
+
+
+def _present_group_fields(rows, fields):
+    return tuple(field for field in fields if any(field in row for row in rows))
 
 
 def _plot_group_accuracy(summary_rows, output_path):

--- a/tests/test_stimulus_decoding.py
+++ b/tests/test_stimulus_decoding.py
@@ -49,13 +49,16 @@ class TestStimulusDecoding(unittest.TestCase):
                 {"data": np.array([train_data], dtype=object)},
                 {"data": np.array([validation_data], dtype=object)},
             ],
-        ):
+        ) as loadmat:
             rows = evaluate_participant_time_resolved_stimulus_transfer("unused", 1, config=config)
 
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["variant"], "without_null")
+        self.assertEqual(rows[0]["transfer_direction"], "main-to-cue")
         self.assertEqual(rows[0]["accuracy"], 1.0)
         self.assertEqual(rows[0]["chance_accuracy"], 0.5)
+        self.assertTrue(str(loadmat.call_args_list[0].args[0]).endswith("Part1Data.mat"))
+        self.assertTrue(str(loadmat.call_args_list[1].args[0]).endswith("Part1CueData.mat"))
 
     def test_evaluate_participant_stimulus_decoding_diagnostics(self):
         labels = [1, 2, 1, 2]
@@ -87,9 +90,43 @@ class TestStimulusDecoding(unittest.TestCase):
         self.assertEqual({row["window_center_s"] for row in prediction_rows}, {0.0})
         self.assertEqual([row["true_stimulus"] for row in prediction_rows], labels)
         self.assertEqual([row["true_stimulus_id"] for row in prediction_rows], labels)
+        self.assertEqual({row["transfer_direction"] for row in prediction_rows}, {"main-to-cue"})
         self.assertEqual([row["validation_trial_index"] for row in prediction_rows], [0, 1, 2, 3])
         self.assertEqual([row["validation_trial_number"] for row in prediction_rows], [1, 2, 3, 4])
         self.assertEqual({row["actual_components_pca"] for row in prediction_rows}, {1})
+        self.assertTrue(all(row["correct"] for row in prediction_rows))
+
+    def test_cue_to_main_transfer_swaps_train_and_validation_files(self):
+        labels = [1, 2, 1, 2]
+        cue_train_data = _mat_data(labels, [-2.0, 2.0, -1.0, 1.0], [-0.1, 0.0])
+        main_validation_data = _mat_data(labels, [-1.5, 1.5, -0.5, 0.5], [-0.1, 0.0])
+        config = StimulusDecodingConfig(
+            window_centers=(0.0,),
+            window_size=0.0,
+            components_pca=float("inf"),
+            chance_classes=2,
+            transfer_direction="cue-to-main",
+        )
+
+        with patch(
+            "pymegdec.stimulus_decoding.sio.loadmat",
+            side_effect=[
+                {"data": np.array([cue_train_data], dtype=object)},
+                {"data": np.array([main_validation_data], dtype=object)},
+            ],
+        ) as loadmat:
+            rows, prediction_rows = evaluate_participant_stimulus_decoding_diagnostics(
+                "unused",
+                1,
+                config=config,
+                diagnostic_window_centers=(0.0,),
+            )
+
+        self.assertTrue(str(loadmat.call_args_list[0].args[0]).endswith("Part1CueData.mat"))
+        self.assertTrue(str(loadmat.call_args_list[1].args[0]).endswith("Part1Data.mat"))
+        self.assertEqual(rows[0]["transfer_direction"], "cue-to-main")
+        self.assertEqual({row["transfer_direction"] for row in prediction_rows}, {"cue-to-main"})
+        self.assertEqual([row["true_stimulus_id"] for row in prediction_rows], labels)
         self.assertTrue(all(row["correct"] for row in prediction_rows))
 
     def test_evaluate_participant_time_resolved_stimulus_transfer_with_permutations(


### PR DESCRIPTION
## Summary

Adds controls-first stimulus-decoding robustness support:

- adds `transfer_direction` to stimulus decoding, with `main-to-cue` as the default and `cue-to-main` as the reverse-transfer control
- carries `transfer_direction` through accuracy, prediction, summary, confusion, and per-stimulus outputs
- adds `scripts/export_stimulus_robustness.py` for the default, reverse-transfer, balanced-SVM, PCA-50, PCA-200, and 0-30 Hz controls
- adds a manual `Manual stimulus robustness export` workflow that restores the existing MEG cache and uploads `stimulus-robustness-outputs`

## Validation

- `PYTHONPATH=src python -m unittest discover -v` passed: 67 tests, 6 skipped
- `python -m ruff check src tests scripts` passed
- `python -m black --check src tests scripts` passed
- `python -m mypy src` passed
- `python -m pylint src/pymegdec/stimulus_decoding.py` passed
- parsed stimulus workflow YAML files successfully
- one-participant real-data robustness smoke run completed and wrote 2,440 prediction rows, 12 participant/window/control rows, and 12 summary rows

No committed file hardcodes the local MEG data path.