### PR TITLE
Remove generic PCA preprocessing helper

### DIFF
--- a/evaluate_model_transfer.py
+++ b/evaluate_model_transfer.py
@@ -24,7 +24,6 @@ from pymegdec.preprocessing import (  # noqa: E402
     extract_windows,
     filter_features,
     preprocess_features,
-    reduce_features_pca,
 )
 
 __all__ = [
@@ -36,7 +35,6 @@ __all__ = [
     "get_default_classifier_param",
     "get_original_feature_importance",
     "preprocess_features",
-    "reduce_features_pca",
     "train_multiclass_classifier",
 ]
 

--- a/src/pymegdec/preprocessing.py
+++ b/src/pymegdec/preprocessing.py
@@ -3,7 +3,6 @@
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.signal import butter, detrend, filtfilt
-from sklearn.decomposition import PCA
 
 
 def preprocess_features(

--- a/src/pymegdec/preprocessing.py
+++ b/src/pymegdec/preprocessing.py
@@ -95,18 +95,3 @@ def extract_windows(data, train_window, null_time_window):
         raise ValueError("Invalid null window")
 
     return stimuli_features_cell, null_features_cell
-
-
-def reduce_features_pca(features, n_components):
-    n_components = min(n_components, features.shape[0], features.shape[1])
-    pca = PCA(n_components=n_components)
-    features_train_exp_mean = np.mean(features, axis=0)
-    features_centered = features - features_train_exp_mean
-    reduced_features = pca.fit_transform(features_centered)
-    explained_variance = np.sum(pca.explained_variance_ratio_) * 100
-    return (
-        reduced_features,
-        pca.components_.T,
-        features_train_exp_mean,
-        explained_variance,
-    )


### PR DESCRIPTION
## Summary

- remove `reduce_features_pca` from `pymegdec.preprocessing`
- drop the legacy root-wrapper export for `reduce_features_pca`
- remove the now-unused `sklearn.decomposition.PCA` import

## Rationale

PCA feature-reduction bookkeeping is now handled by RepTrace's generic windowed decoding utilities. PyMEGDec should keep dataset-specific MATLAB/MEG preprocessing helpers rather than exposing generic decoding infrastructure.

## Validation

- Not run locally; connector-only change.