### PR TITLE
Pin RepTrace dependency to 0.1.0 release

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2288,8 +2288,8 @@ scikit-learn = "*"
 [package.source]
 type = "git"
 url = "https://github.com/IPS-Stuttgart/RepTrace.git"
-reference = "main"
-resolved_reference = "d39a92fdd001ec7f09dde70127e54cfabda5fc1e"
+reference = "0.1.0"
+resolved_reference = "7fe273322ebc22c5b881567a0a5bdeccc6579d94"
 
 [[package]]
 name = "requests"
@@ -2867,4 +2867,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "4b9b80783fa711cac7b36134e3c620b80741147a9501513e2190a3bac66aceaf"
+content-hash = "e515de919b17b3348408ea9dd6890c22c4abfad864684f39ee0c5e1d2a32a04b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas>=3.0.2,<4.0.0",
-    "reptrace @ git+https://github.com/IPS-Stuttgart/RepTrace.git@main",
+    "reptrace @ git+https://github.com/IPS-Stuttgart/RepTrace.git@0.1.0",
     "scikit-learn",
     "scipy",
 ]


### PR DESCRIPTION
## Summary

- Pin PyMEGDec's RepTrace dependency to the `0.1.0` GitHub release tag instead of the moving `main` branch.
- This keeps the PyMEGDec/RepTrace integration tied to a stable RepTrace API release.

## Notes

- `IPS-Stuttgart/RepTrace@0.1.0` currently resolves to the same commit as RepTrace `main`, so this is a reproducibility pin rather than a functional dependency upgrade.
- I did not modify `poetry.lock` through the connector because the lockfile content was truncated by the file API. Please run `poetry lock --no-update` or `poetry lock` locally if Poetry reports a stale lockfile for this dependency reference change.

## Validation

- Verified via GitHub compare that `IPS-Stuttgart/RepTrace@0.1.0` and `IPS-Stuttgart/RepTrace@main` are currently identical.
- Diff limited to the RepTrace dependency reference in `pyproject.toml`.