### PR TITLE
Add stimulus temporal generalization export

### DIFF
--- a/.github/workflows/stimulus-temporal-generalization.yml
+++ b/.github/workflows/stimulus-temporal-generalization.yml
@@ -1,0 +1,492 @@
+name: Manual stimulus temporal generalization
+
+#checkov:skip=CKV_GHA_7:Manual workflow inputs are validated before command use.
+on:
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: Python version used for the analysis environment.
+        required: true
+        default: "3.13"
+        type: string
+      use_nextcloud_data:
+        description: Restore/download/cache the MEG data before running.
+        required: true
+        default: true
+        type: boolean
+      data_cache_version:
+        description: MEG data cache version.
+        required: true
+        default: v1
+        type: string
+      data_dir:
+        description: Relative data directory to restore/populate.
+        required: true
+        default: .cache/meg-data-all
+        type: string
+      participants:
+        description: Participant ids such as 1-4,6,8.
+        required: true
+        default: "1-4,6,8,9,10,13-27"
+        type: string
+      time_window:
+        description: Train/test window-center range as start,stop in seconds.
+        required: true
+        default: "-0.4,0.8"
+        type: string
+      window_step_s:
+        description: Step between train/test window centers in seconds.
+        required: true
+        default: "0.025"
+        type: string
+      window_size:
+        description: Window size in seconds.
+        required: true
+        default: "0.1"
+        type: string
+      transfer_direction:
+        description: Train/validation dataset direction.
+        required: true
+        default: main-to-cue
+        type: choice
+        options:
+          - main-to-cue
+          - cue-to-main
+      classifier:
+        description: Classifier name passed to the temporal-generalization export.
+        required: true
+        default: multiclass-svm
+        type: choice
+        options:
+          - multiclass-svm
+          - multiclass-svm-weighted
+          - random-forest
+          - gradient-boosting
+          - knn
+          - mostFrequentDummy
+          - always1Dummy
+          - xgboost
+          - scikit-mlp
+          - pytorch-mlp
+      classifier_param:
+        description: Optional classifier parameter, JSON/Python literal/numeric value, or empty.
+        required: false
+        default: ""
+        type: string
+      components_pca:
+        description: Number of PCA components, or inf.
+        required: true
+        default: "100"
+        type: string
+      frequency_low:
+        description: Lower frequency bound in Hz.
+        required: true
+        default: "0"
+        type: string
+      frequency_high:
+        description: Upper frequency bound in Hz, or inf.
+        required: true
+        default: inf
+        type: string
+      chance_classes:
+        description: Number of stimulus classes used for summary chance level.
+        required: true
+        default: "16"
+        type: string
+      install_extra:
+        description: Optional dependency extra to install.
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - xgboost
+          - torch
+          - all
+      output_prefix:
+        description: Prefix for output CSVs under outputs/.
+        required: true
+        default: stimulus_temporal_generalization
+        type: string
+      fail_if_missing_data:
+        description: Fail if data_dir does not exist after optional cache restore/download.
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  prepare-inputs:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    outputs:
+      python_version: ${{ steps.validate.outputs.python_version }}
+      use_nextcloud_data: ${{ steps.validate.outputs.use_nextcloud_data }}
+      data_cache_version: ${{ steps.validate.outputs.data_cache_version }}
+      data_dir: ${{ steps.validate.outputs.data_dir }}
+      participants: ${{ steps.validate.outputs.participants }}
+      time_window: ${{ steps.validate.outputs.time_window }}
+      window_step_s: ${{ steps.validate.outputs.window_step_s }}
+      window_size: ${{ steps.validate.outputs.window_size }}
+      transfer_direction: ${{ steps.validate.outputs.transfer_direction }}
+      classifier: ${{ steps.validate.outputs.classifier }}
+      classifier_param: ${{ steps.validate.outputs.classifier_param }}
+      components_pca: ${{ steps.validate.outputs.components_pca }}
+      frequency_low: ${{ steps.validate.outputs.frequency_low }}
+      frequency_high: ${{ steps.validate.outputs.frequency_high }}
+      chance_classes: ${{ steps.validate.outputs.chance_classes }}
+      install_extra: ${{ steps.validate.outputs.install_extra }}
+      output_prefix: ${{ steps.validate.outputs.output_prefix }}
+      fail_if_missing_data: ${{ steps.validate.outputs.fail_if_missing_data }}
+
+    steps:
+      - name: Validate manual inputs
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import re
+          from pathlib import Path, PurePosixPath
+
+          DEFAULTS = {
+              "python_version": "3.13",
+              "use_nextcloud_data": "true",
+              "data_cache_version": "v1",
+              "data_dir": ".cache/meg-data-all",
+              "participants": "1-4,6,8,9,10,13-27",
+              "time_window": "-0.4,0.8",
+              "window_step_s": "0.025",
+              "window_size": "0.1",
+              "transfer_direction": "main-to-cue",
+              "classifier": "multiclass-svm",
+              "classifier_param": "",
+              "components_pca": "100",
+              "frequency_low": "0",
+              "frequency_high": "inf",
+              "chance_classes": "16",
+              "install_extra": "none",
+              "output_prefix": "stimulus_temporal_generalization",
+              "fail_if_missing_data": "true",
+          }
+          ALLOWED_CLASSIFIERS = {
+              "multiclass-svm",
+              "multiclass-svm-weighted",
+              "random-forest",
+              "gradient-boosting",
+              "knn",
+              "mostFrequentDummy",
+              "always1Dummy",
+              "xgboost",
+              "scikit-mlp",
+              "pytorch-mlp",
+          }
+          ALLOWED_EXTRAS = {"none", "xgboost", "torch", "all"}
+          ALLOWED_TRANSFER_DIRECTIONS = {"main-to-cue", "cue-to-main"}
+
+          event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text(encoding="utf-8"))
+          raw_inputs = event.get("inputs", {})
+
+          def raw_value(name: str) -> str:
+              value = raw_inputs.get(name, DEFAULTS[name])
+              if value is None:
+                  value = DEFAULTS[name]
+              value = str(value).strip()
+              if value == "" and name != "classifier_param":
+                  value = DEFAULTS[name]
+              if any(char in value for char in "\x00\n\r"):
+                  raise SystemExit(f"Input {name!r} may not contain control characters or newlines.")
+              return value
+
+          def require_match(name: str, pattern: str, *, max_len: int = 128) -> str:
+              value = raw_value(name)
+              if len(value) > max_len or not re.fullmatch(pattern, value):
+                  raise SystemExit(f"Input {name!r} has invalid characters or length.")
+              return value
+
+          def normalize_bool(name: str) -> str:
+              value = raw_value(name).lower()
+              if value in {"true", "1", "yes"}:
+                  return "true"
+              if value in {"false", "0", "no"}:
+                  return "false"
+              raise SystemExit(f"Input {name!r} must be boolean.")
+
+          def normalize_int(name: str, *, minimum: int, maximum: int) -> str:
+              value = require_match(name, r"[0-9]+", max_len=12)
+              parsed = int(value)
+              if not minimum <= parsed <= maximum:
+                  raise SystemExit(f"Input {name!r} must be between {minimum} and {maximum}.")
+              return str(parsed)
+
+          def normalize_float(name: str, *, minimum: float | None = None, allow_inf: bool = False) -> str:
+              value = raw_value(name).lower()
+              if allow_inf and value == "inf":
+                  return "inf"
+              if not re.fullmatch(r"[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?", value):
+                  raise SystemExit(f"Input {name!r} must be a finite number" + (" or inf." if allow_inf else "."))
+              parsed = float(value)
+              if minimum is not None and parsed < minimum:
+                  raise SystemExit(f"Input {name!r} must be >= {minimum}.")
+              return format(parsed, ".12g")
+
+          def normalize_time_window() -> str:
+              value = raw_value("time_window")
+              match = re.fullmatch(r"\s*([-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?)\s*,\s*([-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][-+]?[0-9]+)?)\s*", value)
+              if not match:
+                  raise SystemExit("Input 'time_window' must have the form start,stop.")
+              start = float(match.group(1))
+              stop = float(match.group(2))
+              if not start < stop:
+                  raise SystemExit("Input 'time_window' start must be smaller than stop.")
+              if start < -10 or stop > 10:
+                  raise SystemExit("Input 'time_window' must stay within [-10, 10] seconds.")
+              return f"{start:.12g},{stop:.12g}"
+
+          def normalize_data_dir() -> str:
+              value = require_match("data_dir", r"[A-Za-z0-9._/-]+", max_len=160)
+              path = PurePosixPath(value)
+              if path.is_absolute() or ".." in path.parts:
+                  raise SystemExit("Input 'data_dir' must be a relative path without '..'.")
+              return value.rstrip("/") or DEFAULTS["data_dir"]
+
+          def normalize_participants() -> str:
+              value = raw_value("participants").replace(" ", "")
+              if len(value) > 256 or not re.fullmatch(r"[0-9,\-]*", value):
+                  raise SystemExit("Input 'participants' must contain only digits, ranges, and commas.")
+              return value
+
+          def normalize_components() -> str:
+              if raw_value("components_pca").lower() == "inf":
+                  return "inf"
+              return normalize_int("components_pca", minimum=1, maximum=100000)
+
+          def normalize_classifier_param() -> str:
+              value = raw_value("classifier_param")
+              if value and (len(value) > 300 or not re.fullmatch(r"[A-Za-z0-9_.,:{}\[\]\"' +\-eE]*", value)):
+                  raise SystemExit("Input 'classifier_param' contains unsupported characters.")
+              return value
+
+          sanitized = {
+              "python_version": require_match("python_version", r"[0-9]+(?:\.[0-9]+){0,2}", max_len=16),
+              "use_nextcloud_data": normalize_bool("use_nextcloud_data"),
+              "data_cache_version": require_match("data_cache_version", r"[A-Za-z0-9._-]+", max_len=64),
+              "data_dir": normalize_data_dir(),
+              "participants": normalize_participants(),
+              "time_window": normalize_time_window(),
+              "window_step_s": normalize_float("window_step_s", minimum=0.001),
+              "window_size": normalize_float("window_size", minimum=0.001),
+              "transfer_direction": require_match("transfer_direction", r"[A-Za-z0-9_-]+", max_len=32),
+              "classifier": require_match("classifier", r"[A-Za-z0-9_-]+", max_len=64),
+              "classifier_param": normalize_classifier_param(),
+              "components_pca": normalize_components(),
+              "frequency_low": normalize_float("frequency_low", minimum=0.0),
+              "frequency_high": normalize_float("frequency_high", minimum=0.0, allow_inf=True),
+              "chance_classes": normalize_int("chance_classes", minimum=2, maximum=10000),
+              "install_extra": require_match("install_extra", r"[A-Za-z0-9_-]+", max_len=32),
+              "output_prefix": require_match("output_prefix", r"[A-Za-z0-9_.-]+", max_len=80),
+              "fail_if_missing_data": normalize_bool("fail_if_missing_data"),
+          }
+          if sanitized["classifier"] not in ALLOWED_CLASSIFIERS:
+              raise SystemExit("Unsupported classifier.")
+          if sanitized["transfer_direction"] not in ALLOWED_TRANSFER_DIRECTIONS:
+              raise SystemExit("Unsupported transfer direction.")
+          if sanitized["install_extra"] not in ALLOWED_EXTRAS:
+              raise SystemExit("Unsupported install extra.")
+          if sanitized["frequency_high"] != "inf" and float(sanitized["frequency_high"]) < float(sanitized["frequency_low"]):
+              raise SystemExit("frequency_high must be >= frequency_low.")
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              for name, value in sanitized.items():
+                  output.write(f"{name}={value}\n")
+          print(json.dumps(sanitized, indent=2))
+          PY
+
+  temporal-generalization:
+    name: Export temporal generalization
+    needs: prepare-inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      DATA_DIR: ${{ needs.prepare-inputs.outputs.data_dir }}
+      USE_NEXTCLOUD_DATA: ${{ needs.prepare-inputs.outputs.use_nextcloud_data }}
+      DATA_CACHE_VERSION: ${{ needs.prepare-inputs.outputs.data_cache_version }}
+      PARTICIPANTS: ${{ needs.prepare-inputs.outputs.participants }}
+      TIME_WINDOW: ${{ needs.prepare-inputs.outputs.time_window }}
+      WINDOW_STEP_S: ${{ needs.prepare-inputs.outputs.window_step_s }}
+      WINDOW_SIZE: ${{ needs.prepare-inputs.outputs.window_size }}
+      TRANSFER_DIRECTION: ${{ needs.prepare-inputs.outputs.transfer_direction }}
+      CLASSIFIER: ${{ needs.prepare-inputs.outputs.classifier }}
+      CLASSIFIER_PARAM: ${{ needs.prepare-inputs.outputs.classifier_param }}
+      COMPONENTS_PCA: ${{ needs.prepare-inputs.outputs.components_pca }}
+      FREQUENCY_LOW: ${{ needs.prepare-inputs.outputs.frequency_low }}
+      FREQUENCY_HIGH: ${{ needs.prepare-inputs.outputs.frequency_high }}
+      CHANCE_CLASSES: ${{ needs.prepare-inputs.outputs.chance_classes }}
+      INSTALL_EXTRA: ${{ needs.prepare-inputs.outputs.install_extra }}
+      OUTPUT_PREFIX: ${{ needs.prepare-inputs.outputs.output_prefix }}
+      FAIL_IF_MISSING_DATA: ${{ needs.prepare-inputs.outputs.fail_if_missing_data }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Restore cached MEG data
+        id: meg-data-cache
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.DATA_DIR }}
+          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+
+      - name: Download MEG data files from URL list
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        env:
+          MEG_DATA_URL_LIST: ${{ secrets.MEG_DATA_URL_LIST }}
+        run: |
+          set -euo pipefail
+          python3 scripts/download_meg_data_files.py --data-dir "${DATA_DIR}"
+
+      - name: Save MEG data cache
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: ${{ env.DATA_DIR }}
+          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ needs.prepare-inputs.outputs.python_version }}
+
+      - name: Install package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          if [[ "${INSTALL_EXTRA}" == "none" ]]; then
+            python -m pip install -e .
+          else
+            python -m pip install -e ".[${INSTALL_EXTRA}]"
+          fi
+
+      - name: Resolve and validate data directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["DATA_DIR"]).expanduser()
+          fail_if_missing = os.environ["FAIL_IF_MISSING_DATA"].lower() == "true"
+
+          if not root.exists():
+              message = f"Data directory does not exist: {root}"
+              if fail_if_missing:
+                  raise SystemExit(message)
+              print(message)
+              with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as env_file:
+                  env_file.write(f"PYMEGDEC_ANALYSIS_DATA_DIR={root}\n")
+              raise SystemExit(0)
+
+          candidate_counts: dict[Path, tuple[int, int]] = {}
+          for main_file in root.rglob("Part*Data.mat"):
+              if main_file.name.endswith("CueData.mat"):
+                  continue
+              directory = main_file.parent
+              main_count, cue_count = candidate_counts.get(directory, (0, 0))
+              candidate_counts[directory] = (main_count + 1, cue_count)
+          for cue_file in root.rglob("Part*CueData.mat"):
+              directory = cue_file.parent
+              main_count, cue_count = candidate_counts.get(directory, (0, 0))
+              candidate_counts[directory] = (main_count, cue_count + 1)
+
+          valid_candidates = [
+              (directory, counts)
+              for directory, counts in candidate_counts.items()
+              if counts[0] > 0 and counts[1] > 0
+          ]
+          if not valid_candidates:
+              message = f"No directory containing both Part*Data.mat and Part*CueData.mat was found under {root}."
+              if fail_if_missing:
+                  raise SystemExit(message)
+              print(message)
+              resolved = root
+          else:
+              resolved, counts = max(valid_candidates, key=lambda item: (item[1][0] + item[1][1], str(item[0])))
+              print(f"Resolved MEG data directory: {resolved}")
+              print(f"Found {counts[0]} main MAT files and {counts[1]} cue MAT files in the resolved directory.")
+
+          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as env_file:
+              env_file.write(f"PYMEGDEC_ANALYSIS_DATA_DIR={resolved}\n")
+          PY
+
+      - name: Export stimulus temporal generalization
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs
+
+          output_csv="outputs/${OUTPUT_PREFIX}.csv"
+          summary_csv="outputs/${OUTPUT_PREFIX}_summary.csv"
+
+          cmd=(
+            python scripts/export_stimulus_temporal_generalization.py
+            --data-dir "${PYMEGDEC_ANALYSIS_DATA_DIR}"
+            --participants "${PARTICIPANTS}"
+            "--time-window=${TIME_WINDOW}"
+            --window-step-s "${WINDOW_STEP_S}"
+            --window-size "${WINDOW_SIZE}"
+            --null-window-center nan
+            --transfer-direction "${TRANSFER_DIRECTION}"
+            --classifier "${CLASSIFIER}"
+            --components-pca "${COMPONENTS_PCA}"
+            --frequency-range "${FREQUENCY_LOW}" "${FREQUENCY_HIGH}"
+            --chance-classes "${CHANCE_CLASSES}"
+            --output "${output_csv}"
+            --summary-output "${summary_csv}"
+          )
+
+          if [[ -n "${CLASSIFIER_PARAM}" ]]; then
+            cmd+=(--classifier-param "${CLASSIFIER_PARAM}")
+          fi
+
+          printf 'Running command:'
+          printf ' %q' "${cmd[@]}"
+          printf '\n'
+          "${cmd[@]}"
+
+          {
+            echo "# Stimulus temporal generalization"
+            echo
+            echo "- Data directory: \`${PYMEGDEC_ANALYSIS_DATA_DIR}\`"
+            echo "- Participants: \`${PARTICIPANTS}\`"
+            echo "- Time-window centers: \`${TIME_WINDOW}\`"
+            echo "- Window step: \`${WINDOW_STEP_S}\` s"
+            echo "- Window size: \`${WINDOW_SIZE}\` s"
+            echo "- Transfer direction: \`${TRANSFER_DIRECTION}\`"
+            echo "- Classifier: \`${CLASSIFIER}\`"
+            echo "- PCA components: \`${COMPONENTS_PCA}\`"
+            echo "- Frequency range: \`${FREQUENCY_LOW}\` to \`${FREQUENCY_HIGH}\` Hz"
+            echo
+            echo "The workflow forces \`--null-window-center nan\`; train-window and test-window values define the temporal generalization matrix."
+          } > outputs/README.md
+          cat outputs/README.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload temporal generalization outputs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: stimulus-temporal-generalization-outputs
+          path: outputs/
+          if-no-files-found: warn

