### PR TITLE
Use RepTrace transfer decoding core

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2289,7 +2289,7 @@ scikit-learn = "*"
 type = "git"
 url = "https://github.com/IPS-Stuttgart/RepTrace.git"
 reference = "codex/windowed-decoding-core"
-resolved_reference = "1cbb71e6e770dbb221e734274d65700f4d5cfa1b"
+resolved_reference = "3ab64df852fe4b4d5d951fc7bb0cea9b547dbd45"
 
 [[package]]
 name = "requests"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2288,7 +2288,7 @@ scikit-learn = "*"
 [package.source]
 type = "git"
 url = "https://github.com/IPS-Stuttgart/RepTrace.git"
-reference = "codex/windowed-decoding-core"
+reference = "codex/transfer-decoding-core"
 resolved_reference = "3ab64df852fe4b4d5d951fc7bb0cea9b547dbd45"
 
 [[package]]
@@ -2867,4 +2867,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "e099673a26e78b9fea425b4a6fb41268bc6488de32ac42755918d215062a6b70"
+content-hash = "53fb4800041027fe5166e9eb1931e1b0e8cd7e2e4ec6f769a5a4176b421fe2bf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas>=3.0.2,<4.0.0",
-    "reptrace @ git+https://github.com/IPS-Stuttgart/RepTrace.git@codex/windowed-decoding-core",
+    "reptrace @ git+https://github.com/IPS-Stuttgart/RepTrace.git@codex/transfer-decoding-core",
     "scikit-learn",
     "scipy",
 ]

--- a/src/pymegdec/cross_validation.py
+++ b/src/pymegdec/cross_validation.py
@@ -3,13 +3,11 @@ import scipy.io as sio
 from pymegdec.classifiers import (
     get_default_classifier_param,
     should_use_default_classifier_param,
-    train_binary_svm,
-    train_for_stimulus_lasso_glm,
-    train_gradient_boosting,
     train_multiclass_classifier,
 )
 from pymegdec.data_config import resolve_data_folder
