### PR TITLE
Use RepTrace decoding cores

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2288,8 +2288,8 @@ scikit-learn = "*"
 [package.source]
 type = "git"
 url = "https://github.com/IPS-Stuttgart/RepTrace.git"
-reference = "main"
-resolved_reference = "e746de3532a7ca0aecd55cf807f81efdce53d91b"
+reference = "codex/windowed-decoding-core"
+resolved_reference = "2a994337fc10caa83499d13cc43cbedb27015dfb"
 
 [[package]]
 name = "requests"
@@ -2867,4 +2867,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "4b9b80783fa711cac7b36134e3c620b80741147a9501513e2190a3bac66aceaf"
+content-hash = "e099673a26e78b9fea425b4a6fb41268bc6488de32ac42755918d215062a6b70"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2289,7 +2289,7 @@ scikit-learn = "*"
 type = "git"
 url = "https://github.com/IPS-Stuttgart/RepTrace.git"
 reference = "codex/windowed-decoding-core"
-resolved_reference = "2a994337fc10caa83499d13cc43cbedb27015dfb"
+resolved_reference = "1cbb71e6e770dbb221e734274d65700f4d5cfa1b"
 
 [[package]]
 name = "requests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas>=3.0.2,<4.0.0",
-    "reptrace @ git+https://github.com/IPS-Stuttgart/RepTrace.git@main",
+    "reptrace @ git+https://github.com/IPS-Stuttgart/RepTrace.git@codex/windowed-decoding-core",
     "scikit-learn",
     "scipy",
 ]

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -1,31 +1,20 @@
-"""Classifier factories and wrappers used by the decoding routines."""
-
-from dataclasses import dataclass
-from typing import Callable
+"""Classifier compatibility wrappers used by PyMEGDec decoding routines."""
 
 import numpy as np
-from sklearn.dummy import DummyClassifier
-from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
-from sklearn.linear_model import LogisticRegression
-from sklearn.neighbors import KNeighborsClassifier
-from sklearn.neural_network import MLPClassifier
-from sklearn.pipeline import make_pipeline
-from sklearn.preprocessing import StandardScaler
-from sklearn.svm import SVC
+from reptrace.decoding.classifiers import (
+    CLASSIFIER_REGISTRY as REPTRACE_CLASSIFIER_REGISTRY,
+    DEFAULT_CLASSIFIER_PARAMS as REPTRACE_DEFAULT_CLASSIFIER_PARAMS,
+    ClassifierSpec,
+    get_default_classifier_param as get_reptrace_default_classifier_param,
+    should_use_default_classifier_param,
+    train_binary_svm,
+    train_classifier as train_reptrace_classifier,
+    train_gradient_boosting,
+    train_lasso_logistic,
+)
 
