### PR TITLE
Add structured MkDocs documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - README.md
+      - mkdocs.yml
+      - docs/**
+      - .github/workflows/docs.yml
+  push:
+    branches: [main]
+    paths:
+      - README.md
+      - mkdocs.yml
+      - docs/**
+      - .github/workflows/docs.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install documentation dependencies
+        run: python -m pip install mkdocs
+      - name: Build documentation
+        run: mkdocs build --strict

--- a/README.md
+++ b/README.md
@@ -1,55 +1,16 @@
 # PyMEGDec
 
-Utilities for MEG decoding experiments, including model transfer between experiment
-conditions and cross-validation on a single dataset.
-Reusable decoding summaries and prediction-table diagnostics are provided by
-RepTrace; PyMEGDec keeps the MEG-specific loading, preprocessing, and workflow
-entry points.
+PyMEGDec contains the MEG-specific analysis layer for decoding experiments. It
+loads participant MATLAB files, prepares MEG windows, runs model-transfer and
+cross-validation workflows, and exports stimulus, alpha, and reaction-time
+analysis tables.
 
-## Project boundary with RepTrace
+Generic decoding summaries and reusable prediction-table diagnostics belong in
+[RepTrace](https://github.com/IPS-Stuttgart/RepTrace). PyMEGDec keeps the
+project-specific data conventions, preprocessing defaults, CTF sensor-geometry
+handling, and paper-facing scripts.
 
-PyMEGDec owns the dataset-specific MEG analysis layer. Keep MATLAB `.mat`
-loading, `Part*Data.mat` / `Part*CueData.mat` participant-file conventions, CTF
-sensor geometry handling, alpha analyses, stimulus-specific defaults, and
-paper-facing scripts in this repository.
-
-RepTrace owns the reusable M/EEG decoding layer. Feature-matrix decoding,
-classifier calibration, temporal generalization, onset/state inference,
-confusion and per-class metrics, MNE `Epochs` decoding, and generic
-summary-table/reporting helpers should live in RepTrace and be imported here
-rather than duplicated.
-
-When adding new functionality, adapt PyMEGDec data into RepTrace's
-feature-matrix or probability-observation interfaces instead of duplicating
-reusable decoding logic here.
-
-## Repository layout
-
-```text
-src/pymegdec/              Package source code
-  alpha_signal.py          Alpha-band filtering and phase extraction
-  alpha_metrics.py         Per-trial alpha power and phase-gradient export
-  alpha_movement.py        Sensor-level alpha movement trajectory export
-  alpha_visualization.py   Alpha signal and phase-shift plotting helpers
-  reaction_time_analysis.py Alpha/RT join and association summaries
-  stimulus_decoding.py     Time-resolved train-main / validate-cue decoding
-  classifiers.py           Classifier factories and PyTorch Lightning model
-  preprocessing.py         Filtering, downsampling, window extraction
-  model_transfer.py        Train-on-experiment / validate-on-cue evaluation
-  cross_validation.py      Single-dataset cross-validation routine
-tests/                     Unit and data-dependent unittest suites
-.github/workflows/         CI jobs for unit and data-dependent test subsets
-```
-
-Top-level `cross_validation.py`, `evaluate_model_transfer.py`,
-`extract_alpha_signal.py`, `show_bandpass_signal_and_shifts.py`, and
-`export_alpha_metrics.py` are compatibility wrappers for existing imports and
-direct script usage. `analyze_alpha_reaction_time.py` provides an exploratory
-analysis command for alpha metrics and behavioral reaction times.
-`analyze_stimulus_decoding.py` exports time-resolved stimulus decoding curves.
-`analyze_alpha_movement.py` exports sensor-level alpha movement trajectories.
-
-## Setup
+## Quick start
 
 ```bash
 python -m pip install --upgrade pip
@@ -63,245 +24,42 @@ Install optional classifier backends when needed:
 poetry install --extras "all"
 ```
 
-## Data directory
-
-Participant data is configured at runtime so private or machine-specific paths
-do not need to be committed. Data files are expected to be named like
-`Part2Data.mat` and `Part2CueData.mat`.
-
-Resolution order:
-
-1. Pass `--data-dir` to a CLI command, or pass `data_folder` to the Python API.
-2. Set the `PYMEGDEC_DATA_DIR` environment variable.
-3. Create a local `.pymegdec-data-dir` file containing one path. The resolver
-   searches the current directory, its parents, and the project root.
-4. Fall back to the current working directory for backwards compatibility.
-
-`.pymegdec-data-dir` is ignored by git and can contain a path relative to the
-file location.
-
-On PowerShell:
-
-```powershell
-$env:PYMEGDEC_DATA_DIR = "C:\path\to\data"
-python -m unittest
-```
-
-## CLI usage
+Configure the data directory with `--data-dir`, `PYMEGDEC_DATA_DIR`, or an
+ignored `.pymegdec-data-dir` file. Participant files are expected to follow the
+`Part2Data.mat` and `Part2CueData.mat` naming convention.
 
 ```bash
-pymegdec-cross-validate --data-dir "/path/to/MEG-Data" --participant 2
-pymegdec-transfer --data-dir "/path/to/MEG-Data" --participant 2 --null-window-center nan
-pymegdec-stimulus-decoding --data-dir "/path/to/MEG-Data" --participants 2 --output outputs/part2_stimulus_decoding.csv
+pymegdec cross-validate --data-dir /path/to/MEG-Data --participant 2
+pymegdec transfer --data-dir /path/to/MEG-Data --participant 2 --null-window-center nan
+pymegdec stimulus-decoding --data-dir /path/to/MEG-Data --participants 2 --output outputs/part2_stimulus_decoding.csv
 ```
 
-The grouped command exposes the same workflows:
+## Documentation
+
+The longer workflow documentation lives in `docs/`:
+
+- `docs/getting-started.md` — installation, optional extras, and tests.
+- `docs/data.md` — data-directory resolution and participant-file conventions.
+- `docs/cli.md` — grouped CLI commands and compatibility entry points.
+- `docs/stimulus-decoding.md` — time-resolved stimulus decoding, diagnostics,
+  robustness exports, temporal generalization, and onset scanning.
+- `docs/alpha.md` — alpha metrics, sensor-level alpha movement, and alpha/RT
+  analysis.
+- `docs/api.md` — public Python entry points and module boundaries.
+- `docs/development.md` — test strategy and documentation maintenance.
+
+To preview the documentation locally:
 
 ```bash
-pymegdec cross-validate --participant 2
-pymegdec transfer --participant 2 --classifier multiclass-svm
-pymegdec stimulus-decoding --participants 2 --output outputs/part2_stimulus_decoding.csv
-```
-
-## Examples
-
-```python
-from pymegdec.model_transfer import evaluate_model_transfer
-from pymegdec.cross_validation import cross_validate_single_dataset
-
-transfer_accuracy = evaluate_model_transfer("/path/to/MEG-Data", 2, classifier="multiclass-svm")
-cv_accuracy = cross_validate_single_dataset("/path/to/MEG-Data", 2, classifier="multiclass-svm")
-```
-
-If `PYMEGDEC_DATA_DIR` or `.pymegdec-data-dir` is configured, the first argument
-can be `None`:
-
-```python
-transfer_accuracy = evaluate_model_transfer(None, 2, classifier="multiclass-svm")
-cv_accuracy = cross_validate_single_dataset(None, 2, classifier="multiclass-svm")
-```
-
-## Time-resolved stimulus decoding
-
-Stimulus decoding can be evaluated over a sequence of windows around stimulus
-onset. The command trains on `Part*Data.mat`, validates on `Part*CueData.mat`,
-and reports 16-way stimulus accuracy for each participant and window center.
-Pass `--transfer-direction cue-to-main` to swap the direction and train on cue
-data while validating on the main experiment data.
-By default it uses no null class, because the cue validation files do not
-contain null trials and the clean question is which of the 16 stimuli was shown.
-
-```powershell
-python analyze_stimulus_decoding.py --participants 2 --time-window=-0.2,0.6 --window-step-s 0.05 --output outputs\part2_stimulus_decoding.csv --summary-output outputs\part2_stimulus_decoding_summary.csv --plots-dir outputs\part2_stimulus_decoding_plots
-```
-
-The output CSV includes the stimulus-decoding accuracy, chance level, PCA
-variance, and class counts for every participant/window row. Add
-`--permutations N` to run label-shuffle tests (`N=0` by default, no permutation
-step). Summary CSV adds `n_significant_p_0.05` and `n_significant_p_0.01` and
-`n_with_permutation` per window.
-
-```powershell
-python analyze_stimulus_decoding.py `
-  --participants 2 `
-  --time-window=-0.2,0.6 `
-  --window-step-s 0.05 `
-  --permutations 200 `
-  --permutation-seed 42 `
-  --output outputs\part2_stimulus_decoding.csv `
-  --summary-output outputs\part2_stimulus_decoding_summary.csv `
-  --plots-dir outputs\part2_stimulus_decoding_plots
-```
-
-Peak-window diagnostics can be exported for selected windows. These write
-trial-level predictions, confusion counts, per-stimulus accuracy, and
-participant-level peak timing/accuracy.
-
-```powershell
-python analyze_stimulus_decoding.py `
-  --participants 2 `
-  --time-window=-0.2,0.6 `
-  --window-step-s 0.05 `
-  --diagnostic-window-centers 0.15,0.2,0.25 `
-  --predictions-output outputs\part2_stimulus_predictions.csv `
-  --confusion-output outputs\part2_stimulus_confusion.csv `
-  --per-stimulus-output outputs\part2_stimulus_per_stimulus.csv `
-  --participant-peaks-output outputs\part2_stimulus_participant_peaks.csv `
-  --output outputs\part2_stimulus_decoding.csv `
-  --summary-output outputs\part2_stimulus_decoding_summary.csv `
-  --plots-dir outputs\part2_stimulus_decoding_plots
-```
-
-The summary CSV and plot aggregate the curve across participants.
-
-For paper-facing confusion matrices, export only trial-level predictions at
-selected control/peak windows. Model labels are zero-based when
-`--null-window-center nan`, while `true_stimulus_id` and
-`predicted_stimulus_id` are one-based image ids.
-
-```powershell
-python scripts\export_stimulus_predictions.py `
-  --window-centers=-0.175,0.175 `
-  --output outputs\stimulus_predictions.csv `
-  --summary-output outputs\stimulus_prediction_summary.csv `
-  --confusion-output outputs\stimulus_predictions_confusion.csv `
-  --per-stimulus-output outputs\stimulus_predictions_per_stimulus.csv
-```
-
-For controls-first robustness checks, export the default two-window result plus
-reverse transfer, class-balanced SVM, PCA sensitivity, and 0-30 Hz controls:
-
-```powershell
-python scripts\export_stimulus_robustness.py `
-  --predictions-output outputs\stimulus_robustness_predictions.csv `
-  --accuracy-output outputs\stimulus_robustness_accuracy.csv `
-  --summary-output outputs\stimulus_robustness_summary.csv
-```
-
-Temporal generalization trains a separate model at each training window and
-tests each model across all validation windows. This produces a train-time by
-test-time matrix for assessing whether image information is transient or
-generalizes across post-stimulus time.
-
-```powershell
-python scripts\export_stimulus_temporal_generalization.py `
-  --participants 2 `
-  --time-window=-0.4,0.8 `
-  --window-step-s 0.025 `
-  --output outputs\part2_stimulus_temporal_generalization.csv `
-  --summary-output outputs\part2_stimulus_temporal_generalization_summary.csv
-```
-
-Onset-blind scanning trains one classifier at a known post-stimulus window and
-slides it over validation trials. This is a pseudo-continuous test with the
-current epoched data: the model is not given `t=0` while scanning, but the
-known onset is still used afterward to score detection latency and false alarms.
-
-```powershell
-python scripts\export_stimulus_onset_scan.py `
-  --participants 2 `
-  --train-window-center 0.175 `
-  --scan-time-window=-0.4,0.8 `
-  --window-step-s 0.025 `
-  --output outputs\part2_stimulus_onset_scan.csv `
-  --events-output outputs\part2_stimulus_onset_events.csv `
-  --summary-output outputs\part2_stimulus_onset_scan_summary.csv `
-  --event-summary-output outputs\part2_stimulus_onset_event_summary.csv
+python -m pip install mkdocs
+mkdocs serve
 ```
 
 ## Tests
-
-The default suite includes fast tests that run without private MEG files.
-Data-dependent accuracy checks are skipped when the data directory cannot be
-resolved.
 
 ```bash
 python -m unittest discover -v
 ```
 
-To run the data-dependent integration tests, point `PYMEGDEC_DATA_DIR` at a
-directory containing `Part2Data.mat` and `Part2CueData.mat` before running the
-same command.
-
-## Exploratory alpha metrics
-
-Prestimulus alpha metrics can be exported per trial for downstream plotting or
-statistics. By default the exporter uses the `MLO*`, `MRO*`, and `MZO*`
-occipital CTF channels and the `-0.4` to `-0.05 s` window before stimulus
-onset.
-
-```powershell
-python export_alpha_metrics.py --participant 2 --output outputs\part2_alpha_metrics.csv
-python export_alpha_metrics.py --participant 2 --cue --output outputs\part2_cue_alpha_metrics.csv
-```
-
-The exported rows include alpha power, phase concentration, planar phase-fit
-quality, spatial phase frequency, estimated propagation speed, and dominant
-phase-gradient direction on a projected sensor plane. The `outputs/` directory
-is ignored by git.
-
-## Sensor-level alpha movement
-
-The MAT files contain CTF sensor geometry in `data.grad.chanpos`, with positions
-in millimeters. This supports sensor-array analyses of alpha topography, but not
-source-localized brain movement. The movement exporter therefore tracks a
-sensor-level proxy: for each trial and sampled time point, it filters the chosen
-MEG channels to the alpha band, computes alpha power, and writes the
-power-weighted centroid over the MEG sensor positions.
-
-By default it uses all MEG channels matching `^M`, the `8-12 Hz` alpha band, and
-a `-0.4` to `0.8 s` window around stimulus onset.
-
-```powershell
-python analyze_alpha_movement.py --participants 2 --trajectory-output outputs\part2_alpha_movement.csv --summary-output outputs\part2_alpha_movement_summary.csv
-```
-
-The trajectory CSV includes 3D CTF sensor centroids, projected 2D centroids,
-stepwise speed, displacement from the first sampled time point, the peak-power
-channel, and a spatial concentration score. Treat the trajectory as movement of
-the measured alpha topography over sensors, not as anatomical source motion.
-
-Movement summaries can be analyzed into pre/post stimulus effects and simple
-condition-level plots:
-
-```powershell
-python analyze_alpha_movement_results.py --movement-summary outputs\part2_alpha_movement_summary.csv --effect-output outputs\part2_alpha_movement_effects.csv --condition-summary-output outputs\part2_alpha_movement_condition_summary.csv --plots-dir outputs\part2_alpha_movement_plots
-```
-
-The effects compare the mean pre-stimulus centroid with the mean post-stimulus
-centroid, and summarize speed, alpha power, and spatial concentration changes.
-
-## Alpha and reaction time
-
-The saved MEG `Part*Data.mat` files may not contain reaction times. The RT
-analysis command therefore accepts an external behavioral CSV with
-`participant`, `trial`, and `reaction_time` columns. If reaction times are stored
-in a future MAT `trialinfo` column, pass `--trialinfo-rt-column` instead.
-
-```powershell
-python analyze_alpha_reaction_time.py --participants 2 --reaction-times behavior_rt.csv --joined-output outputs\part2_alpha_rt_trials.csv --summary-output outputs\part2_alpha_rt_summary.csv
-```
-
-The summary includes per-participant Pearson/regression rows and a pooled
-within-participant row for each alpha metric. Phase-gradient direction is encoded
-as sine and cosine components before analysis.
+Fast tests run without private MEG files. Data-dependent tests are skipped when
+the participant MAT files cannot be resolved.

--- a/docs/alpha.md
+++ b/docs/alpha.md
@@ -1,0 +1,106 @@
+# Alpha analyses
+
+PyMEGDec contains exploratory alpha-band workflows for per-trial alpha metrics,
+sensor-level alpha topography movement, and alpha/reaction-time associations.
+
+## Alpha metrics
+
+Prestimulus alpha metrics are exported per trial for downstream plotting or
+statistics. The default channel selector uses occipital CTF channels matching
+`MLO*`, `MRO*`, and `MZO*`. The default time window is `-0.4` to `-0.05 s`
+before stimulus onset, and the default alpha band is `8–12 Hz`.
+
+```powershell
+python export_alpha_metrics.py --participant 2 --output outputs\part2_alpha_metrics.csv
+python export_alpha_metrics.py --participant 2 --cue --output outputs\part2_cue_alpha_metrics.csv
+```
+
+The exported rows include:
+
+- Alpha power.
+- Phase concentration.
+- Planar phase-fit quality.
+- Spatial phase frequency.
+- Estimated propagation speed.
+- Dominant phase-gradient direction on a projected sensor plane.
+
+The `outputs/` directory is ignored by git.
+
+## Sensor-level alpha movement
+
+The MAT files contain CTF sensor geometry in `data.grad.chanpos`, with positions
+in millimeters. PyMEGDec uses this geometry for sensor-array analyses of alpha
+topography. The movement exporter does not infer source-localized anatomical
+motion.
+
+For each trial and sampled time point, the exporter filters selected MEG
+channels to the alpha band, computes alpha power, and writes the power-weighted
+centroid over the MEG sensor positions.
+
+Defaults:
+
+- Channel pattern: `^M`, covering all MEG channels.
+- Alpha band: `8–12 Hz`.
+- Time window: `-0.4` to `0.8 s` around stimulus onset.
+
+```powershell
+python analyze_alpha_movement.py `
+  --participants 2 `
+  --trajectory-output outputs\part2_alpha_movement.csv `
+  --summary-output outputs\part2_alpha_movement_summary.csv
+```
+
+The trajectory CSV includes 3D CTF sensor centroids, projected 2D centroids,
+stepwise speed, displacement from the first sampled time point, the peak-power
+channel, and a spatial concentration score. Treat the trajectory as movement of
+the measured alpha topography over sensors, not as anatomical source motion.
+
+## Alpha movement result analysis
+
+Analyze movement summaries into pre/post-stimulus effects and condition-level
+plots:
+
+```powershell
+python analyze_alpha_movement_results.py `
+  --movement-summary outputs\part2_alpha_movement_summary.csv `
+  --effect-output outputs\part2_alpha_movement_effects.csv `
+  --condition-summary-output outputs\part2_alpha_movement_condition_summary.csv `
+  --plots-dir outputs\part2_alpha_movement_plots
+```
+
+Equivalent grouped command:
+
+```bash
+pymegdec alpha-movement-results \
+  --movement-summary outputs/part2_alpha_movement_summary.csv \
+  --effect-output outputs/part2_alpha_movement_effects.csv \
+  --condition-summary-output outputs/part2_alpha_movement_condition_summary.csv \
+  --plots-dir outputs/part2_alpha_movement_plots
+```
+
+The effects compare the mean pre-stimulus centroid with the mean post-stimulus
+centroid and summarize speed, alpha power, and spatial concentration changes.
+
+## Alpha and reaction time
+
+Saved `Part*Data.mat` files may not contain reaction times. The RT analysis
+command therefore accepts an external behavioral CSV with these columns:
+
+```text
+participant,trial,reaction_time
+```
+
+If reaction times are stored in a future MAT `trialinfo` column, pass
+`--trialinfo-rt-column` instead.
+
+```powershell
+python analyze_alpha_reaction_time.py `
+  --participants 2 `
+  --reaction-times behavior_rt.csv `
+  --joined-output outputs\part2_alpha_rt_trials.csv `
+  --summary-output outputs\part2_alpha_rt_summary.csv
+```
+
+The summary includes per-participant Pearson/regression rows and a pooled
+within-participant row for each alpha metric. Phase-gradient direction is encoded
+as sine and cosine components before analysis.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,111 @@
+# Python API
+
+Prefer importing from `pymegdec.*` modules instead of top-level compatibility
+wrappers. The top-level scripts remain available for historical command-line and
+notebook usage.
+
+## Model transfer and cross-validation
+
+```python
+from pymegdec.model_transfer import evaluate_model_transfer
+from pymegdec.cross_validation import cross_validate_single_dataset
+
+transfer_accuracy = evaluate_model_transfer(
+    "/path/to/MEG-Data",
+    2,
+    classifier="multiclass-svm",
+)
+
+cv_accuracy = cross_validate_single_dataset(
+    "/path/to/MEG-Data",
+    2,
+    classifier="multiclass-svm",
+)
+```
+
+If `PYMEGDEC_DATA_DIR` or `.pymegdec-data-dir` is configured, pass `None` for the
+first argument:
+
+```python
+transfer_accuracy = evaluate_model_transfer(None, 2, classifier="multiclass-svm")
+cv_accuracy = cross_validate_single_dataset(None, 2, classifier="multiclass-svm")
+```
+
+## Stimulus decoding
+
+Use `StimulusDecodingConfig` to make time-resolved decoding parameters explicit:
+
+```python
+from pymegdec.stimulus_decoding import (
+    StimulusDecodingConfig,
+    export_time_resolved_stimulus_decoding,
+    window_centers_from_range,
+)
+
+config = StimulusDecodingConfig(
+    window_centers=window_centers_from_range((-0.2, 0.6), 0.05),
+    window_size=0.1,
+    null_window_center=float("nan"),
+    classifier="multiclass-svm",
+    components_pca=100,
+)
+
+rows, summary_rows = export_time_resolved_stimulus_decoding(
+    data_folder="/path/to/MEG-Data",
+    participants=[2],
+    output_path="outputs/part2_stimulus_decoding.csv",
+    summary_output_path="outputs/part2_stimulus_decoding_summary.csv",
+    config=config,
+)
+```
+
+## Data-directory resolver
+
+Use `resolve_data_folder` when writing new workflows that need participant MAT
+files:
+
+```python
+from pymegdec.data_config import resolve_data_folder
+
+data_folder = resolve_data_folder(
+    None,
+    required=True,
+    required_files=["Part2Data.mat", "Part2CueData.mat"],
+)
+```
+
+Resolution order is documented in [Data configuration](data.md).
+
+## Alpha metrics
+
+Alpha metric command-line scripts share parsing helpers from `pymegdec.cli` and
+write CSV rows through the alpha metrics utilities. For new code, keep the core
+calculation in package modules and let top-level scripts handle command-line
+argument parsing only.
+
+## Classifiers
+
+`pymegdec.classifiers.CLASSIFIER_REGISTRY` extends the RepTrace classifier
+registry with PyMEGDec-specific optional backends:
+
+- `xgboost`, installed with the `xgboost` extra.
+- `pytorch-mlp`, installed with the `torch` extra.
+
+Use `pymegdec.classifiers.get_default_classifier_param(classifier)` when a
+workflow wants the package default for a classifier.
+
+## Module ownership
+
+| Module | Responsibility |
+| --- | --- |
+| `data_config.py` | Runtime data-directory resolution. |
+| `preprocessing.py` | Filtering, downsampling, window extraction, and PCA preparation. |
+| `classifiers.py` | Classifier registry and optional PyMEGDec backends. |
+| `cross_validation.py` | Single-dataset participant cross-validation. |
+| `model_transfer.py` | Train-main / validate-cue transfer evaluation. |
+| `stimulus_decoding.py` | Time-resolved stimulus decoding and diagnostic summaries. |
+| `alpha_signal.py` | Alpha filtering and phase extraction. |
+| `alpha_metrics.py` | Per-trial alpha power and phase-gradient metrics. |
+| `alpha_movement.py` | Sensor-level alpha centroid trajectories. |
+| `alpha_movement_analysis.py` | Pre/post movement summaries and plots. |
+| `reaction_time_analysis.py` | Alpha/RT joins and association summaries. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,108 @@
+# CLI reference
+
+PyMEGDec exposes one grouped command plus compatibility entry points. Prefer the
+grouped `pymegdec` command for new documentation and scripts.
+
+## Grouped command
+
+```bash
+pymegdec --help
+```
+
+Available subcommands:
+
+```bash
+pymegdec cross-validate --participant 2
+pymegdec transfer --participant 2 --classifier multiclass-svm
+pymegdec stimulus-decoding --participants 2 --output outputs/part2_stimulus_decoding.csv
+pymegdec alpha-movement-results --movement-summary outputs/part2_alpha_movement_summary.csv --effect-output outputs/part2_alpha_movement_effects.csv --condition-summary-output outputs/part2_alpha_movement_condition_summary.csv
+```
+
+## Compatibility entry points
+
+The package also installs these script names:
+
+```bash
+pymegdec-cross-validate
+pymegdec-transfer
+pymegdec-stimulus-decoding
+pymegdec-alpha-movement-results
+```
+
+Top-level Python wrappers remain available for existing workflows, for example:
+
+```bash
+python analyze_stimulus_decoding.py --participants 2 --output outputs/part2_stimulus_decoding.csv
+python export_alpha_metrics.py --participant 2 --output outputs/part2_alpha_metrics.csv
+python analyze_alpha_movement.py --participants 2 --trajectory-output outputs/part2_alpha_movement.csv --summary-output outputs/part2_alpha_movement_summary.csv
+```
+
+## Shared decoding options
+
+The cross-validation and transfer commands share the core decoding options:
+
+| Option | Meaning | Typical value |
+| --- | --- | --- |
+| `--data-dir` | Directory containing participant MAT files. | `/path/to/MEG-Data` |
+| `--participant` | Participant id. | `2` |
+| `--window-size` | Window duration in seconds. | `0.1` |
+| `--train-window-center` | Stimulus training-window center in seconds. | `0.2` |
+| `--null-window-center` | Null-window center, or `nan`. | `nan` or `-0.2` |
+| `--new-framerate` | Target frame rate, or `inf`. | `inf` |
+| `--classifier` | Classifier registry name. | `multiclass-svm` |
+| `--classifier-param` | Numeric, JSON, or Python literal parameter. | `1.0` |
+| `--components-pca` | PCA component count, or `inf`. | `100` |
+| `--frequency-range LOW HIGH` | Frequency range in Hz. | `0 inf` |
+
+## Cross-validation
+
+Cross-validate one participant's main dataset:
+
+```bash
+pymegdec cross-validate --data-dir /path/to/MEG-Data --participant 2 --folds 10
+```
+
+The command prints the accuracy returned by
+`pymegdec.cross_validation.cross_validate_single_dataset`.
+
+## Model transfer
+
+Train on the main experiment file and validate on the cue file for one
+participant:
+
+```bash
+pymegdec transfer --data-dir /path/to/MEG-Data --participant 2 --null-window-center nan
+```
+
+The command prints the accuracy returned by
+`pymegdec.model_transfer.evaluate_model_transfer`.
+
+## Stimulus decoding
+
+Run train-main / validate-cue decoding across a time range:
+
+```bash
+pymegdec stimulus-decoding \
+  --data-dir /path/to/MEG-Data \
+  --participants 2 \
+  --time-window=-0.2,0.6 \
+  --window-step-s 0.05 \
+  --output outputs/part2_stimulus_decoding.csv \
+  --summary-output outputs/part2_stimulus_decoding_summary.csv \
+  --plots-dir outputs/part2_stimulus_decoding_plots
+```
+
+Use `--transfer-direction cue-to-main` to train on cue data and validate on the
+main experiment data.
+
+## Alpha movement result analysis
+
+Analyze a movement summary exported by `analyze_alpha_movement.py`:
+
+```bash
+pymegdec alpha-movement-results \
+  --movement-summary outputs/part2_alpha_movement_summary.csv \
+  --effect-output outputs/part2_alpha_movement_effects.csv \
+  --condition-summary-output outputs/part2_alpha_movement_condition_summary.csv \
+  --plots-dir outputs/part2_alpha_movement_plots
+```

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,73 @@
+# Data configuration
+
+PyMEGDec intentionally resolves private or machine-specific data paths at
+runtime. Do not commit local paths or participant data files.
+
+## Expected files
+
+Participant data files are expected to use these names:
+
+```text
+Part2Data.mat
+Part2CueData.mat
+```
+
+Replace `2` with the participant id. Workflows that transfer between the main
+experiment and cue experiment require both files for a participant.
+
+## Resolution order
+
+PyMEGDec resolves the data directory in this order:
+
+1. A command-line `--data-dir` option, or the `data_folder` argument in the
+   Python API.
+2. The `PYMEGDEC_DATA_DIR` environment variable.
+3. A local `.pymegdec-data-dir` file containing one path. The resolver searches
+   the current working directory, its parents, and the project root.
+4. The current working directory, preserved for backwards compatibility.
+
+The `.pymegdec-data-dir` file is ignored by git. It may contain an absolute path
+or a path relative to the file location. Blank lines and lines starting with
+`#` are ignored.
+
+## Examples
+
+Pass the directory explicitly:
+
+```bash
+pymegdec stimulus-decoding --data-dir /path/to/MEG-Data --participants 2 --output outputs/part2_stimulus_decoding.csv
+```
+
+Set an environment variable on macOS/Linux:
+
+```bash
+export PYMEGDEC_DATA_DIR=/path/to/MEG-Data
+python -m unittest discover -v
+```
+
+Set an environment variable on PowerShell:
+
+```powershell
+$env:PYMEGDEC_DATA_DIR = "C:\path\to\MEG-Data"
+python -m unittest discover -v
+```
+
+Use a local config file:
+
+```bash
+echo /path/to/MEG-Data > .pymegdec-data-dir
+pymegdec transfer --participant 2 --null-window-center nan
+```
+
+## Participant ranges
+
+Commands that accept multiple participants use compact participant specs such as:
+
+```text
+2
+1-4
+1-4,6,8
+```
+
+When participants are omitted, workflows that require main and cue data search
+for ids that have both `Part*Data.mat` and `Part*CueData.mat` available.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,70 @@
+# Development
+
+## Test strategy
+
+Run the full default suite from the repository root:
+
+```bash
+python -m unittest discover -v
+```
+
+The suite includes fast tests that do not require private MEG files. Tests that
+need participant MAT files should skip cleanly when the data directory cannot be
+resolved.
+
+To run data-dependent tests, configure the data directory first:
+
+```bash
+export PYMEGDEC_DATA_DIR=/path/to/MEG-Data
+python -m unittest discover -v
+```
+
+On PowerShell:
+
+```powershell
+$env:PYMEGDEC_DATA_DIR = "C:\path\to\MEG-Data"
+python -m unittest discover -v
+```
+
+## Static checks
+
+The project configuration includes Ruff, mypy, Black, isort, and pylint settings
+in `pyproject.toml`. Use the GitHub Actions workflows as the source of truth for
+which checks are required before merging.
+
+## Documentation maintenance
+
+Documentation is source-controlled Markdown in `docs/` and is built with
+MkDocs. Keep the README short and move detailed workflow instructions into the
+relevant documentation page.
+
+Recommended structure for future additions:
+
+- New user workflow: add or update a page under `docs/` and link it from
+  `mkdocs.yml`.
+- New command-line option: document it in `docs/cli.md` or the workflow-specific
+  page.
+- New output table: document the producer command, row granularity, and the most
+  important columns near the workflow that creates it.
+- New reusable decoding method: consider whether it belongs in RepTrace instead
+  of PyMEGDec.
+
+Preview locally:
+
+```bash
+python -m pip install mkdocs
+mkdocs serve
+```
+
+Validate before committing:
+
+```bash
+mkdocs build --strict
+```
+
+## Output and provenance guidelines
+
+When adding new exports, prefer explicit output paths and deterministic rows.
+For paper-facing workflows, include enough metadata columns to reconstruct the
+run, for example participant id, train/validation direction, window center,
+classifier, PCA setting, frequency range, and random seed where applicable.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,70 @@
+# Getting started
+
+## Requirements
+
+PyMEGDec targets Python `>=3.11,<3.14`. The project uses Poetry for local
+development and dependency resolution.
+
+## Install for development
+
+From the repository root:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install poetry
+poetry install
+```
+
+Run commands inside the Poetry environment:
+
+```bash
+poetry run pymegdec --help
+poetry run python -m unittest discover -v
+```
+
+## Optional classifier backends
+
+The default install includes the core scientific stack and the RepTrace-backed
+classifier registry. Additional classifier backends are available through extras:
+
+```bash
+poetry install --extras "xgboost"
+poetry install --extras "torch"
+poetry install --extras "all"
+```
+
+The PyMEGDec-specific classifier additions are:
+
+- `xgboost`, which requires the `xgboost` extra.
+- `pytorch-mlp`, which requires the `torch` extra.
+
+Other classifier names are inherited from RepTrace's classifier registry.
+
+## Smoke tests
+
+Run the default test suite:
+
+```bash
+python -m unittest discover -v
+```
+
+Fast unit tests are designed to run without private MEG files. Data-dependent
+integration tests are skipped when the data directory cannot be resolved.
+
+To run the integration checks, configure a data directory containing files such
+as `Part2Data.mat` and `Part2CueData.mat` before invoking the same test command.
+
+## Documentation preview
+
+The documentation is plain Markdown under `docs/` and can be served with MkDocs:
+
+```bash
+python -m pip install mkdocs
+mkdocs serve
+```
+
+Build the static site locally with strict link checking:
+
+```bash
+mkdocs build --strict
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,58 @@
+# PyMEGDec documentation
+
+PyMEGDec provides project-specific utilities for MEG decoding experiments. The
+package focuses on workflows that need the repository's participant-file naming
+conventions, MATLAB `.mat` loading, CTF sensor geometry, MEG preprocessing, and
+paper-facing exports.
+
+The usual workflow is:
+
+1. Configure the local MEG data directory.
+2. Choose a participant or participant range.
+3. Run cross-validation, model transfer, stimulus decoding, alpha-metric export,
+   sensor-level alpha-movement export, or alpha/reaction-time analysis.
+4. Analyze the exported CSV tables and plots.
+
+## Boundary with RepTrace
+
+PyMEGDec should keep code that is tied to this MEG dataset and its analysis
+scripts:
+
+- `Part*Data.mat` and `Part*CueData.mat` conventions.
+- Dataset-specific MATLAB loading and trial metadata interpretation.
+- CTF sensor-position handling for alpha topography and movement proxies.
+- Stimulus-decoding defaults used by the project workflows.
+- Compatibility wrappers for existing scripts.
+
+Reusable decoding functionality should live in
+[RepTrace](https://github.com/IPS-Stuttgart/RepTrace) and be imported here:
+
+- Feature-matrix and MNE `Epochs` decoding helpers.
+- Classifier calibration and prediction diagnostics.
+- Generic confusion/per-class metrics.
+- Temporal generalization, onset/state inference, and report aggregation.
+
+## Repository layout
+
+```text
+src/pymegdec/              Package source code
+  alpha_signal.py          Alpha-band filtering and phase extraction
+  alpha_metrics.py         Per-trial alpha power and phase-gradient export
+  alpha_movement.py        Sensor-level alpha movement trajectory export
+  alpha_visualization.py   Alpha signal and phase-shift plotting helpers
+  reaction_time_analysis.py Alpha/RT joins and association summaries
+  stimulus_decoding.py     Time-resolved train-main / validate-cue decoding
+  classifiers.py           Classifier registry and optional model backends
+  preprocessing.py         Filtering, downsampling, window extraction
+  model_transfer.py        Train-on-experiment / validate-on-cue evaluation
+  cross_validation.py      Single-dataset cross-validation routine
+scripts/                   Paper-facing and diagnostic exports
+tests/                     Unit and data-dependent unittest suites
+.github/workflows/         CI jobs for unit and data-dependent test subsets
+```
+
+Top-level files such as `cross_validation.py`, `evaluate_model_transfer.py`,
+`export_alpha_metrics.py`, `analyze_stimulus_decoding.py`, and
+`analyze_alpha_movement.py` are compatibility entry points for direct script use.
+New code should prefer the package modules under `src/pymegdec/` and the grouped
+`pymegdec` command where possible.

--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -1,0 +1,147 @@
+# Stimulus decoding workflows
+
+Stimulus decoding evaluates image identity over time. The default direction
+trains on `Part*Data.mat`, validates on `Part*CueData.mat`, and reports 16-way
+stimulus accuracy for each participant and window center.
+
+Use `--transfer-direction cue-to-main` to swap the direction and train on cue
+data while validating on the main experiment data.
+
+By default, stimulus decoding uses no null class because the cue validation
+files do not contain null trials; the direct question is which of the 16 stimuli
+was shown.
+
+## Time-resolved decoding curve
+
+```powershell
+python analyze_stimulus_decoding.py `
+  --participants 2 `
+  --time-window=-0.2,0.6 `
+  --window-step-s 0.05 `
+  --output outputs\part2_stimulus_decoding.csv `
+  --summary-output outputs\part2_stimulus_decoding_summary.csv `
+  --plots-dir outputs\part2_stimulus_decoding_plots
+```
+
+The participant/window CSV includes decoding accuracy, chance level, PCA
+variance, and class counts. The summary CSV aggregates across participants by
+window center.
+
+Equivalent grouped command:
+
+```bash
+pymegdec stimulus-decoding \
+  --participants 2 \
+  --time-window=-0.2,0.6 \
+  --window-step-s 0.05 \
+  --output outputs/part2_stimulus_decoding.csv \
+  --summary-output outputs/part2_stimulus_decoding_summary.csv \
+  --plots-dir outputs/part2_stimulus_decoding_plots
+```
+
+## Permutation p-values
+
+Add label-shuffle tests with `--permutations N`. `N=0` disables the permutation
+step.
+
+```powershell
+python analyze_stimulus_decoding.py `
+  --participants 2 `
+  --time-window=-0.2,0.6 `
+  --window-step-s 0.05 `
+  --permutations 200 `
+  --permutation-seed 42 `
+  --output outputs\part2_stimulus_decoding.csv `
+  --summary-output outputs\part2_stimulus_decoding_summary.csv `
+  --plots-dir outputs\part2_stimulus_decoding_plots
+```
+
+The summary output adds `n_significant_p_0.05`, `n_significant_p_0.01`, and
+`n_with_permutation` per window.
+
+## Peak-window diagnostics
+
+Export trial-level predictions, confusion counts, per-stimulus accuracy, and
+participant-level peak timing for selected windows:
+
+```powershell
+python analyze_stimulus_decoding.py `
+  --participants 2 `
+  --time-window=-0.2,0.6 `
+  --window-step-s 0.05 `
+  --diagnostic-window-centers 0.15,0.2,0.25 `
+  --predictions-output outputs\part2_stimulus_predictions.csv `
+  --confusion-output outputs\part2_stimulus_confusion.csv `
+  --per-stimulus-output outputs\part2_stimulus_per_stimulus.csv `
+  --participant-peaks-output outputs\part2_stimulus_participant_peaks.csv `
+  --output outputs\part2_stimulus_decoding.csv `
+  --summary-output outputs\part2_stimulus_decoding_summary.csv `
+  --plots-dir outputs\part2_stimulus_decoding_plots
+```
+
+When diagnostics are requested through `pymegdec stimulus-decoding`, pass
+`--diagnostic-window-centers` together with the diagnostic output paths.
+
+## Paper-facing prediction exports
+
+For confusion matrices and paper-facing trial-level tables, export predictions
+at selected control and peak windows:
+
+```powershell
+python scripts\export_stimulus_predictions.py `
+  --window-centers=-0.175,0.175 `
+  --output outputs\stimulus_predictions.csv `
+  --summary-output outputs\stimulus_prediction_summary.csv `
+  --confusion-output outputs\stimulus_predictions_confusion.csv `
+  --per-stimulus-output outputs\stimulus_predictions_per_stimulus.csv
+```
+
+Model labels are zero-based when `--null-window-center nan`. The exported
+`true_stimulus_id` and `predicted_stimulus_id` columns use one-based image ids.
+
+## Robustness checks
+
+The controls-first robustness export writes the default two-window result plus
+reverse transfer, class-balanced SVM, PCA sensitivity, and 0–30 Hz controls:
+
+```powershell
+python scripts\export_stimulus_robustness.py `
+  --predictions-output outputs\stimulus_robustness_predictions.csv `
+  --accuracy-output outputs\stimulus_robustness_accuracy.csv `
+  --summary-output outputs\stimulus_robustness_summary.csv
+```
+
+## Temporal generalization
+
+Temporal generalization trains a separate model at each training window and
+tests each model across all validation windows. The output is a train-time by
+test-time matrix for assessing whether stimulus information is transient or
+generalizes across post-stimulus time.
+
+```powershell
+python scripts\export_stimulus_temporal_generalization.py `
+  --participants 2 `
+  --time-window=-0.4,0.8 `
+  --window-step-s 0.025 `
+  --output outputs\part2_stimulus_temporal_generalization.csv `
+  --summary-output outputs\part2_stimulus_temporal_generalization_summary.csv
+```
+
+## Onset-blind scanning
+
+Onset scanning trains one classifier at a known post-stimulus window and slides
+it over validation trials. With the current epoched data this is a
+pseudo-continuous test: the model is not given `t=0` while scanning, but the
+known onset is used afterward to score detection latency and false alarms.
+
+```powershell
+python scripts\export_stimulus_onset_scan.py `
+  --participants 2 `
+  --train-window-center 0.175 `
+  --scan-time-window=-0.4,0.8 `
+  --window-step-s 0.025 `
+  --output outputs\part2_stimulus_onset_scan.csv `
+  --events-output outputs\part2_stimulus_onset_events.csv `
+  --summary-output outputs\part2_stimulus_onset_scan_summary.csv `
+  --event-summary-output outputs\part2_stimulus_onset_event_summary.csv
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: PyMEGDec
+site_description: MEG decoding utilities for model-transfer, stimulus-decoding, alpha, and reaction-time analyses.
+repo_url: https://github.com/IPS-Stuttgart/PyMEGDec
+repo_name: IPS-Stuttgart/PyMEGDec
+
+theme:
+  name: readthedocs
+
+nav:
+  - Overview: index.md
+  - Getting started: getting-started.md
+  - Data configuration: data.md
+  - CLI reference: cli.md
+  - Stimulus decoding: stimulus-decoding.md
+  - Alpha analyses: alpha.md
+  - Python API: api.md
+  - Development: development.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true


### PR DESCRIPTION
Summary:

- Shortens README to project overview, quick start, docs index, and test command.
- Adds MkDocs configuration plus structured documentation pages for setup, data configuration, CLI usage, stimulus decoding, alpha analyses, Python API, and development notes.
- Adds a docs build workflow for documentation changes.

Testing: not run locally in this environment.