### PR TITLE
Update Poetry lockfile

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2288,8 +2288,8 @@ scikit-learn = "*"
 [package.source]
 type = "git"
 url = "https://github.com/IPS-Stuttgart/RepTrace.git"
-reference = "codex/transfer-decoding-core"
-resolved_reference = "3ab64df852fe4b4d5d951fc7bb0cea9b547dbd45"
+reference = "main"
+resolved_reference = "d39a92fdd001ec7f09dde70127e54cfabda5fc1e"
 
 [[package]]
 name = "requests"
@@ -2867,4 +2867,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "53fb4800041027fe5166e9eb1931e1b0e8cd7e2e4ec6f769a5a4176b421fe2bf"
+content-hash = "4b9b80783fa711cac7b36134e3c620b80741147a9501513e2190a3bac66aceaf"


### PR DESCRIPTION
## Summary

Regenerate `poetry.lock` from current `main` with `poetry lock`.

This updates the locked RepTrace git dependency from the old transfer-core branch to `main`, matching the current `pyproject.toml` dependency declaration, and refreshes the Poetry content hash.

## Validation

- `git pull --ff-only` on the existing PyMEGDec checkout
- `poetry lock`
- `poetry check`