### PR TITLE
Add Python CI matrix for PyMEGDec tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,35 @@ on:
       - main
 
 jobs:
-  unit:
+  unit-minimal:
+    name: Unit tests without optional ML deps (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install base dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry env use python
+          poetry install
+
+      - name: Run fast tests
+        run: poetry run python -m unittest discover -v
+
+  unit-ml-extras:
+    name: Unit tests with optional ML deps
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +56,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install dependencies
+      - name: Install package with optional ML dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -23,7 +23,6 @@ class TestMLPClassifierTorch(unittest.TestCase):
 
     def test_seeded_data_loaders_are_reproducible(self):
         try:
-            import torch  # noqa: F401
             from pymegdec.classifiers import _build_pytorch_data_loaders
         except ImportError as exc:
             self.skipTest(f"PyTorch dependencies are not installed: {exc}")

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -23,6 +23,7 @@ class TestMLPClassifierTorch(unittest.TestCase):
 
     def test_seeded_data_loaders_are_reproducible(self):
         try:
+            import torch  # noqa: F401
             from pymegdec.classifiers import _build_pytorch_data_loaders
         except ImportError as exc:
             self.skipTest(f"PyTorch dependencies are not installed: {exc}")


### PR DESCRIPTION
## Summary

- split the Python test workflow into minimal-install unit tests, ML-extra unit tests, and the existing private-data integration job
- run minimal-install fast tests across Python 3.11, 3.12, and 3.13 with `fail-fast: false`
- keep optional `torch`/`xgboost` ML-extra coverage on Python 3.12 so optional backends are still exercised without making every matrix leg heavy
- preserve the private-data integration job and its secret-gated skip behavior

## Validation

- Workflow-only change; not run locally.
- Checked the PR branch is one commit ahead of current `main` and modifies only `.github/workflows/tests.yml`.