-_DEFAULT_CLASSIFIER_PARAMS = {
-    "lasso": 0.005,
-    "multiclass-svm": 0.5,
-    "multiclass-svm-weighted": 0.5,
-    "svm-binary": 0.5,
-    "binary-svm": 0.5,
-    "random-forest": 100,
-    "gradient-boosting": 100,
-    "knn": 5,
-    "mostFrequentDummy": None,
-    "always1Dummy": None,
+_PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS = {
     "xgboost": 100,
-    "scikit-mlp": (150, 1000),
     "pytorch-mlp": {
         "hidden_dim": 720,
         "max_epochs": 500,
@@ -34,12 +23,20 @@ _DEFAULT_CLASSIFIER_PARAMS = {
         "random_seed": 0,
     },
 }
-
-
-@dataclass(frozen=True)
-class ClassifierSpec:
-    builder: Callable
-    fits_in_builder: bool = False
+_DEFAULT_CLASSIFIER_PARAMS = {
+    **REPTRACE_DEFAULT_CLASSIFIER_PARAMS,
+    **_PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS,
+}
+__all__ = [
+    "CLASSIFIER_REGISTRY",
+    "ClassifierSpec",
+    "get_default_classifier_param",
+    "should_use_default_classifier_param",
+    "train_binary_svm",
+    "train_for_stimulus_lasso_glm",
+    "train_gradient_boosting",
+    "train_multiclass_classifier",
+]
 
 
 def __getattr__(name):
@@ -48,59 +45,6 @@ def __getattr__(name):
 
         return MLPClassifierTorch
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def should_use_default_classifier_param(classifier_param):
-    try:
-        return np.all(np.isnan(classifier_param))
-    except TypeError:
-        return False
-
-
-def _build_multiclass_svm(_features, _labels, classifier_param, random_state):
-    return make_pipeline(
-        StandardScaler(),
-        SVC(C=classifier_param, kernel="linear", random_state=random_state),
-    )
-
-
-def _build_multiclass_svm_weighted(_features, _labels, classifier_param, random_state):
-    return make_pipeline(
-        StandardScaler(),
-        SVC(
-            C=classifier_param,
-            kernel="linear",
-            class_weight="balanced",
-            random_state=random_state,
-        ),
-    )
-
-
-def _build_random_forest(_features, _labels, classifier_param, random_state):
-    return RandomForestClassifier(
-        n_estimators=int(classifier_param),
-        min_samples_leaf=5,
-        random_state=random_state,
-    )
-
-
-def _build_gradient_boosting(_features, _labels, classifier_param, random_state):
-    return GradientBoostingClassifier(
-        n_estimators=int(classifier_param),
-        random_state=random_state,
-    )
-
-
-def _build_knn(_features, _labels, classifier_param, _random_state):
-    return KNeighborsClassifier(n_neighbors=int(classifier_param))
-
-
-def _build_most_frequent_dummy(_features, _labels, _classifier_param, _random_state):
-    return DummyClassifier(strategy="most_frequent")
-
-
-def _build_always_one_dummy(_features, _labels, _classifier_param, _random_state):
-    return DummyClassifier(strategy="constant", constant=1)
 
 
 def _build_xgboost(_features, _labels, classifier_param, random_state):
@@ -116,14 +60,6 @@ def _build_xgboost(_features, _labels, classifier_param, random_state):
     )
 
 
-def _build_scikit_mlp(_features, _labels, classifier_param, random_state):
-    return MLPClassifier(
-        hidden_layer_sizes=int(classifier_param[0]),
-        max_iter=int(classifier_param[1]),
-        random_state=random_state,
-    )
-
-
 def _build_pytorch_mlp_classifier(features, labels, classifier_param, random_state):
     return _train_pytorch_mlp(
         features,
@@ -134,15 +70,8 @@ def _build_pytorch_mlp_classifier(features, labels, classifier_param, random_sta
 
 
 CLASSIFIER_REGISTRY = {
-    "multiclass-svm": ClassifierSpec(_build_multiclass_svm),
-    "multiclass-svm-weighted": ClassifierSpec(_build_multiclass_svm_weighted),
-    "random-forest": ClassifierSpec(_build_random_forest),
-    "gradient-boosting": ClassifierSpec(_build_gradient_boosting),
-    "knn": ClassifierSpec(_build_knn),
-    "mostFrequentDummy": ClassifierSpec(_build_most_frequent_dummy),
-    "always1Dummy": ClassifierSpec(_build_always_one_dummy),
+    **REPTRACE_CLASSIFIER_REGISTRY,
     "xgboost": ClassifierSpec(_build_xgboost),
-    "scikit-mlp": ClassifierSpec(_build_scikit_mlp),
     "pytorch-mlp": ClassifierSpec(_build_pytorch_mlp_classifier, fits_in_builder=True),
 }
 
@@ -154,17 +83,14 @@ def train_multiclass_classifier(
     classifier_param,
     random_state=None,
 ):
-    try:
-        classifier_spec = CLASSIFIER_REGISTRY[classifier]
-    except KeyError as exc:
-        supported_classifiers = ", ".join(sorted(CLASSIFIER_REGISTRY))
-        raise ValueError(f"Unsupported classifier: {classifier}. " f"Supported classifiers: {supported_classifiers}") from exc
-
-    model = classifier_spec.builder(features, labels, classifier_param, random_state)
-    if classifier_spec.fits_in_builder:
-        return model
-    model.fit(features, labels)
-    return model
+    return train_reptrace_classifier(
+        features,
+        labels,
+        classifier,
+        classifier_param,
+        random_state=random_state,
+        registry=CLASSIFIER_REGISTRY,
+    )
 
 
 def _train_pytorch_mlp(features, labels, classifier_param, random_state=None):
@@ -260,60 +186,24 @@ def _build_pytorch_trainer(classifier_param, *, random_seed=None):
     )
 
 
-def train_gradient_boosting(
-    train_features,
-    train_labels,
-    classifier_param,
-    random_state=None,
-):
-    model = GradientBoostingClassifier(
-        n_estimators=int(classifier_param),
-        max_leaf_nodes=21,
-        learning_rate=0.1,
-        random_state=random_state,
-    )
-    model.fit(train_features, train_labels)
-    return model
-
-
 def train_for_stimulus_lasso_glm(
     train_features,
     train_labels,
     lambda_,
     random_state=None,
 ):
-    model = make_pipeline(
-        StandardScaler(),
-        LogisticRegression(
-            penalty="l1",
-            C=1 / lambda_,
-            solver="liblinear",
-            max_iter=1000,
-            random_state=random_state,
-        ),
+    return train_lasso_logistic(
+        train_features,
+        train_labels,
+        lambda_,
+        random_state=random_state,
     )
-    model.fit(train_features, train_labels)
-    return model
-
-
-def train_binary_svm(
-    train_features,
-    train_labels,
-    box_constraint,
-    random_state=None,
-):
-    model = make_pipeline(
-        StandardScaler(),
-        SVC(C=box_constraint, kernel="linear", random_state=random_state),
-    )
-    model.fit(train_features, train_labels)
-    return model
 
 
 def get_default_classifier_param(classifier):
-    if classifier in _DEFAULT_CLASSIFIER_PARAMS:
-        classifier_param = _DEFAULT_CLASSIFIER_PARAMS[classifier]
+    if classifier in _PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS:
+        classifier_param = _PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS[classifier]
         if isinstance(classifier_param, dict):
             return classifier_param.copy()
         return classifier_param
-    raise ValueError(f"Unsupported classifier: {classifier}")
+    return get_reptrace_default_classifier_param(classifier)

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -22,9 +22,14 @@ from pymegdec.preprocessing import (
     downsample_data,
     extract_windows,
     filter_features,
-    reduce_features_pca,
 )
 from reptrace.decoding.temporal_generalization import TemporalFeatureWindow, compute_temporal_generalization_matrix  # pylint: disable=no-name-in-module
+from reptrace.decoding.windowed import (
+    fit_window_model as fit_reptrace_window_model,
+    permutation_accuracy_curve as reptrace_permutation_accuracy_curve,
+    predict_window_model as predict_reptrace_window_model,
+    score_windowed_decoding,
+)
 from reptrace.metrics.confusion import confusion_counts, per_class_accuracy  # pylint: disable=no-name-in-module
 from reptrace.onset_detection import annotate_threshold_crossings, detect_onsets
 from reptrace.results.tables import peak_metric_rows, summarize_metric_table  # pylint: disable=no-name-in-module
@@ -855,18 +860,6 @@ def _prepare_data(data, config):
     return data
 
 
-# jscpd:ignore-start
-@dataclass(frozen=True)
-class _WindowModelBundle:
-    model: object
-    train_window: tuple[float, float]
-    train_labels: np.ndarray
-    pca_coeff: np.ndarray | None
-    train_features_mean: np.ndarray | None
-    explained_variance_percent: float
-    actual_components_pca: int
-
-
 def _train_window_model(train_data, labels_train, window_center, classifier_param, config):
     train_window = _centered_window(window_center, config.window_size)
     null_window = _null_window(config)
@@ -876,28 +869,18 @@ def _train_window_model(train_data, labels_train, window_center, classifier_para
     if train_null_features:
         train_labels = np.concatenate((labels_train, np.zeros(len(train_null_features), dtype=int)))
 
-    pca_components = _actual_pca_components(config.components_pca, train_features)
-    pca_coeff = None
-    train_features_mean = None
-    explained_variance = np.nan
-    if config.components_pca != float("inf"):
-        train_features, pca_coeff, train_features_mean, explained_variance = reduce_features_pca(train_features, int(config.components_pca))
-
-    model = train_multiclass_classifier(
+    return fit_reptrace_window_model(
         train_features,
         train_labels,
-        config.classifier,
-        classifier_param,
-        random_state=config.random_state,
-    )
-    return _WindowModelBundle(
-        model=model,
+        fit_model=lambda features, labels: train_multiclass_classifier(
+            features,
+            labels,
+            config.classifier,
+            classifier_param,
+            random_state=config.random_state,
+        ),
+        components_pca=config.components_pca,
         train_window=train_window,
-        train_labels=train_labels,
-        pca_coeff=pca_coeff,
-        train_features_mean=train_features_mean,
-        explained_variance_percent=explained_variance,
-        actual_components_pca=pca_components,
     )
 
 
@@ -919,23 +902,7 @@ def _temporal_feature_window(window_center, labels, config, *, features=None):
 
 
 def _predict_window_model(model_bundle, features):
-    if model_bundle.pca_coeff is not None:
-        features = (features - model_bundle.train_features_mean) @ model_bundle.pca_coeff[:, : model_bundle.actual_components_pca]
-    predictions = model_bundle.model.predict(features)
-    scores = _prediction_scores(model_bundle.model, features)
-    return predictions, scores
-
-
-def _prediction_scores(model, features):
-    if hasattr(model, "decision_function"):
-        scores = np.asarray(model.decision_function(features), dtype=float)
-        if scores.ndim == 1:
-            return np.abs(scores)
-        return np.max(scores, axis=1)
-    if hasattr(model, "predict_proba"):
-        scores = np.asarray(model.predict_proba(features), dtype=float)
-        return np.max(scores, axis=1)
-    return np.full(features.shape[0], np.nan, dtype=float)
+    return predict_reptrace_window_model(model_bundle, features)
 
 
 # pylint: disable-next=too-many-arguments,too-many-positional-arguments
@@ -1118,38 +1085,27 @@ def _evaluate_window(
         train_labels = np.concatenate((labels_train, np.zeros(len(train_null_features), dtype=int)))
     validation_features = np.hstack(validation_stimuli_features).T
 
-    pca_components = _actual_pca_components(config.components_pca, train_features)
-    explained_variance = np.nan
-    if config.components_pca != float("inf"):
-        train_features, coeff, train_features_mean, explained_variance = reduce_features_pca(train_features, int(config.components_pca))
-        validation_features = (validation_features - train_features_mean) @ coeff[:, :pca_components]
-
-    model = train_multiclass_classifier(
+    decoding_result = score_windowed_decoding(
         train_features,
         train_labels,
-        config.classifier,
-        classifier_param,
-        random_state=config.random_state,
-    )
-    predictions = model.predict(validation_features)
-    accuracy = float(np.mean(predictions == labels_validation))
-    permutation_accuracy = np.array([], dtype=float)
-    permutation_p = np.nan
-    if config.permutations > 0:
-        permutation_accuracy = _permutation_accuracy_curve(
-            train_features,
-            validation_features,
-            labels_validation,
-            train_labels,
+        validation_features,
+        labels_validation,
+        fit_model=lambda features, labels: train_multiclass_classifier(
+            features,
+            labels,
             config.classifier,
             classifier_param,
-            config.random_state,
-            config.permutations,
-            permutation_rng,
-        )
-        permutation_p = float(np.mean(permutation_accuracy >= accuracy))
-        if np.isfinite(permutation_p):
-            permutation_p = (permutation_p * config.permutations + 1.0) / (config.permutations + 1.0)
+            random_state=config.random_state,
+        ),
+        components_pca=config.components_pca,
+        train_window=train_window,
+        n_permutations=config.permutations,
+        permutation_rng=permutation_rng,
+    )
+    model_bundle = decoding_result.model_bundle
+    predictions = decoding_result.predictions
+    accuracy = decoding_result.accuracy
+    permutation_accuracy = decoding_result.permutation_accuracy
     chance_accuracy = 1.0 / config.chance_classes
     variant = "without_null" if np.isnan(config.null_window_center) else "with_null"
     null_prediction_rate = float(np.mean(predictions == 0)) if variant == "with_null" else np.nan
@@ -1172,7 +1128,7 @@ def _evaluate_window(
         "n_validation_classes": len(np.unique(labels_validation)),
         "n_permutations": int(config.permutations),
         "permutation_seed": config.permutation_seed,
-        "permutation_p_value": permutation_p,
+        "permutation_p_value": decoding_result.permutation_p_value,
         "permutation_accuracy_mean": (float(np.mean(permutation_accuracy)) if permutation_accuracy.size else np.nan),
         "permutation_accuracy_std": (float(np.std(permutation_accuracy, ddof=1)) if permutation_accuracy.size > 1 else np.nan),
         "null_window_center_s": config.null_window_center,
@@ -1180,8 +1136,8 @@ def _evaluate_window(
         "classifier": config.classifier,
         "classifier_param": classifier_param,
         "components_pca": config.components_pca,
-        "actual_components_pca": pca_components,
-        "pca_explained_variance_percent": explained_variance,
+        "actual_components_pca": model_bundle.actual_components_pca,
+        "pca_explained_variance_percent": model_bundle.explained_variance_percent,
         "frequency_low_hz": config.frequency_range[0],
         "frequency_high_hz": config.frequency_range[1],
     }
@@ -1196,7 +1152,7 @@ def _evaluate_window(
             labels_validation,
             predictions,
             config,
-            pca_components,
+            model_bundle.actual_components_pca,
         )
     return row
 
@@ -1259,12 +1215,6 @@ def _null_window(config):
     return _centered_window(config.null_window_center, config.window_size)
 
 
-def _actual_pca_components(components_pca, features):
-    if components_pca == float("inf"):
-        return features.shape[1]
-    return min(int(components_pca), features.shape[0], features.shape[1])
-
-
 def _window_center_key(value):
     return float(np.round(float(value), 10))
 
@@ -1291,23 +1241,21 @@ def _permutation_accuracy_curve(
     n_permutations,
     permutation_rng,
 ):
-    if permutation_rng is None:
-        permutation_rng = np.random.default_rng()
-
-    permuted_scores = []
-    for _ in range(int(n_permutations)):
-        permuted_train_labels = np.array(train_labels, copy=True)
-        permutation_rng.shuffle(permuted_train_labels)
-        model = train_multiclass_classifier(
-            train_features,
-            permuted_train_labels,
+    return reptrace_permutation_accuracy_curve(
+        train_features,
+        validation_features=validation_features,
+        validation_labels=labels_validation,
+        train_labels=train_labels,
+        fit_model=lambda features, labels: train_multiclass_classifier(
+            features,
+            labels,
             classifier,
             classifier_param,
             random_state=random_state,
-        )
-        predictions = model.predict(validation_features)
-        permuted_scores.append(float(np.mean(predictions == labels_validation)))
-    return np.asarray(permuted_scores, dtype=float)
+        ),
+        n_permutations=n_permutations,
+        permutation_rng=permutation_rng,
+    )
 
 
 def _summary_stats(values):

--- a/tests/test_stimulus_decoding.py
+++ b/tests/test_stimulus_decoding.py
@@ -342,7 +342,7 @@ class TestStimulusDecoding(unittest.TestCase):
                 ],
             ),
             patch(
-                "pymegdec.stimulus_decoding._permutation_accuracy_curve",
+                "reptrace.decoding.windowed.permutation_accuracy_curve",
                 return_value=np.array([0.0, 0.25, 0.5]),
             ),
         ):


### PR DESCRIPTION
## Summary
- Replace PyMEGDec's local stimulus window PCA/train/predict/permutation block with calls into `reptrace.decoding.windowed`.
- Replace the shared sklearn classifier registry and score-related classifier plumbing with imports from `reptrace.decoding.classifiers`.
- Keep PyMEGDec responsible for MEG `.mat` loading, filtering/downsampling, FieldTrip window extraction, labels, stimulus-specific output rows, and optional PyMEGDec-only `xgboost` / `pytorch-mlp` wrappers.

## Validation
- `poetry install`
- `poetry check --lock`
- `poetry run ruff check src\pymegdec\stimulus_decoding.py tests\test_stimulus_decoding.py`
- `poetry run python -m unittest tests.test_stimulus_decoding -v`
- `poetry run python -m unittest tests.test_stimulus_decoding tests.test_model_transfer tests.test_classifier_registry -v`
- `poetry run python -m unittest tests.test_classifiers tests.test_classifier_registry tests.test_model_transfer tests.test_stimulus_decoding -v`
- `poetry run ruff check src\pymegdec\classifiers.py src\pymegdec\stimulus_decoding.py tests\test_classifiers.py tests\test_classifier_registry.py`
- `git diff --check`

## Follow-up
The transfer/cross-validation/null-class/PCA/scoring port continued in IPS-Stuttgart/PyMEGDec#54, stacked on IPS-Stuttgart/RepTrace#9.