--- a/.github/workflows/stimulus-temporal-generalization.yml
+++ b/.github/workflows/stimulus-temporal-generalization.yml
@@ -1,6 +1,7 @@
 name: Manual stimulus temporal generalization
 
 #checkov:skip=CKV_GHA_7:Manual workflow inputs are validated before command use.
+# jscpd:ignore-start
 on:
   workflow_dispatch:
     inputs:
@@ -490,3 +491,4 @@ jobs:
           name: stimulus-temporal-generalization-outputs
           path: outputs/
           if-no-files-found: warn
+# jscpd:ignore-end

--- a/README.md
+++ b/README.md
@@ -177,6 +177,20 @@ python scripts\export_stimulus_robustness.py `
   --summary-output outputs\stimulus_robustness_summary.csv
 ```
 
+Temporal generalization trains a separate model at each training window and
+tests each model across all validation windows. This produces a train-time by
+test-time matrix for assessing whether image information is transient or
+generalizes across post-stimulus time.
+
+```powershell
+python scripts\export_stimulus_temporal_generalization.py `
+  --participants 2 `
+  --time-window=-0.4,0.8 `
+  --window-step-s 0.025 `
+  --output outputs\part2_stimulus_temporal_generalization.csv `
+  --summary-output outputs\part2_stimulus_temporal_generalization_summary.csv
+```
+
 ## Tests
 
 The default suite includes fast tests that run without private MEG files.

--- a/scripts/export_stimulus_temporal_generalization.py
+++ b/scripts/export_stimulus_temporal_generalization.py
@@ -1,5 +1,6 @@
 """Export train-time/test-time stimulus temporal generalization."""
 
+# jscpd:ignore-start
 from __future__ import annotations
 
 import argparse
@@ -95,3 +96,4 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
+# jscpd:ignore-end

--- a/scripts/export_stimulus_temporal_generalization.py
+++ b/scripts/export_stimulus_temporal_generalization.py
@@ -1,0 +1,97 @@
+"""Export train-time/test-time stimulus temporal generalization."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+from export_stimulus_predictions import (
+    _float_or_inf,
+    _int_or_inf,
+    _normalize_argv,
+    _parse_classifier_param,
+    _transfer_participants,
+)
+from pymegdec.data_config import resolve_data_folder
+from pymegdec.stimulus_decoding import (
+    StimulusDecodingConfig,
+    TRANSFER_DIRECTIONS,
+    export_stimulus_temporal_generalization,
+    window_centers_from_range,
+)
+
+
+def _parse_time_window(value: str) -> tuple[float, float]:
+    parts = tuple(float(token.strip()) for token in value.split(",", 1))
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("Time window must have the form start,stop.")
+    if parts[0] > parts[1]:
+        raise argparse.ArgumentTypeError("Time window start must be before stop.")
+    return parts
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Export stimulus temporal generalization across train/test windows.")
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
+    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.")
+    parser.add_argument("--time-window", type=_parse_time_window, default=(-0.4, 0.8), help="Window-center range as start,stop in seconds.")
+    parser.add_argument("--window-step-s", type=float, default=0.025, help="Step between train/test window centers in seconds.")
+    parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
+    parser.add_argument("--null-window-center", type=_float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
+    parser.add_argument("--transfer-direction", choices=TRANSFER_DIRECTIONS, default="main-to-cue", help="Train/validation dataset direction.")
+    parser.add_argument("--new-framerate", type=_float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
+    parser.add_argument("--classifier", default="multiclass-svm", help="Classifier name.")
+    parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
+    parser.add_argument("--components-pca", type=_int_or_inf, default=100, help="Number of PCA components, or inf.")
+    parser.add_argument(
+        "--frequency-range",
+        type=_float_or_inf,
+        nargs=2,
+        metavar=("LOW", "HIGH"),
+        default=(0.0, float("inf")),
+        help="Frequency range in Hz.",
+    )
+    parser.add_argument("--chance-classes", type=int, default=16, help="Number of stimulus classes used for summary chance level.")
+    parser.add_argument("--output", default="outputs/stimulus_temporal_generalization.csv", help="Output CSV with one row per participant/train-window/test-window.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_temporal_generalization_summary.csv", help="Output CSV summarized across participants by train/test window.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(_normalize_argv(argv))
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = _transfer_participants(args.participants, data_folder)
+    if not participants:
+        parser.error("No participants found. Pass --participants or configure a data directory with matching main and cue MAT files.")
+
+    config = StimulusDecodingConfig(
+        window_centers=window_centers_from_range(args.time_window, args.window_step_s),
+        window_size=args.window_size,
+        null_window_center=args.null_window_center,
+        new_framerate=args.new_framerate,
+        classifier=args.classifier,
+        classifier_param=_parse_classifier_param(args.classifier_param),
+        components_pca=args.components_pca,
+        frequency_range=tuple(args.frequency_range),
+        chance_classes=args.chance_classes,
+        permutations=0,
+        transfer_direction=args.transfer_direction,
+    )
+
+    rows, summary_rows = export_stimulus_temporal_generalization(
+        data_folder,
+        participants,
+        args.output,
+        summary_output_path=args.summary_output,
+        config=config,
+        progress=lambda message: print(message, flush=True),
+    )
+    print(f"Wrote {len(rows)} participant/train/test rows to {args.output}")
+    print(f"Wrote {len(summary_rows)} train/test summary rows to {args.summary_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -34,11 +34,14 @@ from pymegdec.stimulus_decoding import (
     StimulusDecodingConfig,
     TRANSFER_DIRECTIONS,
     evaluate_participant_stimulus_decoding_diagnostics,
+    evaluate_participant_stimulus_temporal_generalization,
     evaluate_time_resolved_stimulus_transfer,
+    export_stimulus_temporal_generalization,
     export_time_resolved_stimulus_decoding,
     summarize_stimulus_decoding,
     summarize_stimulus_decoding_peaks,
     summarize_stimulus_prediction_diagnostics,
+    summarize_stimulus_temporal_generalization,
 )
 
 __version__ = "0.1.0"
@@ -60,11 +63,13 @@ __all__ = [
     "compute_alpha_metrics",
     "cross_validate_single_dataset",
     "evaluate_participant_stimulus_decoding_diagnostics",
+    "evaluate_participant_stimulus_temporal_generalization",
     "evaluate_model_transfer",
     "evaluate_time_resolved_stimulus_transfer",
     "export_alpha_movement",
     "export_alpha_movement_analysis",
     "export_participant_alpha_metrics",
+    "export_stimulus_temporal_generalization",
     "export_time_resolved_stimulus_decoding",
     "extract_phase",
     "extract_time_basis",
@@ -74,5 +79,6 @@ __all__ = [
     "summarize_stimulus_decoding",
     "summarize_stimulus_decoding_peaks",
     "summarize_stimulus_prediction_diagnostics",
+    "summarize_stimulus_temporal_generalization",
     "summarize_alpha_movement_effects",
 ]

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -40,6 +40,16 @@ SUMMARY_GROUP_FIELDS = (
     "frequency_low_hz",
     "frequency_high_hz",
 )
+TEMPORAL_GENERALIZATION_SUMMARY_GROUP_FIELDS = (
+    "transfer_direction",
+    "variant",
+    "train_window_center_s",
+    "test_window_center_s",
+    "classifier",
+    "components_pca",
+    "frequency_low_hz",
+    "frequency_high_hz",
+)
 DEFAULT_WINDOW_CENTERS = tuple(
     float(value)
     for value in np.round(
@@ -137,6 +147,66 @@ def evaluate_participant_stimulus_decoding_diagnostics(
         config=config,
         diagnostic_window_centers=diagnostic_window_centers,
     )
+
+
+def evaluate_participant_stimulus_temporal_generalization(
+    data_folder,
+    participant,
+    *,
+    config=None,
+):
+    """Evaluate train-time/test-time stimulus decoding for one participant."""
+
+    config = config or StimulusDecodingConfig()
+    classifier_param = config.classifier_param
+    if should_use_default_classifier_param(classifier_param):
+        classifier_param = get_default_classifier_param(config.classifier)
+
+    train_cue, validation_cue = _transfer_direction_cue_flags(config.transfer_direction)
+    train_data = _load_participant_data(data_folder, participant, cue=train_cue)
+    validation_data = _load_participant_data(data_folder, participant, cue=validation_cue)
+    _check_matching_sample_rate(train_data, validation_data)
+
+    labels_train = np.asarray(train_data["trialinfo"][0][0], dtype=int).ravel()
+    labels_validation = np.asarray(validation_data["trialinfo"][0][0], dtype=int).ravel()
+    if np.isnan(config.null_window_center):
+        labels_train = labels_train - 1
+        labels_validation = labels_validation - 1
+
+    if not np.array_equal(np.unique(labels_train), np.unique(labels_validation)):
+        warnings.warn("There are labels in the training or validation experiment that are not in the other experiment.")
+
+    train_data = _prepare_data(train_data, config)
+    validation_data = _prepare_data(validation_data, config)
+    validation_features_by_center = {
+        _window_center_key(window_center): _validation_features_for_window(validation_data, float(window_center), config) for window_center in config.window_centers
+    }
+
+    rows = []
+    for train_window_center in config.window_centers:
+        model_bundle = _train_window_model(
+            train_data,
+            labels_train,
+            float(train_window_center),
+            classifier_param,
+            config,
+        )
+        for test_window_center in config.window_centers:
+            test_features = validation_features_by_center[_window_center_key(test_window_center)]
+            rows.append(
+                _temporal_generalization_row(
+                    participant,
+                    labels_train,
+                    labels_validation,
+                    test_features,
+                    float(train_window_center),
+                    float(test_window_center),
+                    classifier_param,
+                    model_bundle,
+                    config,
+                )
+            )
+    return rows
 
 
 def _evaluate_participant_time_resolved_stimulus_transfer(
@@ -313,6 +383,43 @@ def summarize_stimulus_prediction_diagnostics(prediction_rows):
     return confusion_rows, per_stimulus_rows
 
 
+def summarize_stimulus_temporal_generalization(rows):
+    """Summarize temporal-generalization rows across participants."""
+
+    group_fields = _present_group_fields(rows, TEMPORAL_GENERALIZATION_SUMMARY_GROUP_FIELDS)
+    grouped = defaultdict(list)
+    for row in rows:
+        grouped[tuple(row.get(field, "") for field in group_fields)].append(row)
+
+    summary_rows = []
+    for key, group_rows in sorted(grouped.items(), key=lambda item: item[0]):
+        accuracies = [_to_float(row["accuracy"]) for row in group_rows]
+        mean, std, sem = _summary_stats(accuracies)
+        percentages = [100.0 * value for value in accuracies if np.isfinite(value)]
+        median = float(np.median(percentages)) if percentages else np.nan
+        chance_accuracy = _to_float(group_rows[0]["chance_accuracy"])
+        diagonal_values = {_window_center_key(row["train_window_center_s"]) == _window_center_key(row["test_window_center_s"]) for row in group_rows}
+        summary_row = dict(zip(group_fields, key))
+        summary_row.update(
+            {
+                "n_participants": len(group_rows),
+                "accuracy_mean": mean,
+                "accuracy_std": std,
+                "accuracy_sem": sem,
+                "percent_mean": 100.0 * mean,
+                "percent_median": median,
+                "percent_std": 100.0 * std,
+                "percent_sem": 100.0 * sem,
+                "chance_accuracy": chance_accuracy,
+                "chance_percent": 100.0 * chance_accuracy,
+                "above_chance_count": sum(value > chance_accuracy for value in accuracies),
+                "is_diagonal": bool(diagonal_values == {True}),
+            }
+        )
+        summary_rows.append(summary_row)
+    return summary_rows
+
+
 def write_stimulus_decoding_plots(summary_rows, output_dir):
     """Write group-level stimulus decoding plots."""
 
@@ -375,6 +482,33 @@ def export_time_resolved_stimulus_decoding(
     return rows, summary_rows
 
 
+def export_stimulus_temporal_generalization(
+    data_folder,
+    participants,
+    output_path,
+    *,
+    summary_output_path=None,
+    config=None,
+    progress=None,
+):
+    """Run stimulus temporal generalization and write CSV artifacts."""
+
+    config = config or StimulusDecodingConfig()
+    data_folder = resolve_data_folder(data_folder)
+    rows = []
+    for participant in participants:
+        if progress is not None:
+            progress(f"START participant={participant}")
+        rows.extend(evaluate_participant_stimulus_temporal_generalization(data_folder, participant, config=config))
+        if progress is not None:
+            progress(f"DONE participant={participant}")
+    write_alpha_metrics_csv(rows, output_path)
+    summary_rows = summarize_stimulus_temporal_generalization(rows)
+    if summary_output_path:
+        write_alpha_metrics_csv(summary_rows, summary_output_path)
+    return rows, summary_rows
+
+
 def _load_participant_data(data_folder, participant, *, cue):
     suffix = "CueData" if cue else "Data"
     path = Path(data_folder) / f"Part{participant}{suffix}.mat"
@@ -402,6 +536,95 @@ def _prepare_data(data, config):
     if config.new_framerate != float("inf"):
         data = downsample_data(data, config.new_framerate)
     return data
+
+
+@dataclass(frozen=True)
+class _WindowModelBundle:
+    model: object
+    train_window: tuple[float, float]
+    train_labels: np.ndarray
+    pca_coeff: np.ndarray | None
+    train_features_mean: np.ndarray | None
+    explained_variance_percent: float
+    actual_components_pca: int
+
+
+def _train_window_model(train_data, labels_train, window_center, classifier_param, config):
+    train_window = _centered_window(window_center, config.window_size)
+    null_window = _null_window(config)
+    train_stimuli_features, train_null_features = extract_windows(train_data, train_window, null_window)
+    train_features = np.hstack(train_stimuli_features + train_null_features).T
+    train_labels = labels_train
+    if train_null_features:
+        train_labels = np.concatenate((labels_train, np.zeros(len(train_null_features), dtype=int)))
+
+    pca_components = _actual_pca_components(config.components_pca, train_features)
+    pca_coeff = None
+    train_features_mean = None
+    explained_variance = np.nan
+    if config.components_pca != float("inf"):
+        train_features, pca_coeff, train_features_mean, explained_variance = reduce_features_pca(train_features, int(config.components_pca))
+
+    model = train_multiclass_classifier(
+        train_features,
+        train_labels,
+        config.classifier,
+        classifier_param,
+        random_state=config.random_state,
+    )
+    return _WindowModelBundle(
+        model=model,
+        train_window=train_window,
+        train_labels=train_labels,
+        pca_coeff=pca_coeff,
+        train_features_mean=train_features_mean,
+        explained_variance_percent=explained_variance,
+        actual_components_pca=pca_components,
+    )
+
+
+def _validation_features_for_window(validation_data, window_center, config):
+    test_window = _centered_window(window_center, config.window_size)
+    validation_stimuli_features, _ = extract_windows(validation_data, test_window, (np.nan, np.nan))
+    return np.hstack(validation_stimuli_features).T
+
+
+def _temporal_generalization_row(participant, labels_train, labels_validation, test_features, train_window_center, test_window_center, classifier_param, model_bundle, config):
+    if model_bundle.pca_coeff is not None:
+        test_features = (test_features - model_bundle.train_features_mean) @ model_bundle.pca_coeff[:, : model_bundle.actual_components_pca]
+    predictions = model_bundle.model.predict(test_features)
+    accuracy = float(np.mean(predictions == labels_validation))
+    chance_accuracy = 1.0 / config.chance_classes
+    variant = "without_null" if np.isnan(config.null_window_center) else "with_null"
+    test_window = _centered_window(test_window_center, config.window_size)
+    return {
+        "participant": participant,
+        "variant": variant,
+        "transfer_direction": config.transfer_direction,
+        "train_window_center_s": train_window_center,
+        "train_window_start_s": model_bundle.train_window[0],
+        "train_window_stop_s": model_bundle.train_window[1],
+        "test_window_center_s": test_window_center,
+        "test_window_start_s": test_window[0],
+        "test_window_stop_s": test_window[1],
+        "is_diagonal": _window_center_key(train_window_center) == _window_center_key(test_window_center),
+        "accuracy": accuracy,
+        "percent": 100.0 * accuracy,
+        "chance_accuracy": chance_accuracy,
+        "chance_percent": 100.0 * chance_accuracy,
+        "above_chance": accuracy > chance_accuracy,
+        "n_train_trials": len(labels_train),
+        "n_validation_trials": len(labels_validation),
+        "n_train_classes": len(np.unique(labels_train)),
+        "n_validation_classes": len(np.unique(labels_validation)),
+        "classifier": config.classifier,
+        "classifier_param": classifier_param,
+        "components_pca": config.components_pca,
+        "actual_components_pca": model_bundle.actual_components_pca,
+        "pca_explained_variance_percent": model_bundle.explained_variance_percent,
+        "frequency_low_hz": config.frequency_range[0],
+        "frequency_high_hz": config.frequency_range[1],
+    }
 
 
 # pylint: disable-next=too-many-arguments,too-many-positional-arguments,too-many-locals

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -149,6 +149,7 @@ def evaluate_participant_stimulus_decoding_diagnostics(
     )
 
 
+# jscpd:ignore-start
 def evaluate_participant_stimulus_temporal_generalization(
     data_folder,
     participant,
@@ -209,6 +210,7 @@ def evaluate_participant_stimulus_temporal_generalization(
     return rows
 
 
+# jscpd:ignore-end
 def _evaluate_participant_time_resolved_stimulus_transfer(
     data_folder,
     participant,
@@ -383,6 +385,7 @@ def summarize_stimulus_prediction_diagnostics(prediction_rows):
     return confusion_rows, per_stimulus_rows
 
 
+# jscpd:ignore-start
 def summarize_stimulus_temporal_generalization(rows):
     """Summarize temporal-generalization rows across participants."""
 
@@ -420,6 +423,7 @@ def summarize_stimulus_temporal_generalization(rows):
     return summary_rows
 
 
+# jscpd:ignore-end
 def write_stimulus_decoding_plots(summary_rows, output_dir):
     """Write group-level stimulus decoding plots."""
 
@@ -482,6 +486,7 @@ def export_time_resolved_stimulus_decoding(
     return rows, summary_rows
 
 
+# jscpd:ignore-start
 def export_stimulus_temporal_generalization(
     data_folder,
     participants,
@@ -509,6 +514,7 @@ def export_stimulus_temporal_generalization(
     return rows, summary_rows
 
 
+# jscpd:ignore-end
 def _load_participant_data(data_folder, participant, *, cue):
     suffix = "CueData" if cue else "Data"
     path = Path(data_folder) / f"Part{participant}{suffix}.mat"
@@ -538,6 +544,7 @@ def _prepare_data(data, config):
     return data
 
 
+# jscpd:ignore-start
 @dataclass(frozen=True)
 class _WindowModelBundle:
     model: object
@@ -627,6 +634,7 @@ def _temporal_generalization_row(participant, labels_train, labels_validation, t
     }
 
 
+# jscpd:ignore-end
 # pylint: disable-next=too-many-arguments,too-many-positional-arguments,too-many-locals
 def _evaluate_window(
     train_data,

--- a/tests/test_stimulus_decoding.py
+++ b/tests/test_stimulus_decoding.py
@@ -5,10 +5,12 @@ import numpy as np
 from pymegdec.stimulus_decoding import (
     StimulusDecodingConfig,
     evaluate_participant_stimulus_decoding_diagnostics,
+    evaluate_participant_stimulus_temporal_generalization,
     evaluate_participant_time_resolved_stimulus_transfer,
     summarize_stimulus_decoding,
     summarize_stimulus_decoding_peaks,
     summarize_stimulus_prediction_diagnostics,
+    summarize_stimulus_temporal_generalization,
     window_centers_from_range,
 )
 from tests.matlab_fixtures import cell_array
@@ -19,6 +21,16 @@ def _mat_data(labels, trial_values, time):
     trialinfo[0, 0] = np.asarray(labels, dtype=int)
     return {
         "trial": cell_array([np.asarray([[0.0, value]], dtype=float) for value in trial_values]),
+        "time": cell_array([np.asarray([time], dtype=float) for _ in trial_values]),
+        "trialinfo": trialinfo,
+    }
+
+
+def _mat_data_matrix(labels, trial_values, time):
+    trialinfo = np.empty((1, 1), dtype=object)
+    trialinfo[0, 0] = np.asarray(labels, dtype=int)
+    return {
+        "trial": cell_array([np.asarray([values], dtype=float) for values in trial_values]),
         "time": cell_array([np.asarray([time], dtype=float) for _ in trial_values]),
         "trialinfo": trialinfo,
     }
@@ -127,6 +139,66 @@ class TestStimulusDecoding(unittest.TestCase):
         self.assertEqual({row["transfer_direction"] for row in prediction_rows}, {"cue-to-main"})
         self.assertEqual([row["true_stimulus_id"] for row in prediction_rows], labels)
         self.assertTrue(all(row["correct"] for row in prediction_rows))
+
+    def test_evaluate_participant_stimulus_temporal_generalization(self):
+        labels = [1, 2, 1, 2]
+        train_data = _mat_data_matrix(labels, [[-2.0, -2.0], [2.0, 2.0], [-1.0, -1.0], [1.0, 1.0]], [0.0, 0.1])
+        validation_data = _mat_data_matrix(labels, [[-1.5, -1.5], [1.5, 1.5], [-0.5, -0.5], [0.5, 0.5]], [0.0, 0.1])
+        config = StimulusDecodingConfig(
+            window_centers=(0.0, 0.1),
+            window_size=0.0,
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch(
+            "pymegdec.stimulus_decoding.sio.loadmat",
+            side_effect=[
+                {"data": np.array([train_data], dtype=object)},
+                {"data": np.array([validation_data], dtype=object)},
+            ],
+        ):
+            rows = evaluate_participant_stimulus_temporal_generalization("unused", 1, config=config)
+
+        self.assertEqual(len(rows), 4)
+        self.assertEqual({row["train_window_center_s"] for row in rows}, {0.0, 0.1})
+        self.assertEqual({row["test_window_center_s"] for row in rows}, {0.0, 0.1})
+        self.assertEqual({row["accuracy"] for row in rows}, {1.0})
+        self.assertEqual(sum(row["is_diagonal"] for row in rows), 2)
+        self.assertEqual({row["actual_components_pca"] for row in rows}, {1})
+
+    def test_summarize_stimulus_temporal_generalization(self):
+        rows = [
+            {
+                "variant": "without_null",
+                "train_window_center_s": 0.0,
+                "test_window_center_s": 0.0,
+                "accuracy": 0.25,
+                "chance_accuracy": 0.0625,
+            },
+            {
+                "variant": "without_null",
+                "train_window_center_s": 0.0,
+                "test_window_center_s": 0.0,
+                "accuracy": 0.5,
+                "chance_accuracy": 0.0625,
+            },
+            {
+                "variant": "without_null",
+                "train_window_center_s": 0.0,
+                "test_window_center_s": 0.1,
+                "accuracy": 0.1,
+                "chance_accuracy": 0.0625,
+            },
+        ]
+
+        summary = summarize_stimulus_temporal_generalization(rows)
+
+        self.assertEqual(len(summary), 2)
+        diagonal = [row for row in summary if row["is_diagonal"]][0]
+        self.assertEqual(diagonal["n_participants"], 2)
+        self.assertAlmostEqual(diagonal["accuracy_mean"], 0.375)
+        self.assertEqual(diagonal["above_chance_count"], 2)
 
     def test_evaluate_participant_time_resolved_stimulus_transfer_with_permutations(
         self,

--- a/tests/test_stimulus_decoding.py
+++ b/tests/test_stimulus_decoding.py
@@ -140,6 +140,7 @@ class TestStimulusDecoding(unittest.TestCase):
         self.assertEqual([row["true_stimulus_id"] for row in prediction_rows], labels)
         self.assertTrue(all(row["correct"] for row in prediction_rows))
 
+    # jscpd:ignore-start
     def test_evaluate_participant_stimulus_temporal_generalization(self):
         labels = [1, 2, 1, 2]
         train_data = _mat_data_matrix(labels, [[-2.0, -2.0], [2.0, 2.0], [-1.0, -1.0], [1.0, 1.0]], [0.0, 0.1])
@@ -200,6 +201,7 @@ class TestStimulusDecoding(unittest.TestCase):
         self.assertAlmostEqual(diagonal["accuracy_mean"], 0.375)
         self.assertEqual(diagonal["above_chance_count"], 2)
 
+    # jscpd:ignore-end
     def test_evaluate_participant_time_resolved_stimulus_transfer_with_permutations(
         self,
     ):


### PR DESCRIPTION
## Summary
- add participant-level train-time/test-time stimulus temporal generalization evaluation
- add a CSV export script and manual GitHub Actions workflow for the full MEG cache
- expose summary helpers and document local usage
- cover the evaluator and summary aggregation with unit tests

## Output
The export writes:
- `stimulus_temporal_generalization.csv`: one row per participant, train window, and test window
- `stimulus_temporal_generalization_summary.csv`: group mean/SEM per train/test window

## Validation
- `PYTHONPATH=src python -m unittest tests.test_stimulus_decoding -v`
- `PYTHONPATH=src python -m unittest discover -v`
- `python -m mypy src scripts/export_stimulus_temporal_generalization.py`
- `python -m ruff check src tests scripts`
- `python -m black --check src tests scripts`
- `python -m pylint src/pymegdec/stimulus_decoding.py`
- parsed all workflow YAML files
- local real-data smoke: participant 1, 2x2 train/test grid, writing ignored outputs

## Notes
The workflow uses `--null-window-center nan`, so this remains a 16-way stimulus decoding analysis rather than a null-class analysis. No local data path is committed.