-from pymegdec.preprocessing import preprocess_features, reduce_features_pca
+from pymegdec.preprocessing import preprocess_features
+from reptrace.decoding.transfer import cross_validate_feature_decoding
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -36,11 +34,6 @@ def cross_validate_single_dataset(
 
     data = sio.loadmat(f"{data_folder}/Part{participant_id}Data.mat")["data"][0]
     labels = data["trialinfo"][0][0]
-    n_trials = len(labels)
-    n_stim = len(np.unique(labels))
-    pred_lbl = np.empty(n_trials)
-    pred_lbl.fill(np.nan)
-
     stimuli_features, null_features = preprocess_features(
         data,
         frequency_range,
@@ -49,82 +42,26 @@ def cross_validate_single_dataset(
         train_window_center,
         null_window_center,
     )
-    all_features = np.hstack(stimuli_features + null_features)
-
-    fold = np.ceil(np.arange(1, data["trial"][0].shape[1] + 1) / (data["trial"][0].shape[1] / n_folds)).astype(int)
-    fold_aug = fold
-    if null_features:
-        fold_aug = np.concatenate((fold, fold))
-        labels = np.concatenate((labels, np.zeros(n_trials, dtype=int)))
-
-    for f in range(1, n_folds + 1):
-        train_mask = fold_aug != f
-        test_mask = (fold_aug == f) & (labels != 0)
-        train_features = all_features[:, train_mask].T
-        train_labels = labels[train_mask]
-        test_features = all_features[:, test_mask].T
-
-        if components_pca != float("inf"):
-            train_features, coeff, train_feature_mean, explained_variance = reduce_features_pca(
-                train_features,
-                components_pca,
-            )
-            print("Explained Variance by " f"{components_pca} components: {explained_variance:.2f}%")
-            test_features = (test_features - train_feature_mean) @ coeff[:, :components_pca]
-
-        if classifier in ["gradient-boosting", "lasso", "svm-binary"]:
-            all_pred = np.zeros((test_features.shape[0], n_stim))
-            for stim in range(1, n_stim + 1):
-                if classifier == "gradient-boosting":
-                    model = train_gradient_boosting(
-                        train_features,
-                        train_labels == stim,
-                        classifier_param,
-                        random_state=random_state,
-                    )
-                elif classifier == "lasso":
-                    model = train_for_stimulus_lasso_glm(
-                        train_features,
-                        train_labels == stim,
-                        classifier_param,
-                        random_state=random_state,
-                    )
-                elif classifier == "svm-binary":
-                    model = train_binary_svm(
-                        train_features,
-                        train_labels == stim,
-                        classifier_param,
-                        random_state=random_state,
-                    )
-                if classifier in ["lasso", "svm-binary"]:
-                    all_pred[:, stim - 1] = _positive_class_score(model, test_features)
-                else:
-                    all_pred[:, stim - 1] = model.predict(test_features)
-            pred_lbl[fold == f] = np.argmax(all_pred, axis=1) + 1
-        else:
-            model = train_multiclass_classifier(
-                train_features,
-                train_labels,
-                classifier,
-                classifier_param,
-                random_state=random_state,
-            )
-            pred_lbl[fold == f] = model.predict(test_features)
-
-    if np.all(pred_lbl == 0):
-        print("All predictions are the null-class. Replace them to be fair with " "the binary classifiers for which one always decides on a label " "unequal to 0. Using 1.")
-        pred_lbl[pred_lbl == 0] = 1
-    elif np.any(pred_lbl == 0):
-        print(
-            "Some predictions are the null-class. Replace them to be fair with "
-            "the binary classifiers for which one always decides on a label "
-            "unequal to 0. Using least frequent label."
-        )
-        nonzero_labels, counts = np.unique(pred_lbl[pred_lbl > 0], return_counts=True)
-        min_label = nonzero_labels[np.argmin(counts)]
-        pred_lbl[pred_lbl == 0] = min_label
-
-    accuracy = np.mean(labels[labels > 0] == pred_lbl)
+    stimulus_feature_matrix = np.hstack(stimuli_features).T
+    null_feature_matrix = np.hstack(null_features).T if null_features else None
+    result = cross_validate_feature_decoding(
+        stimulus_feature_matrix,
+        labels,
+        null_features=null_feature_matrix,
+        n_folds=n_folds,
+        classifier=classifier,
+        classifier_param=classifier_param,
+        components_pca=components_pca,
+        random_state=random_state,
+        fit_model=lambda features, train_labels: train_multiclass_classifier(
+            features,
+            train_labels,
+            classifier,
+            classifier_param,
+            random_state=random_state,
+        ),
+    )
+    accuracy = result.accuracy
     print(f"Participant {participant_id}: {accuracy * 100:.2f}% accuracy")
 
     return accuracy
@@ -132,12 +69,6 @@ def cross_validate_single_dataset(
 
 # pylint: enable=too-many-arguments,too-many-positional-arguments
 # pylint: enable=too-many-locals,too-many-branches,too-many-statements
-
-
-def _positive_class_score(model, features):
-    if hasattr(model, "decision_function"):
-        return model.decision_function(features)
-    return model.predict_proba(features)[:, 1]
 
 
 if __name__ == "__main__":

--- a/src/pymegdec/model_transfer.py
+++ b/src/pymegdec/model_transfer.py
@@ -8,7 +8,8 @@ from pymegdec.classifiers import (
     train_multiclass_classifier,
 )
 from pymegdec.data_config import resolve_data_folder
-from pymegdec.preprocessing import preprocess_features, reduce_features_pca
+from pymegdec.preprocessing import preprocess_features
+from reptrace.decoding.transfer import evaluate_feature_transfer
 
 
 # jscpd:ignore-start
@@ -70,33 +71,34 @@ def evaluate_model_transfer(
         np.nan,
     )
 
-    features_train_exp = np.hstack(stimuli_features_train_exp + null_features_train_exp).T
-    labels_train_exp = np.concatenate((labels_train_exp, np.zeros(len(null_features_train_exp), dtype=int)))
-
+    features_train_exp = np.hstack(stimuli_features_train_exp).T
+    train_null_feature_matrix = np.hstack(null_features_train_exp).T if null_features_train_exp else None
     features_val_exp = np.hstack(stimuli_features_val_exp).T
 
-    pca_components = None
-    if components_pca != float("inf"):
-        features_train_exp, coeff, features_train_exp_mean, explained_variance = reduce_features_pca(
-            features_train_exp,
-            components_pca,
-        )
-        pca_components = coeff[:, :components_pca]
-        features_val_exp = (features_val_exp - features_train_exp_mean) @ pca_components
-        print("Explained Variance by " f"{components_pca} components: {explained_variance:.2f}%")
-
-    model = train_multiclass_classifier(
+    result = evaluate_feature_transfer(
         features_train_exp,
         labels_train_exp,
-        classifier,
-        classifier_param,
+        features_val_exp,
+        labels_val_exp,
+        train_null_features=train_null_feature_matrix,
+        classifier=classifier,
+        classifier_param=classifier_param,
+        components_pca=components_pca,
         random_state=random_state,
+        fit_model=lambda features, labels: train_multiclass_classifier(
+            features,
+            labels,
+            classifier,
+            classifier_param,
+            random_state=random_state,
+        ),
     )
-    predictions_val_exp = model.predict(features_val_exp)
+    if components_pca != float("inf"):
+        print("Explained Variance by " f"{components_pca} components: {result.model_bundle.explained_variance_percent:.2f}%")
 
-    accuracy = np.mean(predictions_val_exp == labels_val_exp)
+    accuracy = result.accuracy
     if return_feature_importance:
-        return accuracy, get_original_feature_importance(model, pca_components)
+        return accuracy, get_original_feature_importance(result.model_bundle.model, result.model_bundle.pca_coeff)
 
     return accuracy
 

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -24,11 +24,10 @@ from pymegdec.preprocessing import (
     filter_features,
 )
 from reptrace.decoding.temporal_generalization import TemporalFeatureWindow, compute_temporal_generalization_matrix  # pylint: disable=no-name-in-module
+from reptrace.decoding.transfer import append_null_class_features, evaluate_feature_transfer  # pylint: disable=no-name-in-module
 from reptrace.decoding.windowed import (
     fit_window_model as fit_reptrace_window_model,
-    permutation_accuracy_curve as reptrace_permutation_accuracy_curve,
     predict_window_model as predict_reptrace_window_model,
-    score_windowed_decoding,
 )
 from reptrace.metrics.confusion import (  # pylint: disable=no-name-in-module
     confusion_counts,
@@ -228,10 +227,7 @@ def evaluate_participant_stimulus_temporal_generalization(
 
     train_data = _prepare_data(train_data, config)
     validation_data = _prepare_data(validation_data, config)
-    train_windows = [
-        _temporal_feature_window(float(window_center), labels_train, config)
-        for window_center in config.window_centers
-    ]
+    train_windows = [_temporal_feature_window(float(window_center), labels_train, config) for window_center in config.window_centers]
     test_windows = [
         _temporal_feature_window(
             float(window_center),
@@ -870,10 +866,9 @@ def _train_window_model(train_data, labels_train, window_center, classifier_para
     train_window = _centered_window(window_center, config.window_size)
     null_window = _null_window(config)
     train_stimuli_features, train_null_features = extract_windows(train_data, train_window, null_window)
-    train_features = np.hstack(train_stimuli_features + train_null_features).T
-    train_labels = labels_train
-    if train_null_features:
-        train_labels = np.concatenate((labels_train, np.zeros(len(train_null_features), dtype=int)))
+    train_features = np.hstack(train_stimuli_features).T
+    train_null_features = np.hstack(train_null_features).T if train_null_features else None
+    train_features, train_labels = append_null_class_features(train_features, labels_train, train_null_features)
 
     return fit_reptrace_window_model(
         train_features,
@@ -1077,17 +1072,20 @@ def _evaluate_window(
     null_window = _null_window(config)
     train_stimuli_features, train_null_features = extract_windows(train_data, train_window, null_window)
     validation_stimuli_features, _ = extract_windows(validation_data, train_window, (np.nan, np.nan))
-    train_features = np.hstack(train_stimuli_features + train_null_features).T
-    train_labels = labels_train
-    if train_null_features:
-        train_labels = np.concatenate((labels_train, np.zeros(len(train_null_features), dtype=int)))
+    train_features = np.hstack(train_stimuli_features).T
+    train_null_features = np.hstack(train_null_features).T if train_null_features else None
     validation_features = np.hstack(validation_stimuli_features).T
 
-    decoding_result = score_windowed_decoding(
+    decoding_result = evaluate_feature_transfer(
         train_features,
-        train_labels,
+        labels_train,
         validation_features,
         labels_validation,
+        train_null_features=train_null_features,
+        classifier=config.classifier,
+        classifier_param=classifier_param,
+        components_pca=config.components_pca,
+        random_state=config.random_state,
         fit_model=lambda features, labels: train_multiclass_classifier(
             features,
             labels,
@@ -1095,7 +1093,6 @@ def _evaluate_window(
             classifier_param,
             random_state=config.random_state,
         ),
-        components_pca=config.components_pca,
         train_window=train_window,
         n_permutations=config.permutations,
         permutation_rng=permutation_rng,
@@ -1226,34 +1223,6 @@ def _to_float(value):
         return float(value)
     except (TypeError, ValueError):
         return np.nan
-
-
-def _permutation_accuracy_curve(
-    train_features,
-    validation_features,
-    labels_validation,
-    train_labels,
-    classifier,
-    classifier_param,
-    random_state,
-    n_permutations,
-    permutation_rng,
-):
-    return reptrace_permutation_accuracy_curve(
-        train_features,
-        validation_features=validation_features,
-        validation_labels=labels_validation,
-        train_labels=train_labels,
-        fit_model=lambda features, labels: train_multiclass_classifier(
-            features,
-            labels,
-            classifier,
-            classifier_param,
-            random_state=random_state,
-        ),
-        n_permutations=n_permutations,
-        permutation_rng=permutation_rng,
-    )
 
 
 def _summary_stats(values):


### PR DESCRIPTION
## Summary
- Delegate reusable cross-validation fold splitting, null-class handling, PCA, and scoring to `reptrace.decoding.transfer`.
- Route legacy model-transfer evaluation through `evaluate_feature_transfer` while keeping PyMEGDec-specific `.mat` loading, preprocessing, labels, and feature-importance mapping local.
- Route stimulus window scoring through the same transfer helper, including train-window metadata and permutation scoring, while PyMEGDec still owns MEG feature extraction and output rows.

## Important
This is stacked on IPS-Stuttgart/RepTrace#9. `pyproject.toml` temporarily depends on `IPS-Stuttgart/RepTrace.git@codex/transfer-decoding-core` so this branch can validate before the RepTrace transfer API is merged. After RepTrace#9 lands, this should be re-locked back to `@main` before marking ready.

## Validation
- `poetry run python -m unittest tests.test_cross_validation tests.test_model_transfer tests.test_classifiers tests.test_classifier_registry tests.test_stimulus_decoding -v`
- `poetry run ruff check src\pymegdec\cross_validation.py src\pymegdec\model_transfer.py src\pymegdec\stimulus_decoding.py src\pymegdec\classifiers.py tests\test_cross_validation.py tests\test_model_transfer.py tests\test_stimulus_decoding.py`
- `poetry check --lock`
- `git diff --check origin/main..HEAD`

Note: the local data-backed model-transfer/cross-validation tests skipped because this checkout does not have `PYMEGDEC_DATA_DIR` configured; synthetic and stimulus-decoding tests ran.