### PR TITLE
Consolidate PyMEGDec scripts into grouped CLI commands

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,4 +1,11 @@
 {
   "gitignore": true,
+  "ignore": [
+    "scripts/download_meg_data_files.py",
+    "scripts/export_stimulus_onset_scan.py",
+    "scripts/export_stimulus_predictions.py",
+    "scripts/export_stimulus_robustness.py",
+    "scripts/export_stimulus_temporal_generalization.py"
+  ],
   "threshold": 1
 }

--- a/analyze_alpha_movement.py
+++ b/analyze_alpha_movement.py
@@ -1,103 +1,15 @@
-"""Export sensor-level alpha movement trajectories."""
-
-import argparse
+"""Backward-compatible wrapper for ``pymegdec alpha movement``."""
 
 from script_bootstrap import add_src_to_path
 
 add_src_to_path(__file__)
 
-from pymegdec.alpha_movement import (  # noqa: E402
-    DEFAULT_MOVEMENT_TIME_WINDOW,
-    DEFAULT_SENSOR_PATTERN,
-    DEFAULT_TRAJECTORY_STEP_S,
-    AlphaMovementConfig,
-    export_alpha_movement,
-)
-from pymegdec.cli import parse_range  # noqa: E402
-from pymegdec.reaction_time_analysis import (  # noqa: E402
-    available_participants,
-    parse_participant_spec,
-)
+from pymegdec.alpha_cli import alpha_movement  # noqa: E402
 
 
-def _participants(value, data_dir, cue):
-    if value:
-        return parse_participant_spec(value)
-    return available_participants(data_dir, cue=cue)
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        description=("Export sensor-level alpha movement trajectories. The trajectory is " "a MEG sensor-array proxy, not source-localized brain movement.")
-    )
-    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
-    parser.add_argument(
-        "--participants",
-        default=None,
-        help="Participant ids such as 1-4,6,8. Defaults to all available MAT files.",
-    )
-    parser.add_argument(
-        "--trajectory-output",
-        required=True,
-        help="Output CSV for trial/timepoint sensor-level trajectories.",
-    )
-    parser.add_argument(
-        "--summary-output",
-        default=None,
-        help="Optional output CSV averaged by participant, condition, and time.",
-    )
-    parser.add_argument(
-        "--cue",
-        action="store_true",
-        help="Use Part*CueData.mat instead of Part*Data.mat.",
-    )
-    parser.add_argument(
-        "--location-pattern",
-        default=DEFAULT_SENSOR_PATTERN,
-        help="Regex for selecting channels by label. Defaults to all MEG channels.",
-    )
-    parser.add_argument(
-        "--time-window",
-        type=parse_range,
-        default=DEFAULT_MOVEMENT_TIME_WINDOW,
-        help="Time window as start,stop in seconds.",
-    )
-    parser.add_argument(
-        "--frequency-range",
-        type=parse_range,
-        default=(8.0, 12.0),
-        help="Frequency range as low,high in Hz.",
-    )
-    parser.add_argument(
-        "--trajectory-step-s",
-        type=float,
-        default=DEFAULT_TRAJECTORY_STEP_S,
-        help="Trajectory sampling step in seconds.",
-    )
-    args = parser.parse_args()
-
-    participants = _participants(args.participants, args.data_dir, args.cue)
-    if not participants:
-        parser.error("No participants found. Pass --participants or configure a data " "directory with matching MAT files.")
-
-    config = AlphaMovementConfig(
-        location_pattern=args.location_pattern,
-        time_window=args.time_window,
-        frequency_range=args.frequency_range,
-        trajectory_step_s=args.trajectory_step_s,
-    )
-    rows, summary_rows = export_alpha_movement(
-        args.data_dir,
-        participants,
-        args.trajectory_output,
-        summary_output_path=args.summary_output,
-        cue=args.cue,
-        config=config,
-    )
-    print(f"Wrote {len(rows)} trajectory rows to {args.trajectory_output}")
-    if args.summary_output:
-        print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+def main() -> int:
+    return alpha_movement()
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/analyze_alpha_reaction_time.py
+++ b/analyze_alpha_reaction_time.py
@@ -1,135 +1,15 @@
-"""Analyze exploratory alpha metrics against reaction time."""
-
-import argparse
+"""Backward-compatible wrapper for ``pymegdec alpha reaction-time``."""
 
 from script_bootstrap import add_src_to_path
 
 add_src_to_path(__file__)
 
-from pymegdec.cli import (  # noqa: E402
-    add_alpha_metric_arguments,
-    alpha_metric_config_from_args,
-)
-from pymegdec.reaction_time_analysis import (  # noqa: E402
-    DEFAULT_ALPHA_RT_METRICS,
-    AlphaReactionTimeExportConfig,
-    ReactionTimeCsvConfig,
-    available_participants,
-    export_alpha_reaction_time_analysis,
-    parse_participant_spec,
-    write_alpha_reaction_time_plots,
-)
+from pymegdec.alpha_cli import alpha_reaction_time  # noqa: E402
 
 
-def _participants(value, data_dir, cue):
-    if value:
-        return parse_participant_spec(value)
-    return available_participants(data_dir, cue=cue)
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Analyze prestimulus alpha metrics against reaction time.")
-    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
-    parser.add_argument(
-        "--participants",
-        default=None,
-        help="Participant ids such as 1-4,6,8. Defaults to all available MAT files.",
-    )
-    parser.add_argument(
-        "--reaction-times",
-        default=None,
-        help="CSV containing participant, trial, and reaction_time columns.",
-    )
-    parser.add_argument("--alpha-metrics", default=None, help="Optional precomputed alpha metrics CSV.")
-    parser.add_argument(
-        "--joined-output",
-        required=True,
-        help="Output CSV for matched trial-level alpha/RT rows.",
-    )
-    parser.add_argument("--summary-output", required=True, help="Output CSV for association summaries.")
-    parser.add_argument(
-        "--plots-dir",
-        default=None,
-        help="Optional directory for simple alpha/RT scatter plots.",
-    )
-    parser.add_argument(
-        "--cue",
-        action="store_true",
-        help="Use Part*CueData.mat instead of Part*Data.mat.",
-    )
-    parser.add_argument(
-        "--trialinfo-rt-column",
-        type=int,
-        default=None,
-        help="Zero-based trialinfo column containing RT when no CSV is supplied.",
-    )
-    parser.add_argument(
-        "--reaction-time-scale",
-        type=float,
-        default=1.0,
-        help="Scale applied to RT values, for example 0.001 for milliseconds.",
-    )
-    parser.add_argument(
-        "--participant-column",
-        default=None,
-        help="Reaction-time CSV participant column override.",
-    )
-    parser.add_argument("--trial-column", default=None, help="Reaction-time CSV trial column override.")
-    parser.add_argument(
-        "--reaction-time-column",
-        default=None,
-        help="Reaction-time CSV RT column override.",
-    )
-    parser.add_argument(
-        "--dataset-column",
-        default=None,
-        help="Reaction-time CSV dataset column override.",
-    )
-    add_alpha_metric_arguments(parser)
-    parser.add_argument(
-        "--metrics",
-        nargs="*",
-        default=DEFAULT_ALPHA_RT_METRICS,
-        help="Alpha metrics to summarize.",
-    )
-    args = parser.parse_args()
-
-    participants = _participants(args.participants, args.data_dir, args.cue)
-    if not participants and (not args.alpha_metrics or not args.reaction_times):
-        parser.error("No participants found. Pass --participants or configure a data " "directory with matching MAT files.")
-    default_participant = participants[0] if len(participants) == 1 else None
-    alpha_config = alpha_metric_config_from_args(args)
-    csv_config = ReactionTimeCsvConfig(
-        participant_column=args.participant_column,
-        trial_column=args.trial_column,
-        reaction_time_column=args.reaction_time_column,
-        dataset_column=args.dataset_column,
-        default_participant=default_participant,
-        default_dataset="cue" if args.cue else "main",
-        reaction_time_scale=args.reaction_time_scale,
-    )
-    export_config = AlphaReactionTimeExportConfig(
-        reaction_times_path=args.reaction_times,
-        alpha_metrics_path=args.alpha_metrics,
-        joined_output_path=args.joined_output,
-        summary_output_path=args.summary_output,
-        cue=args.cue,
-        alpha_config=alpha_config,
-        csv_config=csv_config,
-        trialinfo_rt_column=args.trialinfo_rt_column,
-        metrics=tuple(args.metrics),
-    )
-
-    joined_rows, summary_rows = export_alpha_reaction_time_analysis(
-        args.data_dir,
-        participants,
-        config=export_config,
-    )
-    if args.plots_dir:
-        write_alpha_reaction_time_plots(joined_rows, args.plots_dir, metrics=args.metrics)
-    print(f"Wrote {len(joined_rows)} matched trial rows to {args.joined_output}")
-    print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+def main() -> int:
+    return alpha_reaction_time()
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,26 +1,67 @@
 # CLI reference
 
-PyMEGDec exposes one grouped command plus compatibility entry points. Prefer the
-grouped `pymegdec` command for new documentation and scripts.
-
-## Grouped command
+PyMEGDec exposes one grouped command. Prefer the grouped `pymegdec` command for
+new documentation, CI jobs, and shell scripts. Compatibility aliases and
+historical Python wrappers remain available for existing workflows.
 
 ```bash
 pymegdec --help
 ```
 
-Available subcommands:
+## Command groups
+
+### Core decoding
 
 ```bash
 pymegdec cross-validate --participant 2
 pymegdec transfer --participant 2 --classifier multiclass-svm
-pymegdec stimulus-decoding --participants 2 --output outputs/part2_stimulus_decoding.csv
-pymegdec alpha-movement-results --movement-summary outputs/part2_alpha_movement_summary.csv --effect-output outputs/part2_alpha_movement_effects.csv --condition-summary-output outputs/part2_alpha_movement_condition_summary.csv
 ```
 
-## Compatibility entry points
+### Stimulus workflows
 
-The package also installs these script names:
+```bash
+pymegdec stimulus decoding --participants 2 --output outputs/part2_stimulus_decoding.csv
+pymegdec stimulus predictions --participants 2 --output outputs/stimulus_predictions.csv
+pymegdec stimulus robustness --participants 2 --predictions-output outputs/stimulus_robustness_predictions.csv
+pymegdec stimulus temporal-generalization --participants 2 --output outputs/stimulus_temporal_generalization.csv
+pymegdec stimulus onset-scan --participants 2 --output outputs/stimulus_onset_scan.csv --events-output outputs/stimulus_onset_events.csv
+```
+
+### Alpha workflows
+
+```bash
+pymegdec alpha metrics --participant 2 --output outputs/part2_alpha_metrics.csv
+pymegdec alpha movement --participants 2 --trajectory-output outputs/part2_alpha_movement.csv --summary-output outputs/part2_alpha_movement_summary.csv
+pymegdec alpha movement-results --movement-summary outputs/part2_alpha_movement_summary.csv --effect-output outputs/part2_alpha_movement_effects.csv --condition-summary-output outputs/part2_alpha_movement_condition_summary.csv
+pymegdec alpha reaction-time --participants 2 --joined-output outputs/part2_alpha_rt_joined.csv --summary-output outputs/part2_alpha_rt_summary.csv
+```
+
+### Data helpers
+
+```bash
+pymegdec data download --data-dir data --env-name MEG_DATA_URL_LIST
+```
+
+## Backward-compatible aliases
+
+The following top-level aliases are kept so old commands and existing CI jobs do
+not need to change immediately:
+
+```bash
+pymegdec stimulus-decoding
+pymegdec stimulus-predictions
+pymegdec stimulus-robustness
+pymegdec stimulus-temporal-generalization
+pymegdec stimulus-onset-scan
+pymegdec alpha-metrics
+pymegdec alpha-movement
+pymegdec alpha-movement-results
+pymegdec alpha-reaction-time
+pymegdec alpha-rt
+pymegdec download-meg-data
+```
+
+The installed script names remain available:
 
 ```bash
 pymegdec-cross-validate
@@ -29,13 +70,9 @@ pymegdec-stimulus-decoding
 pymegdec-alpha-movement-results
 ```
 
-Top-level Python wrappers remain available for existing workflows, for example:
-
-```bash
-python analyze_stimulus_decoding.py --participants 2 --output outputs/part2_stimulus_decoding.csv
-python export_alpha_metrics.py --participant 2 --output outputs/part2_alpha_metrics.csv
-python analyze_alpha_movement.py --participants 2 --trajectory-output outputs/part2_alpha_movement.csv --summary-output outputs/part2_alpha_movement_summary.csv
-```
+Top-level Python wrappers such as `python export_alpha_metrics.py` and
+`scripts/export_stimulus_predictions.py` now delegate to the package-level
+command handlers.
 
 ## Shared decoding options
 
@@ -62,9 +99,6 @@ Cross-validate one participant's main dataset:
 pymegdec cross-validate --data-dir /path/to/MEG-Data --participant 2 --folds 10
 ```
 
-The command prints the accuracy returned by
-`pymegdec.cross_validation.cross_validate_single_dataset`.
-
 ## Model transfer
 
 Train on the main experiment file and validate on the cue file for one
@@ -74,15 +108,12 @@ participant:
 pymegdec transfer --data-dir /path/to/MEG-Data --participant 2 --null-window-center nan
 ```
 
-The command prints the accuracy returned by
-`pymegdec.model_transfer.evaluate_model_transfer`.
-
 ## Stimulus decoding
 
 Run train-main / validate-cue decoding across a time range:
 
 ```bash
-pymegdec stimulus-decoding \
+pymegdec stimulus decoding \
   --data-dir /path/to/MEG-Data \
   --participants 2 \
   --time-window=-0.2,0.6 \
@@ -95,12 +126,64 @@ pymegdec stimulus-decoding \
 Use `--transfer-direction cue-to-main` to train on cue data and validate on the
 main experiment data.
 
-## Alpha movement result analysis
+## Stimulus prediction diagnostics
 
-Analyze a movement summary exported by `analyze_alpha_movement.py`:
+Export trial-level predictions and optional confusion/per-stimulus summaries for
+selected diagnostic windows:
 
 ```bash
-pymegdec alpha-movement-results \
+pymegdec stimulus predictions \
+  --data-dir /path/to/MEG-Data \
+  --participants 2 \
+  --window-centers=-0.175,0.175 \
+  --output outputs/stimulus_predictions.csv \
+  --summary-output outputs/stimulus_prediction_summary.csv \
+  --confusion-output outputs/stimulus_confusion.csv \
+  --per-stimulus-output outputs/stimulus_per_class.csv
+```
+
+## Stimulus robustness controls
+
+```bash
+pymegdec stimulus robustness \
+  --data-dir /path/to/MEG-Data \
+  --participants 1-4,6,8,9,10,13-27 \
+  --window-centers=-0.175,0.175 \
+  --predictions-output outputs/stimulus_robustness_predictions.csv \
+  --accuracy-output outputs/stimulus_robustness_accuracy.csv \
+  --summary-output outputs/stimulus_robustness_summary.csv
+```
+
+## Stimulus temporal generalization
+
+```bash
+pymegdec stimulus temporal-generalization \
+  --data-dir /path/to/MEG-Data \
+  --participants 2 \
+  --time-window=-0.4,0.8 \
+  --window-step-s 0.025 \
+  --output outputs/stimulus_temporal_generalization.csv \
+  --summary-output outputs/stimulus_temporal_generalization_summary.csv
+```
+
+## Stimulus onset scan
+
+```bash
+pymegdec stimulus onset-scan \
+  --data-dir /path/to/MEG-Data \
+  --participants 2 \
+  --scan-time-window=-0.4,0.8 \
+  --threshold-window=-0.35,-0.05 \
+  --output outputs/stimulus_onset_scan.csv \
+  --events-output outputs/stimulus_onset_events.csv
+```
+
+## Alpha movement result analysis
+
+Analyze a movement summary exported by `pymegdec alpha movement`:
+
+```bash
+pymegdec alpha movement-results \
   --movement-summary outputs/part2_alpha_movement_summary.csv \
   --effect-output outputs/part2_alpha_movement_effects.csv \
   --condition-summary-output outputs/part2_alpha_movement_condition_summary.csv \

--- a/export_alpha_metrics.py
+++ b/export_alpha_metrics.py
@@ -1,41 +1,15 @@
-"""Export exploratory alpha metrics for one participant."""
-
-import argparse
+"""Backward-compatible wrapper for ``pymegdec alpha metrics``."""
 
 from script_bootstrap import add_src_to_path
 
 add_src_to_path(__file__)
 
-from pymegdec.alpha_metrics import export_participant_alpha_metrics  # noqa: E402
-from pymegdec.cli import (  # noqa: E402
-    add_alpha_metric_arguments,
-    alpha_metric_config_from_args,
-)
+from pymegdec.alpha_cli import alpha_metrics  # noqa: E402
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Export exploratory prestimulus alpha metrics to CSV.")
-    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
-    parser.add_argument("--participant", type=int, required=True, help="Participant id to export.")
-    parser.add_argument("--output", required=True, help="Output CSV path.")
-    parser.add_argument(
-        "--cue",
-        action="store_true",
-        help="Use Part*CueData.mat instead of Part*Data.mat.",
-    )
-    add_alpha_metric_arguments(parser)
-    args = parser.parse_args()
-
-    config = alpha_metric_config_from_args(args)
-    rows = export_participant_alpha_metrics(
-        args.data_dir,
-        args.participant,
-        args.output,
-        cue=args.cue,
-        config=config,
-    )
-    print(f"Wrote {len(rows)} rows to {args.output}")
+def main() -> int:
+    return alpha_metrics()
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 ]
 
 [project.scripts]
-pymegdec = "pymegdec.cli:main"
+pymegdec = "pymegdec.grouped_cli:main"
 pymegdec-cross-validate = "pymegdec.cli:cross_validate"
 pymegdec-transfer = "pymegdec.cli:transfer"
 pymegdec-stimulus-decoding = "pymegdec.cli:stimulus_decoding"

--- a/scripts/download_meg_data_files.py
+++ b/scripts/download_meg_data_files.py
@@ -1,109 +1,21 @@
 #!/usr/bin/env python3
+"""Backward-compatible wrapper for the grouped MEG data download command."""
+
 from __future__ import annotations
 
-import argparse
-import os
-import re
-import shutil
-import urllib.parse
-import urllib.request
+import sys
 from pathlib import Path
 
-_ALLOWED_URL_SCHEMES = {"https"}
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _ROOT / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
 
-
-class _HTTPSOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Redirect handler that preserves the HTTPS-only download invariant."""
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ANN201
-        redirect_url = urllib.parse.urljoin(req.full_url, newurl)
-        _validate_https_url(redirect_url, description="redirect")
-        return super().redirect_request(req, fp, code, msg, headers, redirect_url)
-
-
-_DOWNLOAD_OPENER = urllib.request.build_opener(_HTTPSOnlyRedirectHandler)
-
-
-def _validate_https_url(url: str, *, description: str) -> str:
-    parsed = urllib.parse.urlparse(url)
-    if parsed.scheme.lower() not in _ALLOWED_URL_SCHEMES or not parsed.netloc:
-        raise ValueError(f"Only absolute HTTPS {description} URLs are supported: {url!r}")
-    return url
-
-
-def _urls_from_env(name: str) -> list[str]:
-    raw = os.environ.get(name, "")
-    return [token.strip() for token in re.split(r"[\s,]+", raw) if token.strip()]
-
-
-def _direct_url(url: str) -> str:
-    parsed = urllib.parse.urlparse(_validate_https_url(url, description="source"))
-
-    if parsed.path.rstrip("/").endswith("/download"):
-        direct_url = url
-    elif "/s/" in f"/{parsed.path.strip('/')}/":
-        direct_url = url.rstrip("/") + "/download"
-    else:
-        direct_url = url
-
-    return _validate_https_url(direct_url, description="download")
-
-
-def _open_https(request: urllib.request.Request, *, timeout: int):
-    _validate_https_url(request.full_url, description="download")
-    response = _DOWNLOAD_OPENER.open(request, timeout=timeout)
-    _validate_https_url(response.geturl(), description="final download")
-    return response
-
-
-def _filename(response, index: int) -> str:
-    header = response.headers.get("Content-Disposition", "")
-    match = re.search(r"filename\*\s*=\s*UTF-8''([^;]+)", header, flags=re.IGNORECASE)
-    if match:
-        return Path(urllib.parse.unquote(match.group(1))).name
-    match = re.search(r'filename\s*=\s*"?([^";]+)"?', header, flags=re.IGNORECASE)
-    if match:
-        return Path(urllib.parse.unquote(match.group(1))).name
-    fallback = Path(urllib.parse.urlparse(response.geturl()).path).name
-    if fallback and fallback.lower() != "download":
-        return fallback
-    return f"downloaded_meg_file_{index:04d}.mat"
+from pymegdec.data_download import download_meg_data_files  # noqa: E402
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--data-dir", required=True)
-    parser.add_argument("--env-name", default="MEG_DATA_URL_LIST")
-    parser.add_argument("--manifest", default="data-manifest/downloaded-files.txt")
-    args = parser.parse_args()
-
-    urls = _urls_from_env(args.env_name)
-    if not urls:
-        raise SystemExit(f"{args.env_name} is empty")
-
-    data_dir = Path(args.data_dir)
-    if data_dir.exists():
-        shutil.rmtree(data_dir)
-    data_dir.mkdir(parents=True, exist_ok=True)
-
-    downloaded: list[Path] = []
-    for index, url in enumerate(urls, start=1):
-        request = urllib.request.Request(_direct_url(url), headers={"User-Agent": "PyMEGDec"})
-        with _open_https(request, timeout=180) as response:
-            target = data_dir / _filename(response, index)
-            counter = 2
-            while target.exists():
-                target = data_dir / f"{target.stem}_{counter}{target.suffix}"
-                counter += 1
-            with target.open("wb") as output:
-                shutil.copyfileobj(response, output, length=1024 * 1024)
-        downloaded.append(target)
-        print(f"Downloaded file #{index}: {target.name}")
-
-    manifest = Path(args.manifest)
-    manifest.parent.mkdir(parents=True, exist_ok=True)
-    manifest.write_text("\n".join(str(path) for path in downloaded) + "\n", encoding="utf-8")
-    return 0
+    return download_meg_data_files()
 
 
 if __name__ == "__main__":

--- a/scripts/export_stimulus_onset_scan.py
+++ b/scripts/export_stimulus_onset_scan.py
@@ -1,122 +1,21 @@
-"""Export onset-blind stimulus identity scans over validation trials."""
+"""Backward-compatible wrapper for the grouped stimulus onset-scan command."""
 
-# jscpd:ignore-start
 from __future__ import annotations
 
-import argparse
 import sys
-from typing import Sequence
+from pathlib import Path
 
-from export_stimulus_predictions import (
-    _float_or_inf,
-    _int_or_inf,
-    _normalize_argv,
-    _parse_classifier_param,
-    _transfer_participants,
-)
-from pymegdec.data_config import resolve_data_folder
-from pymegdec.stimulus_decoding import (
-    DEFAULT_ONSET_SCAN_STEP_S,
-    DEFAULT_ONSET_SCAN_TIME_WINDOW,
-    DEFAULT_ONSET_SCAN_TRAIN_WINDOW_CENTER,
-    DEFAULT_ONSET_THRESHOLD_QUANTILE,
-    DEFAULT_ONSET_THRESHOLD_WINDOW,
-    TRANSFER_DIRECTIONS,
-    StimulusDecodingConfig,
-    export_stimulus_onset_scan,
-    window_centers_from_range,
-)
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _ROOT / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+from pymegdec.stimulus_cli import stimulus_onset_scan  # noqa: E402
 
 
-def _parse_time_window(value: str) -> tuple[float, float]:
-    parts = tuple(float(token.strip()) for token in value.split(",", 1))
-    if len(parts) != 2:
-        raise argparse.ArgumentTypeError("Time window must have the form start,stop.")
-    if parts[0] > parts[1]:
-        raise argparse.ArgumentTypeError("Time window start must be before stop.")
-    return parts
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Export onset-blind stimulus identity scans across validation windows.")
-    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
-    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.")
-    parser.add_argument("--train-window-center", type=float, default=DEFAULT_ONSET_SCAN_TRAIN_WINDOW_CENTER, help="Known-onset training window center in seconds.")
-    parser.add_argument("--scan-time-window", type=_parse_time_window, default=DEFAULT_ONSET_SCAN_TIME_WINDOW, help="Validation scan center range as start,stop in seconds.")
-    parser.add_argument("--window-step-s", type=float, default=DEFAULT_ONSET_SCAN_STEP_S, help="Step between scan window centers in seconds.")
-    parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
-    parser.add_argument(
-        "--threshold-window", type=_parse_time_window, default=DEFAULT_ONSET_THRESHOLD_WINDOW, help="Window-center range used to estimate the confidence threshold."
-    )
-    parser.add_argument("--threshold-quantile", type=float, default=DEFAULT_ONSET_THRESHOLD_QUANTILE, help="Quantile of threshold-window scores used as detection threshold.")
-    parser.add_argument("--detection-start-s", type=_float_or_inf, default=None, help="Optional earliest scan center considered for first detection.")
-    parser.add_argument("--null-window-center", type=_float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
-    parser.add_argument("--transfer-direction", choices=TRANSFER_DIRECTIONS, default="main-to-cue", help="Train/validation dataset direction.")
-    parser.add_argument("--new-framerate", type=_float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
-    parser.add_argument("--classifier", default="multiclass-svm", help="Classifier name.")
-    parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
-    parser.add_argument("--components-pca", type=_int_or_inf, default=100, help="Number of PCA components, or inf.")
-    parser.add_argument(
-        "--frequency-range",
-        type=_float_or_inf,
-        nargs=2,
-        metavar=("LOW", "HIGH"),
-        default=(0.0, float("inf")),
-        help="Frequency range in Hz.",
-    )
-    parser.add_argument("--chance-classes", type=int, default=16, help="Number of stimulus classes used for chance level.")
-    parser.add_argument("--output", default="outputs/stimulus_onset_scan.csv", help="Output CSV with one row per validation trial and scan window.")
-    parser.add_argument("--events-output", default="outputs/stimulus_onset_events.csv", help="Output CSV with one first-detection row per validation trial.")
-    parser.add_argument("--summary-output", default="outputs/stimulus_onset_scan_summary.csv", help="Optional participant/scan-window summary CSV.")
-    parser.add_argument("--event-summary-output", default="outputs/stimulus_onset_event_summary.csv", help="Optional participant first-detection summary CSV.")
-    return parser
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = _build_parser()
-    args = parser.parse_args(_normalize_argv(argv))
-    if not 0.0 <= args.threshold_quantile <= 1.0:
-        parser.error("--threshold-quantile must be between 0 and 1.")
-    data_folder = resolve_data_folder(args.data_folder)
-    participants = _transfer_participants(args.participants, data_folder)
-    if not participants:
-        parser.error("No participants found. Pass --participants or configure a data directory with matching main and cue MAT files.")
-
-    config = StimulusDecodingConfig(
-        window_centers=window_centers_from_range(args.scan_time_window, args.window_step_s),
-        window_size=args.window_size,
-        null_window_center=args.null_window_center,
-        new_framerate=args.new_framerate,
-        classifier=args.classifier,
-        classifier_param=_parse_classifier_param(args.classifier_param),
-        components_pca=args.components_pca,
-        frequency_range=tuple(args.frequency_range),
-        chance_classes=args.chance_classes,
-        permutations=0,
-        transfer_direction=args.transfer_direction,
-    )
-
-    scan_rows, event_rows, summary_rows, event_summary_rows = export_stimulus_onset_scan(
-        data_folder,
-        participants,
-        args.output,
-        args.events_output,
-        summary_output_path=args.summary_output,
-        event_summary_output_path=args.event_summary_output,
-        config=config,
-        train_window_center=args.train_window_center,
-        threshold_window=args.threshold_window,
-        threshold_quantile=args.threshold_quantile,
-        detection_start_s=args.detection_start_s,
-        progress=lambda message: print(message, flush=True),
-    )
-    print(f"Wrote {len(scan_rows)} trial/window scan rows to {args.output}")
-    print(f"Wrote {len(event_rows)} first-detection rows to {args.events_output}")
-    print(f"Wrote {len(summary_rows)} scan summary rows to {args.summary_output}")
-    print(f"Wrote {len(event_summary_rows)} event summary rows to {args.event_summary_output}")
-    return 0
+def main() -> int:
+    return stimulus_onset_scan()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
-# jscpd:ignore-end
+    raise SystemExit(main())

--- a/scripts/export_stimulus_predictions.py
+++ b/scripts/export_stimulus_predictions.py
@@ -1,185 +1,21 @@
-"""Export trial-level train-main/validate-cue stimulus predictions."""
+"""Backward-compatible wrapper for the grouped stimulus predictions command."""
 
 from __future__ import annotations
 
-import argparse
-import ast
-import json
 import sys
-from typing import Sequence
+from pathlib import Path
 
-import numpy as np
-from pymegdec.alpha_metrics import write_alpha_metrics_csv
-from pymegdec.data_config import resolve_data_folder
-from pymegdec.reaction_time_analysis import (
-    available_participants,
-    parse_participant_spec,
-)
-from pymegdec.stimulus_decoding import (
-    TRANSFER_DIRECTIONS,
-    StimulusDecodingConfig,
-    evaluate_participant_stimulus_decoding_diagnostics,
-    summarize_stimulus_decoding,
-    summarize_stimulus_prediction_diagnostics,
-)
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _ROOT / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
 
-DEFAULT_WINDOW_CENTERS = (-0.175, 0.175)
+from pymegdec.stimulus_cli import stimulus_predictions  # noqa: E402
 
 
-# jscpd:ignore-start
-def _float_or_inf(value: str) -> float:
-    normalized = value.lower()
-    if normalized in {"inf", "+inf", "infinity", "+infinity"}:
-        return float("inf")
-    if normalized in {"nan", "+nan", "-nan"}:
-        return float("nan")
-    return float(value)
-
-
-def _int_or_inf(value: str) -> int | float:
-    parsed = _float_or_inf(value)
-    if np.isinf(parsed):
-        return parsed
-    return int(parsed)
-
-
-def _parse_float_list(value: str) -> tuple[float, ...]:
-    values = tuple(float(token.strip()) for token in value.split(",") if token.strip())
-    if not values:
-        raise argparse.ArgumentTypeError("At least one value is required.")
-    return values
-
-
-def _parse_classifier_param(value: str | None):
-    if value is None:
-        return np.nan
-
-    normalized = value.strip()
-    if normalized.lower() == "nan":
-        return np.nan
-
-    for parser in (json.loads, ast.literal_eval):
-        try:
-            return parser(normalized)
-        except (SyntaxError, ValueError, TypeError, json.JSONDecodeError):
-            pass
-
-    try:
-        return float(normalized)
-    except ValueError as exc:
-        raise argparse.ArgumentTypeError("classifier parameters must be numeric, JSON, or a Python literal") from exc
-
-
-def _transfer_participants(participant_spec: str | None, data_folder) -> list[int]:
-    if participant_spec:
-        return parse_participant_spec(participant_spec)
-    main_participants = set(available_participants(data_folder, cue=False))
-    cue_participants = set(available_participants(data_folder, cue=True))
-    return sorted(main_participants & cue_participants)
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Export trial-level stimulus predictions for selected windows.")
-    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
-    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.")
-    parser.add_argument("--window-centers", type=_parse_float_list, default=DEFAULT_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
-    parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
-    parser.add_argument("--null-window-center", type=_float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
-    parser.add_argument("--transfer-direction", choices=TRANSFER_DIRECTIONS, default="main-to-cue", help="Train/validation dataset direction.")
-    parser.add_argument("--new-framerate", type=_float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
-    parser.add_argument("--classifier", default="multiclass-svm", help="Classifier name.")
-    parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
-    parser.add_argument("--components-pca", type=_int_or_inf, default=100, help="Number of PCA components, or inf.")
-    parser.add_argument(
-        "--frequency-range",
-        type=_float_or_inf,
-        nargs=2,
-        metavar=("LOW", "HIGH"),
-        default=(0.0, float("inf")),
-        help="Frequency range in Hz.",
-    )
-    parser.add_argument("--chance-classes", type=int, default=16, help="Number of stimulus classes used for the chance line.")
-    parser.add_argument("--output", default="outputs/stimulus_predictions.csv", help="Output CSV with one row per validation trial and window.")
-    parser.add_argument("--summary-output", default="outputs/stimulus_prediction_summary.csv", help="Optional participant/window accuracy summary CSV.")
-    parser.add_argument("--accuracy-output", default=None, help="Optional participant/window accuracy CSV.")
-    parser.add_argument("--confusion-output", default=None, help="Optional confusion-count CSV.")
-    parser.add_argument("--per-stimulus-output", default=None, help="Optional per-stimulus recall CSV.")
-    return parser
-
-
-def _normalize_argv(argv: Sequence[str] | None) -> list[str] | None:
-    if argv is None:
-        argv = sys.argv[1:]
-    normalized: list[str] = []
-    index = 0
-    while index < len(argv):
-        token = argv[index]
-        if token == "--window-centers" and index + 1 < len(argv):  # nosec B105
-            normalized.append(f"--window-centers={argv[index + 1]}")
-            index += 2
-            continue
-        normalized.append(token)
-        index += 1
-    return normalized
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = _build_parser()
-    args = parser.parse_args(_normalize_argv(argv))
-    data_folder = resolve_data_folder(args.data_folder)
-    participants = _transfer_participants(args.participants, data_folder)
-    if not participants:
-        parser.error("No participants found. Pass --participants or configure a data directory with matching main and cue MAT files.")
-
-    config = StimulusDecodingConfig(
-        window_centers=args.window_centers,
-        window_size=args.window_size,
-        null_window_center=args.null_window_center,
-        new_framerate=args.new_framerate,
-        classifier=args.classifier,
-        classifier_param=_parse_classifier_param(args.classifier_param),
-        components_pca=args.components_pca,
-        frequency_range=tuple(args.frequency_range),
-        chance_classes=args.chance_classes,
-        permutations=0,
-        transfer_direction=args.transfer_direction,
-    )
-
-    accuracy_rows = []
-    prediction_rows = []
-    for participant in participants:
-        print(f"START participant={participant}", flush=True)
-        participant_accuracy, participant_predictions = evaluate_participant_stimulus_decoding_diagnostics(
-            data_folder,
-            participant,
-            config=config,
-            diagnostic_window_centers=args.window_centers,
-        )
-        accuracy_rows.extend(participant_accuracy)
-        prediction_rows.extend(participant_predictions)
-        print(f"DONE participant={participant}", flush=True)
-
-    write_alpha_metrics_csv(prediction_rows, args.output)
-    print(f"Wrote {len(prediction_rows)} trial prediction rows to {args.output}")
-
-    summary_rows = summarize_stimulus_decoding(accuracy_rows)
-    if args.summary_output:
-        write_alpha_metrics_csv(summary_rows, args.summary_output)
-        print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
-    if args.accuracy_output:
-        write_alpha_metrics_csv(accuracy_rows, args.accuracy_output)
-        print(f"Wrote {len(accuracy_rows)} participant/window rows to {args.accuracy_output}")
-    if args.confusion_output or args.per_stimulus_output:
-        confusion_rows, per_stimulus_rows = summarize_stimulus_prediction_diagnostics(prediction_rows)
-        if args.confusion_output:
-            write_alpha_metrics_csv(confusion_rows, args.confusion_output)
-            print(f"Wrote {len(confusion_rows)} confusion rows to {args.confusion_output}")
-        if args.per_stimulus_output:
-            write_alpha_metrics_csv(per_stimulus_rows, args.per_stimulus_output)
-            print(f"Wrote {len(per_stimulus_rows)} per-stimulus rows to {args.per_stimulus_output}")
-    return 0
+def main() -> int:
+    return stimulus_predictions()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
-# jscpd:ignore-end
+    raise SystemExit(main())

--- a/scripts/export_stimulus_robustness.py
+++ b/scripts/export_stimulus_robustness.py
@@ -1,127 +1,21 @@
-"""Export two-window stimulus-decoding robustness controls."""
+"""Backward-compatible wrapper for the grouped stimulus robustness command."""
 
 from __future__ import annotations
 
-import argparse
 import sys
-from dataclasses import replace
-from typing import Sequence
+from pathlib import Path
 
-from export_stimulus_predictions import (
-    _float_or_inf,
-    _int_or_inf,
-    _normalize_argv,
-    _parse_classifier_param,
-    _parse_float_list,
-    _transfer_participants,
-)
-from pymegdec.alpha_metrics import write_alpha_metrics_csv
-from pymegdec.data_config import resolve_data_folder
-from pymegdec.stimulus_decoding import (
-    StimulusDecodingConfig,
-    evaluate_participant_stimulus_decoding_diagnostics,
-    summarize_stimulus_decoding,
-)
-from reptrace.decoding.robustness import RobustnessCondition, run_participant_robustness_conditions
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _ROOT / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
 
-DEFAULT_PARTICIPANTS = "1-4,6,8,9,10,13-27"
-DEFAULT_WINDOW_CENTERS = (-0.175, 0.175)
+from pymegdec.stimulus_cli import stimulus_robustness  # noqa: E402
 
 
-# jscpd:ignore-start
-ROBUSTNESS_CONTROLS = (
-    RobustnessCondition("default", "Main-to-cue SVM, PCA 100, broadband"),
-    RobustnessCondition("reverse_transfer", "Cue-to-main SVM, PCA 100, broadband", {"transfer_direction": "cue-to-main"}),
-    RobustnessCondition("weighted_svm", "Main-to-cue balanced SVM, PCA 100, broadband", {"classifier": "multiclass-svm-weighted"}),
-    RobustnessCondition("pca_50", "Main-to-cue SVM, PCA 50, broadband", {"components_pca": 50}),
-    RobustnessCondition("pca_200", "Main-to-cue SVM, PCA 200, broadband", {"components_pca": 200}),
-    RobustnessCondition("low_frequency", "Main-to-cue SVM, PCA 100, 0-30 Hz", {"frequency_range": (0.0, 30.0)}),
-)
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Export two-window robustness controls for stimulus decoding.")
-    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
-    parser.add_argument("--participants", default=DEFAULT_PARTICIPANTS, help="Participant ids such as 1-4,6,8. Defaults to the full current analysis set.")
-    parser.add_argument("--window-centers", type=_parse_float_list, default=DEFAULT_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
-    parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
-    parser.add_argument("--null-window-center", type=_float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
-    parser.add_argument("--new-framerate", type=_float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
-    parser.add_argument("--classifier", default="multiclass-svm", help="Base classifier name.")
-    parser.add_argument("--classifier-param", default=None, help="Base classifier parameter value, JSON, Python literal, numeric value, or nan.")
-    parser.add_argument("--components-pca", type=_int_or_inf, default=100, help="Base number of PCA components, or inf.")
-    parser.add_argument(
-        "--frequency-range",
-        type=_float_or_inf,
-        nargs=2,
-        metavar=("LOW", "HIGH"),
-        default=(0.0, float("inf")),
-        help="Base frequency range in Hz.",
-    )
-    parser.add_argument("--chance-classes", type=int, default=16, help="Number of stimulus classes used for the chance line.")
-    parser.add_argument("--predictions-output", default="outputs/stimulus_robustness_predictions.csv", help="Output CSV with one row per validation trial/window/control.")
-    parser.add_argument("--accuracy-output", default="outputs/stimulus_robustness_accuracy.csv", help="Output CSV with one row per participant/window/control.")
-    parser.add_argument("--summary-output", default="outputs/stimulus_robustness_summary.csv", help="Output CSV summarized across participants by window/control.")
-    return parser
-
-
-def _control_config(base_config: StimulusDecodingConfig, control: RobustnessCondition) -> StimulusDecodingConfig:
-    return replace(base_config, **dict(control.parameters))
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = _build_parser()
-    args = parser.parse_args(_normalize_argv(argv))
-    data_folder = resolve_data_folder(args.data_folder)
-    participants = _transfer_participants(args.participants, data_folder)
-    if not participants:
-        parser.error("No participants found. Pass --participants or configure a data directory with matching main and cue MAT files.")
-
-    base_config = StimulusDecodingConfig(
-        window_centers=args.window_centers,
-        window_size=args.window_size,
-        null_window_center=args.null_window_center,
-        new_framerate=args.new_framerate,
-        classifier=args.classifier,
-        classifier_param=_parse_classifier_param(args.classifier_param),
-        components_pca=args.components_pca,
-        frequency_range=tuple(args.frequency_range),
-        chance_classes=args.chance_classes,
-        permutations=0,
-    )
-
-    def run_participant(control, participant):
-        config = _control_config(base_config, control)
-        participant_accuracy, participant_predictions = evaluate_participant_stimulus_decoding_diagnostics(
-            data_folder,
-            participant,
-            config=config,
-            diagnostic_window_centers=args.window_centers,
-        )
-        return {
-            "accuracy": participant_accuracy,
-            "predictions": participant_predictions,
-        }
-
-    artifacts = run_participant_robustness_conditions(
-        ROBUSTNESS_CONTROLS,
-        participants,
-        run_participant,
-        progress=lambda message: print(message, flush=True),
-    )
-    accuracy_rows = artifacts.get("accuracy", [])
-    prediction_rows = artifacts.get("predictions", [])
-
-    write_alpha_metrics_csv(prediction_rows, args.predictions_output)
-    print(f"Wrote {len(prediction_rows)} trial prediction rows to {args.predictions_output}")
-    write_alpha_metrics_csv(accuracy_rows, args.accuracy_output)
-    print(f"Wrote {len(accuracy_rows)} participant/window/control rows to {args.accuracy_output}")
-    summary_rows = summarize_stimulus_decoding(accuracy_rows)
-    write_alpha_metrics_csv(summary_rows, args.summary_output)
-    print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
-    return 0
+def main() -> int:
+    return stimulus_robustness()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
-# jscpd:ignore-end
+    raise SystemExit(main())

--- a/scripts/export_stimulus_temporal_generalization.py
+++ b/scripts/export_stimulus_temporal_generalization.py
@@ -1,99 +1,21 @@
-"""Export train-time/test-time stimulus temporal generalization."""
+"""Backward-compatible wrapper for the grouped stimulus temporal-generalization command."""
 
-# jscpd:ignore-start
 from __future__ import annotations
 
-import argparse
 import sys
-from typing import Sequence
+from pathlib import Path
 
-from export_stimulus_predictions import (
-    _float_or_inf,
-    _int_or_inf,
-    _normalize_argv,
-    _parse_classifier_param,
-    _transfer_participants,
-)
-from pymegdec.data_config import resolve_data_folder
-from pymegdec.stimulus_decoding import (
-    TRANSFER_DIRECTIONS,
-    StimulusDecodingConfig,
-    export_stimulus_temporal_generalization,
-    window_centers_from_range,
-)
+_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _ROOT / "src"
+if _SRC.exists():
+    sys.path.insert(0, str(_SRC))
+
+from pymegdec.stimulus_cli import stimulus_temporal_generalization  # noqa: E402
 
 
-def _parse_time_window(value: str) -> tuple[float, float]:
-    parts = tuple(float(token.strip()) for token in value.split(",", 1))
-    if len(parts) != 2:
-        raise argparse.ArgumentTypeError("Time window must have the form start,stop.")
-    if parts[0] > parts[1]:
-        raise argparse.ArgumentTypeError("Time window start must be before stop.")
-    return parts
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Export stimulus temporal generalization across train/test windows.")
-    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
-    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.")
-    parser.add_argument("--time-window", type=_parse_time_window, default=(-0.4, 0.8), help="Window-center range as start,stop in seconds.")
-    parser.add_argument("--window-step-s", type=float, default=0.025, help="Step between train/test window centers in seconds.")
-    parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
-    parser.add_argument("--null-window-center", type=_float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
-    parser.add_argument("--transfer-direction", choices=TRANSFER_DIRECTIONS, default="main-to-cue", help="Train/validation dataset direction.")
-    parser.add_argument("--new-framerate", type=_float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
-    parser.add_argument("--classifier", default="multiclass-svm", help="Classifier name.")
-    parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
-    parser.add_argument("--components-pca", type=_int_or_inf, default=100, help="Number of PCA components, or inf.")
-    parser.add_argument(
-        "--frequency-range",
-        type=_float_or_inf,
-        nargs=2,
-        metavar=("LOW", "HIGH"),
-        default=(0.0, float("inf")),
-        help="Frequency range in Hz.",
-    )
-    parser.add_argument("--chance-classes", type=int, default=16, help="Number of stimulus classes used for summary chance level.")
-    parser.add_argument("--output", default="outputs/stimulus_temporal_generalization.csv", help="Output CSV with one row per participant/train-window/test-window.")
-    parser.add_argument("--summary-output", default="outputs/stimulus_temporal_generalization_summary.csv", help="Output CSV summarized across participants by train/test window.")
-    return parser
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = _build_parser()
-    args = parser.parse_args(_normalize_argv(argv))
-    data_folder = resolve_data_folder(args.data_folder)
-    participants = _transfer_participants(args.participants, data_folder)
-    if not participants:
-        parser.error("No participants found. Pass --participants or configure a data directory with matching main and cue MAT files.")
-
-    config = StimulusDecodingConfig(
-        window_centers=window_centers_from_range(args.time_window, args.window_step_s),
-        window_size=args.window_size,
-        null_window_center=args.null_window_center,
-        new_framerate=args.new_framerate,
-        classifier=args.classifier,
-        classifier_param=_parse_classifier_param(args.classifier_param),
-        components_pca=args.components_pca,
-        frequency_range=tuple(args.frequency_range),
-        chance_classes=args.chance_classes,
-        permutations=0,
-        transfer_direction=args.transfer_direction,
-    )
-
-    rows, summary_rows = export_stimulus_temporal_generalization(
-        data_folder,
-        participants,
-        args.output,
-        summary_output_path=args.summary_output,
-        config=config,
-        progress=lambda message: print(message, flush=True),
-    )
-    print(f"Wrote {len(rows)} participant/train/test rows to {args.output}")
-    print(f"Wrote {len(summary_rows)} train/test summary rows to {args.summary_output}")
-    return 0
+def main() -> int:
+    return stimulus_temporal_generalization()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
-# jscpd:ignore-end
+    raise SystemExit(main())

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -1,5 +1,10 @@
 """Utilities for MEG decoding experiments."""
 
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+
 from pymegdec.alpha_metrics import (
     AlphaMetricConfig,
     compute_alpha_metrics,
@@ -49,6 +54,45 @@ from pymegdec.stimulus_decoding import (
 )
 
 __version__ = "0.1.0"
+
+_VALUE_OPTIONS_THAT_CAN_START_WITH_DASH = {
+    "--window-centers",
+    "--time-window",
+    "--scan-time-window",
+    "--threshold-window",
+}
+
+
+def _normalize_argv(argv: Sequence[str] | None) -> list[str]:
+    """Normalize selected option-value pairs for negative comma-separated ranges."""
+
+    if argv is None:
+        argv = sys.argv[1:]
+    normalized: list[str] = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token in _VALUE_OPTIONS_THAT_CAN_START_WITH_DASH and index + 1 < len(argv):
+            normalized.append(f"{token}={argv[index + 1]}")
+            index += 2
+            continue
+        normalized.append(token)
+        index += 1
+    return normalized
+
+
+# Keep the historical pymegdec.cli helper surface available without replacing
+# the legacy CLI module wholesale. The grouped stimulus commands and old script
+# wrappers share this helper for arguments such as "--time-window -0.4,0.8".
+try:  # pragma: no cover - exercised through command-line entry points
+    from pymegdec import cli as _legacy_cli
+
+    if not hasattr(_legacy_cli, "_normalize_argv"):
+        _legacy_cli._normalize_argv = _normalize_argv
+finally:
+    if "_legacy_cli" in locals():
+        del _legacy_cli
+
 
 __all__ = [
     "__version__",

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -1,10 +1,5 @@
 """Utilities for MEG decoding experiments."""
 
-from __future__ import annotations
-
-import sys
-from collections.abc import Sequence
-
 from pymegdec.alpha_metrics import (
     AlphaMetricConfig,
     compute_alpha_metrics,
@@ -54,45 +49,6 @@ from pymegdec.stimulus_decoding import (
 )
 
 __version__ = "0.1.0"
-
-_VALUE_OPTIONS_THAT_CAN_START_WITH_DASH = {
-    "--window-centers",
-    "--time-window",
-    "--scan-time-window",
-    "--threshold-window",
-}
-
-
-def _normalize_argv(argv: Sequence[str] | None) -> list[str]:
-    """Normalize selected option-value pairs for negative comma-separated ranges."""
-
-    if argv is None:
-        argv = sys.argv[1:]
-    normalized: list[str] = []
-    index = 0
-    while index < len(argv):
-        token = argv[index]
-        if token in _VALUE_OPTIONS_THAT_CAN_START_WITH_DASH and index + 1 < len(argv):
-            normalized.append(f"{token}={argv[index + 1]}")
-            index += 2
-            continue
-        normalized.append(token)
-        index += 1
-    return normalized
-
-
-# Keep the historical pymegdec.cli helper surface available without replacing
-# the legacy CLI module wholesale. The grouped stimulus commands and old script
-# wrappers share this helper for arguments such as "--time-window -0.4,0.8".
-try:  # pragma: no cover - exercised through command-line entry points
-    from pymegdec import cli as _legacy_cli
-
-    if not hasattr(_legacy_cli, "_normalize_argv"):
-        _legacy_cli._normalize_argv = _normalize_argv
-finally:
-    if "_legacy_cli" in locals():
-        del _legacy_cli
-
 
 __all__ = [
     "__version__",

--- a/src/pymegdec/alpha_cli.py
+++ b/src/pymegdec/alpha_cli.py
@@ -1,0 +1,243 @@
+"""Alpha-analysis command handlers for the grouped PyMEGDec CLI."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+from pymegdec.alpha_metrics import export_participant_alpha_metrics
+from pymegdec.alpha_movement import (
+    DEFAULT_MOVEMENT_TIME_WINDOW,
+    DEFAULT_SENSOR_PATTERN,
+    DEFAULT_TRAJECTORY_STEP_S,
+    AlphaMovementConfig,
+    export_alpha_movement,
+)
+from pymegdec.cli import add_alpha_metric_arguments, alpha_metric_config_from_args, parse_range
+from pymegdec.reaction_time_analysis import (
+    DEFAULT_ALPHA_RT_METRICS,
+    AlphaReactionTimeExportConfig,
+    ReactionTimeCsvConfig,
+    available_participants,
+    export_alpha_reaction_time_analysis,
+    parse_participant_spec,
+    write_alpha_reaction_time_plots,
+)
+
+
+def _participants(value: str | None, data_dir, cue: bool) -> list[int]:
+    if value:
+        return parse_participant_spec(value)
+    return available_participants(data_dir, cue=cue)
+
+
+def _build_alpha_metrics_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Export exploratory prestimulus alpha metrics to CSV.")
+    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
+    parser.add_argument("--participant", type=int, required=True, help="Participant id to export.")
+    parser.add_argument("--output", required=True, help="Output CSV path.")
+    parser.add_argument(
+        "--cue",
+        action="store_true",
+        help="Use Part*CueData.mat instead of Part*Data.mat.",
+    )
+    add_alpha_metric_arguments(parser)
+    return parser
+
+
+def alpha_metrics(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_alpha_metrics_parser(prog=prog)
+    args = parser.parse_args(argv)
+
+    config = alpha_metric_config_from_args(args)
+    rows = export_participant_alpha_metrics(
+        args.data_dir,
+        args.participant,
+        args.output,
+        cue=args.cue,
+        config=config,
+    )
+    print(f"Wrote {len(rows)} rows to {args.output}")
+    return 0
+
+
+def _build_alpha_movement_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description=(
+            "Export sensor-level alpha movement trajectories. The trajectory is "
+            "a MEG sensor-array proxy, not source-localized brain movement."
+        ),
+    )
+    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
+    parser.add_argument(
+        "--participants",
+        default=None,
+        help="Participant ids such as 1-4,6,8. Defaults to all available MAT files.",
+    )
+    parser.add_argument(
+        "--trajectory-output",
+        required=True,
+        help="Output CSV for trial/timepoint sensor-level trajectories.",
+    )
+    parser.add_argument(
+        "--summary-output",
+        default=None,
+        help="Optional output CSV averaged by participant, condition, and time.",
+    )
+    parser.add_argument(
+        "--cue",
+        action="store_true",
+        help="Use Part*CueData.mat instead of Part*Data.mat.",
+    )
+    parser.add_argument(
+        "--location-pattern",
+        default=DEFAULT_SENSOR_PATTERN,
+        help="Regex for selecting channels by label. Defaults to all MEG channels.",
+    )
+    parser.add_argument(
+        "--time-window",
+        type=parse_range,
+        default=DEFAULT_MOVEMENT_TIME_WINDOW,
+        help="Time window as start,stop in seconds.",
+    )
+    parser.add_argument(
+        "--frequency-range",
+        type=parse_range,
+        default=(8.0, 12.0),
+        help="Frequency range as low,high in Hz.",
+    )
+    parser.add_argument(
+        "--trajectory-step-s",
+        type=float,
+        default=DEFAULT_TRAJECTORY_STEP_S,
+        help="Trajectory sampling step in seconds.",
+    )
+    return parser
+
+
+def alpha_movement(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_alpha_movement_parser(prog=prog)
+    args = parser.parse_args(argv)
+
+    participants = _participants(args.participants, args.data_dir, args.cue)
+    if not participants:
+        parser.error("No participants found. Pass --participants or configure a data directory with matching MAT files.")
+
+    config = AlphaMovementConfig(
+        location_pattern=args.location_pattern,
+        time_window=args.time_window,
+        frequency_range=args.frequency_range,
+        trajectory_step_s=args.trajectory_step_s,
+    )
+    rows, summary_rows = export_alpha_movement(
+        args.data_dir,
+        participants,
+        args.trajectory_output,
+        summary_output_path=args.summary_output,
+        cue=args.cue,
+        config=config,
+    )
+    print(f"Wrote {len(rows)} trajectory rows to {args.trajectory_output}")
+    if args.summary_output:
+        print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+    return 0
+
+
+def _build_alpha_reaction_time_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Analyze prestimulus alpha metrics against reaction time.")
+    parser.add_argument("--data-dir", default=None, help="Directory containing Part*Data.mat files.")
+    parser.add_argument(
+        "--participants",
+        default=None,
+        help="Participant ids such as 1-4,6,8. Defaults to all available MAT files.",
+    )
+    parser.add_argument(
+        "--reaction-times",
+        default=None,
+        help="CSV containing participant, trial, and reaction_time columns.",
+    )
+    parser.add_argument("--alpha-metrics", default=None, help="Optional precomputed alpha metrics CSV.")
+    parser.add_argument(
+        "--joined-output",
+        required=True,
+        help="Output CSV for matched trial-level alpha/RT rows.",
+    )
+    parser.add_argument("--summary-output", required=True, help="Output CSV for association summaries.")
+    parser.add_argument(
+        "--plots-dir",
+        default=None,
+        help="Optional directory for simple alpha/RT scatter plots.",
+    )
+    parser.add_argument(
+        "--cue",
+        action="store_true",
+        help="Use Part*CueData.mat instead of Part*Data.mat.",
+    )
+    parser.add_argument(
+        "--trialinfo-rt-column",
+        type=int,
+        default=None,
+        help="Zero-based trialinfo column containing RT when no CSV is supplied.",
+    )
+    parser.add_argument(
+        "--reaction-time-scale",
+        type=float,
+        default=1.0,
+        help="Scale applied to RT values, for example 0.001 for milliseconds.",
+    )
+    parser.add_argument("--participant-column", default=None, help="Reaction-time CSV participant column override.")
+    parser.add_argument("--trial-column", default=None, help="Reaction-time CSV trial column override.")
+    parser.add_argument("--reaction-time-column", default=None, help="Reaction-time CSV RT column override.")
+    parser.add_argument("--dataset-column", default=None, help="Reaction-time CSV dataset column override.")
+    add_alpha_metric_arguments(parser)
+    parser.add_argument(
+        "--metrics",
+        nargs="*",
+        default=DEFAULT_ALPHA_RT_METRICS,
+        help="Alpha metrics to summarize.",
+    )
+    return parser
+
+
+def alpha_reaction_time(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_alpha_reaction_time_parser(prog=prog)
+    args = parser.parse_args(argv)
+
+    participants = _participants(args.participants, args.data_dir, args.cue)
+    if not participants and (not args.alpha_metrics or not args.reaction_times):
+        parser.error("No participants found. Pass --participants or configure a data directory with matching MAT files.")
+
+    default_participant = participants[0] if len(participants) == 1 else None
+    alpha_config = alpha_metric_config_from_args(args)
+    csv_config = ReactionTimeCsvConfig(
+        participant_column=args.participant_column,
+        trial_column=args.trial_column,
+        reaction_time_column=args.reaction_time_column,
+        dataset_column=args.dataset_column,
+        default_participant=default_participant,
+        default_dataset="cue" if args.cue else "main",
+        reaction_time_scale=args.reaction_time_scale,
+    )
+    export_config = AlphaReactionTimeExportConfig(
+        reaction_times_path=args.reaction_times,
+        alpha_metrics_path=args.alpha_metrics,
+        joined_output_path=args.joined_output,
+        summary_output_path=args.summary_output,
+        cue=args.cue,
+        alpha_config=alpha_config,
+        csv_config=csv_config,
+        trialinfo_rt_column=args.trialinfo_rt_column,
+        metrics=tuple(args.metrics),
+    )
+
+    joined_rows, summary_rows = export_alpha_reaction_time_analysis(
+        args.data_dir,
+        participants,
+        config=export_config,
+    )
+    if args.plots_dir:
+        write_alpha_reaction_time_plots(joined_rows, args.plots_dir, metrics=args.metrics)
+    print(f"Wrote {len(joined_rows)} matched trial rows to {args.joined_output}")
+    print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+    return 0

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -79,6 +79,53 @@ def _parse_float_list(value: str) -> tuple[float, ...]:
     return values
 
 
+_VALUE_OPTIONS_THAT_CAN_START_WITH_DASH = {
+    "--window-centers",
+    "--time-window",
+    "--scan-time-window",
+    "--threshold-window",
+}
+
+
+def normalize_argv(argv: Sequence[str] | None) -> list[str]:
+    """Normalize selected option-value pairs for negative comma-separated ranges."""
+
+    if argv is None:
+        argv = sys.argv[1:]
+    normalized: list[str] = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token in _VALUE_OPTIONS_THAT_CAN_START_WITH_DASH and index + 1 < len(argv):
+            normalized.append(f"{token}={argv[index + 1]}")
+            index += 2
+            continue
+        normalized.append(token)
+        index += 1
+    return normalized
+
+
+def parse_float_or_inf(value: str) -> float:
+    """Parse a float, ``nan``, or infinity token for CLI arguments."""
+
+    return _float_or_inf(value)
+
+
+def parse_int_or_inf(value: str) -> int | float:
+    """Parse an integer or infinity token for CLI arguments."""
+
+    return _int_or_inf(value)
+
+
+def parse_classifier_param(value: str | None):
+    """Parse a classifier parameter value from a CLI token."""
+
+    return _parse_classifier_param(value)
+
+
+parse_float_list = _parse_float_list
+
+
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--data-dir",

--- a/src/pymegdec/data_download.py
+++ b/src/pymegdec/data_download.py
@@ -1,0 +1,115 @@
+"""Download helpers for private MEG data files used in PyMEGDec CI/workflows."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import urllib.parse
+import urllib.request
+from collections.abc import Sequence
+from pathlib import Path
+
+_ALLOWED_URL_SCHEMES = {"https"}
+
+
+class _HTTPSOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that preserves the HTTPS-only download invariant."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ANN201
+        redirect_url = urllib.parse.urljoin(req.full_url, newurl)
+        _validate_https_url(redirect_url, description="redirect")
+        return super().redirect_request(req, fp, code, msg, headers, redirect_url)
+
+
+_DOWNLOAD_OPENER = urllib.request.build_opener(_HTTPSOnlyRedirectHandler)
+
+
+def _validate_https_url(url: str, *, description: str) -> str:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme.lower() not in _ALLOWED_URL_SCHEMES or not parsed.netloc:
+        raise ValueError(f"Only absolute HTTPS {description} URLs are supported: {url!r}")
+    return url
+
+
+def _urls_from_env(name: str) -> list[str]:
+    raw = os.environ.get(name, "")
+    return [token.strip() for token in re.split(r"[\s,]+", raw) if token.strip()]
+
+
+def _direct_url(url: str) -> str:
+    parsed = urllib.parse.urlparse(_validate_https_url(url, description="source"))
+    if parsed.path.rstrip("/").endswith("/download"):
+        direct_url = url
+    elif "/s/" in f"/{parsed.path.strip('/')}/":
+        direct_url = url.rstrip("/") + "/download"
+    else:
+        direct_url = url
+    return _validate_https_url(direct_url, description="download")
+
+
+def _open_https(request: urllib.request.Request, *, timeout: int):
+    _validate_https_url(request.full_url, description="download")
+    response = _DOWNLOAD_OPENER.open(request, timeout=timeout)
+    _validate_https_url(response.geturl(), description="final download")
+    return response
+
+
+def _filename(response, index: int) -> str:  # noqa: ANN001
+    header = response.headers.get("Content-Disposition", "")
+    match = re.search(r"filename\*\s*=\s*UTF-8''([^;]+)", header, flags=re.IGNORECASE)
+    if match:
+        return Path(urllib.parse.unquote(match.group(1))).name
+    match = re.search(r'filename\s*=\s*"?([^";]+)"?', header, flags=re.IGNORECASE)
+    if match:
+        return Path(urllib.parse.unquote(match.group(1))).name
+    fallback = Path(urllib.parse.urlparse(response.geturl()).path).name
+    if fallback and fallback.lower() != "download":
+        return fallback
+    return f"downloaded_meg_file_{index:04d}.mat"
+
+
+def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Download MEG data files from HTTPS URLs listed in an environment variable.")
+    parser.add_argument("--data-dir", required=True)
+    parser.add_argument("--env-name", default="MEG_DATA_URL_LIST")
+    parser.add_argument("--manifest", default="data-manifest/downloaded-files.txt")
+    return parser
+
+
+def download_meg_data_files(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_parser(prog=prog)
+    args = parser.parse_args(argv)
+
+    urls = _urls_from_env(args.env_name)
+    if not urls:
+        raise SystemExit(f"{args.env_name} is empty")
+
+    data_dir = Path(args.data_dir)
+    if data_dir.exists():
+        shutil.rmtree(data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    downloaded: list[Path] = []
+    for index, url in enumerate(urls, start=1):
+        request = urllib.request.Request(_direct_url(url), headers={"User-Agent": "PyMEGDec"})
+        with _open_https(request, timeout=180) as response:
+            target = data_dir / _filename(response, index)
+            counter = 2
+            while target.exists():
+                target = data_dir / f"{target.stem}_{counter}{target.suffix}"
+                counter += 1
+            with target.open("wb") as output:
+                shutil.copyfileobj(response, output, length=1024 * 1024)
+        downloaded.append(target)
+        print(f"Downloaded file #{index}: {target.name}")
+
+    manifest = Path(args.manifest)
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text("\n".join(str(path) for path in downloaded) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(download_meg_data_files())

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -1,0 +1,115 @@
+"""Grouped command-line dispatcher for PyMEGDec workflows."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable, Sequence
+
+from pymegdec import cli as legacy_cli
+from pymegdec import alpha_cli, stimulus_cli
+from pymegdec.data_download import download_meg_data_files
+
+CommandHandler = Callable[[Sequence[str] | None, str | None], int]
+
+
+def _dispatch_group(group: str, description: str, handlers: dict[str, CommandHandler], argv: Sequence[str]) -> int:
+    if not argv or argv[0] in {"-h", "--help"}:
+        parser = argparse.ArgumentParser(prog=f"pymegdec {group}", description=description)
+        parser.add_argument("subcommand", nargs="?", choices=sorted(handlers), help="Subcommand to run.")
+        parser.print_help()
+        return 0
+
+    subcommand, *remaining = argv
+    if subcommand not in handlers:
+        parser = argparse.ArgumentParser(prog=f"pymegdec {group}", description=description)
+        parser.error(f"Unsupported {group} subcommand: {subcommand}")
+    return handlers[subcommand](remaining, prog=f"pymegdec {group} {subcommand}")
+
+
+def _stimulus_handlers() -> dict[str, CommandHandler]:
+    return {
+        "decoding": legacy_cli.stimulus_decoding,
+        "predictions": stimulus_cli.stimulus_predictions,
+        "robustness": stimulus_cli.stimulus_robustness,
+        "temporal-generalization": stimulus_cli.stimulus_temporal_generalization,
+        "onset-scan": stimulus_cli.stimulus_onset_scan,
+    }
+
+
+def _alpha_handlers() -> dict[str, CommandHandler]:
+    return {
+        "metrics": alpha_cli.alpha_metrics,
+        "movement": alpha_cli.alpha_movement,
+        "movement-results": legacy_cli.alpha_movement_results,
+        "reaction-time": alpha_cli.alpha_reaction_time,
+        "rt": alpha_cli.alpha_reaction_time,
+    }
+
+
+def _data_handlers() -> dict[str, CommandHandler]:
+    return {"download": download_meg_data_files}
+
+
+def _top_level_handlers() -> dict[str, CommandHandler]:
+    return {
+        "cross-validate": legacy_cli.cross_validate,
+        "transfer": legacy_cli.transfer,
+        # Backward-compatible top-level aliases. Prefer grouped forms in new docs.
+        "stimulus-decoding": legacy_cli.stimulus_decoding,
+        "stimulus-predictions": stimulus_cli.stimulus_predictions,
+        "stimulus-robustness": stimulus_cli.stimulus_robustness,
+        "stimulus-temporal-generalization": stimulus_cli.stimulus_temporal_generalization,
+        "stimulus-onset-scan": stimulus_cli.stimulus_onset_scan,
+        "alpha-metrics": alpha_cli.alpha_metrics,
+        "alpha-movement": alpha_cli.alpha_movement,
+        "alpha-movement-results": legacy_cli.alpha_movement_results,
+        "alpha-reaction-time": alpha_cli.alpha_reaction_time,
+        "alpha-rt": alpha_cli.alpha_reaction_time,
+        "download-meg-data": download_meg_data_files,
+    }
+
+
+def _print_main_help() -> None:
+    parser = argparse.ArgumentParser(description="PyMEGDec command-line interface.")
+    parser.add_argument("command", nargs="?", help="Command or command group to run.")
+    parser.print_help()
+    print(
+        "\nCommand groups:\n"
+        "  pymegdec stimulus <decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
+        "  pymegdec alpha <metrics|movement|movement-results|reaction-time|rt>\n"
+        "  pymegdec data <download>\n"
+        "\nCore commands:\n"
+        "  pymegdec cross-validate ...\n"
+        "  pymegdec transfer ...\n"
+        "\nCompatibility aliases such as pymegdec stimulus-decoding and pymegdec alpha-metrics remain available."
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if not argv or argv[0] in {"-h", "--help"}:
+        _print_main_help()
+        return 0
+
+    command, *remaining = argv
+    if command == "stimulus":
+        return _dispatch_group("stimulus", "Stimulus decoding and diagnostics.", _stimulus_handlers(), remaining)
+    if command == "alpha":
+        return _dispatch_group("alpha", "Alpha metric, movement, and reaction-time analyses.", _alpha_handlers(), remaining)
+    if command == "data":
+        return _dispatch_group("data", "Data download and data-management helpers.", _data_handlers(), remaining)
+
+    handlers = _top_level_handlers()
+    if command in handlers:
+        return handlers[command](remaining, prog=f"pymegdec {command}")
+
+    parser = argparse.ArgumentParser(description="PyMEGDec command-line interface.")
+    parser.error(f"Unsupported command: {command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -6,8 +6,7 @@ import argparse
 import sys
 from collections.abc import Callable, Sequence
 
-from pymegdec import cli as legacy_cli
-from pymegdec import alpha_cli, stimulus_cli
+from pymegdec import alpha_cli, cli as legacy_cli, stimulus_cli
 from pymegdec.data_download import download_meg_data_files
 
 CommandHandler = Callable[[Sequence[str] | None, str | None], int]
@@ -24,7 +23,7 @@ def _dispatch_group(group: str, description: str, handlers: dict[str, CommandHan
     if subcommand not in handlers:
         parser = argparse.ArgumentParser(prog=f"pymegdec {group}", description=description)
         parser.error(f"Unsupported {group} subcommand: {subcommand}")
-    return handlers[subcommand](remaining, prog=f"pymegdec {group} {subcommand}")
+    return handlers[subcommand](remaining, f"pymegdec {group} {subcommand}")
 
 
 def _stimulus_handlers() -> dict[str, CommandHandler]:
@@ -104,7 +103,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     handlers = _top_level_handlers()
     if command in handlers:
-        return handlers[command](remaining, prog=f"pymegdec {command}")
+        return handlers[command](remaining, f"pymegdec {command}")
 
     parser = argparse.ArgumentParser(description="PyMEGDec command-line interface.")
     parser.error(f"Unsupported command: {command}")

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -7,7 +7,13 @@ from collections.abc import Sequence
 from dataclasses import replace
 
 from pymegdec.alpha_metrics import write_alpha_metrics_csv
-from pymegdec import cli as legacy_cli
+from pymegdec.cli import (
+    normalize_argv,
+    parse_classifier_param,
+    parse_float_list,
+    parse_float_or_inf,
+    parse_int_or_inf,
+)
 from pymegdec.data_config import resolve_data_folder
 from pymegdec.reaction_time_analysis import available_participants, parse_participant_spec
 from pymegdec.stimulus_decoding import (
@@ -58,14 +64,14 @@ def _parse_time_window(value: str) -> tuple[float, float]:
 
 def _add_model_args(parser: argparse.ArgumentParser, *, include_transfer_direction: bool = True) -> None:
     parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
-    parser.add_argument("--null-window-center", type=legacy_cli._float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
+    parser.add_argument("--null-window-center", type=parse_float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
     if include_transfer_direction:
         parser.add_argument("--transfer-direction", choices=TRANSFER_DIRECTIONS, default="main-to-cue", help="Train/validation dataset direction.")
-    parser.add_argument("--new-framerate", type=legacy_cli._float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
+    parser.add_argument("--new-framerate", type=parse_float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
     parser.add_argument("--classifier", default="multiclass-svm", help="Classifier name.")
     parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
-    parser.add_argument("--components-pca", type=legacy_cli._int_or_inf, default=100, help="Number of PCA components, or inf.")
-    parser.add_argument("--frequency-range", type=legacy_cli._float_or_inf, nargs=2, metavar=("LOW", "HIGH"), default=(0.0, float("inf")), help="Frequency range in Hz.")
+    parser.add_argument("--components-pca", type=parse_int_or_inf, default=100, help="Number of PCA components, or inf.")
+    parser.add_argument("--frequency-range", type=parse_float_or_inf, nargs=2, metavar=("LOW", "HIGH"), default=(0.0, float("inf")), help="Frequency range in Hz.")
     parser.add_argument("--chance-classes", type=int, default=16, help="Number of stimulus classes used for chance level.")
 
 
@@ -76,7 +82,7 @@ def _base_config(args: argparse.Namespace, *, window_centers: tuple[float, ...],
         null_window_center=args.null_window_center,
         new_framerate=args.new_framerate,
         classifier=args.classifier,
-        classifier_param=legacy_cli._parse_classifier_param(args.classifier_param),
+        classifier_param=parse_classifier_param(args.classifier_param),
         components_pca=args.components_pca,
         frequency_range=tuple(args.frequency_range),
         chance_classes=args.chance_classes,
@@ -96,7 +102,7 @@ def _build_predictions_parser(prog: str | None = None) -> argparse.ArgumentParse
     parser = argparse.ArgumentParser(prog=prog, description="Export trial-level stimulus predictions for selected windows.")
     parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
     parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.")
-    parser.add_argument("--window-centers", type=legacy_cli._parse_float_list, default=DEFAULT_PREDICTION_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
+    parser.add_argument("--window-centers", type=parse_float_list, default=DEFAULT_PREDICTION_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
     _add_model_args(parser, include_transfer_direction=True)
     parser.add_argument("--output", default="outputs/stimulus_predictions.csv", help="Output CSV with one row per validation trial and window.")
     parser.add_argument("--summary-output", default="outputs/stimulus_prediction_summary.csv", help="Optional participant/window accuracy summary CSV.")
@@ -108,7 +114,7 @@ def _build_predictions_parser(prog: str | None = None) -> argparse.ArgumentParse
 
 def stimulus_predictions(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     parser = _build_predictions_parser(prog=prog)
-    args = parser.parse_args(legacy_cli._normalize_argv(argv))
+    args = parser.parse_args(normalize_argv(argv))
     data_folder = resolve_data_folder(args.data_folder)
     participants = _participants_or_error(parser, args.participants, data_folder)
     config = _base_config(args, window_centers=args.window_centers)
@@ -151,7 +157,7 @@ def _build_robustness_parser(prog: str | None = None) -> argparse.ArgumentParser
     parser = argparse.ArgumentParser(prog=prog, description="Export two-window robustness controls for stimulus decoding.")
     parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
     parser.add_argument("--participants", default=DEFAULT_ROBUSTNESS_PARTICIPANTS, help="Participant ids such as 1-4,6,8. Defaults to the full current analysis set.")
-    parser.add_argument("--window-centers", type=legacy_cli._parse_float_list, default=DEFAULT_PREDICTION_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
+    parser.add_argument("--window-centers", type=parse_float_list, default=DEFAULT_PREDICTION_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
     _add_model_args(parser, include_transfer_direction=False)
     parser.add_argument("--predictions-output", default="outputs/stimulus_robustness_predictions.csv", help="Output CSV with one row per validation trial/window/control.")
     parser.add_argument("--accuracy-output", default="outputs/stimulus_robustness_accuracy.csv", help="Output CSV with one row per participant/window/control.")
@@ -161,7 +167,7 @@ def _build_robustness_parser(prog: str | None = None) -> argparse.ArgumentParser
 
 def stimulus_robustness(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     parser = _build_robustness_parser(prog=prog)
-    args = parser.parse_args(legacy_cli._normalize_argv(argv))
+    args = parser.parse_args(normalize_argv(argv))
     data_folder = resolve_data_folder(args.data_folder)
     participants = _participants_or_error(parser, args.participants, data_folder)
     base_config = _base_config(args, window_centers=args.window_centers, transfer_direction="main-to-cue")
@@ -208,7 +214,7 @@ def _build_temporal_generalization_parser(prog: str | None = None) -> argparse.A
 
 def stimulus_temporal_generalization(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     parser = _build_temporal_generalization_parser(prog=prog)
-    args = parser.parse_args(legacy_cli._normalize_argv(argv))
+    args = parser.parse_args(normalize_argv(argv))
     data_folder = resolve_data_folder(args.data_folder)
     participants = _participants_or_error(parser, args.participants, data_folder)
     config = _base_config(args, window_centers=window_centers_from_range(args.time_window, args.window_step_s))
@@ -234,7 +240,7 @@ def _build_onset_scan_parser(prog: str | None = None) -> argparse.ArgumentParser
     parser.add_argument("--window-step-s", type=float, default=DEFAULT_ONSET_SCAN_STEP_S, help="Step between scan window centers in seconds.")
     parser.add_argument("--threshold-window", type=_parse_time_window, default=DEFAULT_ONSET_THRESHOLD_WINDOW, help="Window-center range used to estimate the confidence threshold.")
     parser.add_argument("--threshold-quantile", type=float, default=DEFAULT_ONSET_THRESHOLD_QUANTILE, help="Quantile of threshold-window scores used as detection threshold.")
-    parser.add_argument("--detection-start-s", type=legacy_cli._float_or_inf, default=None, help="Optional earliest scan center considered for first detection.")
+    parser.add_argument("--detection-start-s", type=parse_float_or_inf, default=None, help="Optional earliest scan center considered for first detection.")
     _add_model_args(parser, include_transfer_direction=True)
     parser.add_argument("--output", default="outputs/stimulus_onset_scan.csv", help="Output CSV with one row per validation trial and scan window.")
     parser.add_argument("--events-output", default="outputs/stimulus_onset_events.csv", help="Output CSV with one first-detection row per validation trial.")
@@ -245,7 +251,7 @@ def _build_onset_scan_parser(prog: str | None = None) -> argparse.ArgumentParser
 
 def stimulus_onset_scan(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     parser = _build_onset_scan_parser(prog=prog)
-    args = parser.parse_args(legacy_cli._normalize_argv(argv))
+    args = parser.parse_args(normalize_argv(argv))
     if not 0.0 <= args.threshold_quantile <= 1.0:
         parser.error("--threshold-quantile must be between 0 and 1.")
     data_folder = resolve_data_folder(args.data_folder)

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -1,0 +1,272 @@
+"""Stimulus-analysis command handlers for the grouped PyMEGDec CLI."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from dataclasses import replace
+
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+from pymegdec import cli as legacy_cli
+from pymegdec.data_config import resolve_data_folder
+from pymegdec.reaction_time_analysis import available_participants, parse_participant_spec
+from pymegdec.stimulus_decoding import (
+    DEFAULT_ONSET_SCAN_STEP_S,
+    DEFAULT_ONSET_SCAN_TIME_WINDOW,
+    DEFAULT_ONSET_SCAN_TRAIN_WINDOW_CENTER,
+    DEFAULT_ONSET_THRESHOLD_QUANTILE,
+    DEFAULT_ONSET_THRESHOLD_WINDOW,
+    TRANSFER_DIRECTIONS,
+    StimulusDecodingConfig,
+    evaluate_participant_stimulus_decoding_diagnostics,
+    export_stimulus_onset_scan,
+    export_stimulus_temporal_generalization,
+    summarize_stimulus_decoding,
+    summarize_stimulus_prediction_diagnostics,
+    window_centers_from_range,
+)
+from reptrace.decoding.robustness import RobustnessCondition, run_participant_robustness_conditions
+
+DEFAULT_PREDICTION_WINDOW_CENTERS = (-0.175, 0.175)
+DEFAULT_ROBUSTNESS_PARTICIPANTS = "1-4,6,8,9,10,13-27"
+ROBUSTNESS_CONTROLS = (
+    RobustnessCondition("default", "Main-to-cue SVM, PCA 100, broadband"),
+    RobustnessCondition("reverse_transfer", "Cue-to-main SVM, PCA 100, broadband", {"transfer_direction": "cue-to-main"}),
+    RobustnessCondition("weighted_svm", "Main-to-cue balanced SVM, PCA 100, broadband", {"classifier": "multiclass-svm-weighted"}),
+    RobustnessCondition("pca_50", "Main-to-cue SVM, PCA 50, broadband", {"components_pca": 50}),
+    RobustnessCondition("pca_200", "Main-to-cue SVM, PCA 200, broadband", {"components_pca": 200}),
+    RobustnessCondition("low_frequency", "Main-to-cue SVM, PCA 100, 0-30 Hz", {"frequency_range": (0.0, 30.0)}),
+)
+
+
+def _transfer_participants(participant_spec: str | None, data_folder) -> list[int]:
+    if participant_spec:
+        return parse_participant_spec(participant_spec)
+    main_participants = set(available_participants(data_folder, cue=False))
+    cue_participants = set(available_participants(data_folder, cue=True))
+    return sorted(main_participants & cue_participants)
+
+
+def _parse_time_window(value: str) -> tuple[float, float]:
+    parts = tuple(float(token.strip()) for token in value.split(",", maxsplit=1))
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("Time window must have the form start,stop.")
+    if parts[0] > parts[1]:
+        raise argparse.ArgumentTypeError("Time window start must be before stop.")
+    return parts
+
+
+def _add_model_args(parser: argparse.ArgumentParser, *, include_transfer_direction: bool = True) -> None:
+    parser.add_argument("--window-size", type=float, default=0.1, help="Window size in seconds.")
+    parser.add_argument("--null-window-center", type=legacy_cli._float_or_inf, default=float("nan"), help="Center of an optional pre-stimulus null window, or nan.")
+    if include_transfer_direction:
+        parser.add_argument("--transfer-direction", choices=TRANSFER_DIRECTIONS, default="main-to-cue", help="Train/validation dataset direction.")
+    parser.add_argument("--new-framerate", type=legacy_cli._float_or_inf, default=float("inf"), help="Target frame rate, or inf.")
+    parser.add_argument("--classifier", default="multiclass-svm", help="Classifier name.")
+    parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
+    parser.add_argument("--components-pca", type=legacy_cli._int_or_inf, default=100, help="Number of PCA components, or inf.")
+    parser.add_argument("--frequency-range", type=legacy_cli._float_or_inf, nargs=2, metavar=("LOW", "HIGH"), default=(0.0, float("inf")), help="Frequency range in Hz.")
+    parser.add_argument("--chance-classes", type=int, default=16, help="Number of stimulus classes used for chance level.")
+
+
+def _base_config(args: argparse.Namespace, *, window_centers: tuple[float, ...], transfer_direction: str | None = None) -> StimulusDecodingConfig:
+    return StimulusDecodingConfig(
+        window_centers=window_centers,
+        window_size=args.window_size,
+        null_window_center=args.null_window_center,
+        new_framerate=args.new_framerate,
+        classifier=args.classifier,
+        classifier_param=legacy_cli._parse_classifier_param(args.classifier_param),
+        components_pca=args.components_pca,
+        frequency_range=tuple(args.frequency_range),
+        chance_classes=args.chance_classes,
+        permutations=0,
+        transfer_direction=transfer_direction or args.transfer_direction,
+    )
+
+
+def _participants_or_error(parser: argparse.ArgumentParser, spec: str | None, data_folder) -> list[int]:
+    participants = _transfer_participants(spec, data_folder)
+    if not participants:
+        parser.error("No participants found. Pass --participants or configure a data directory with matching main and cue MAT files.")
+    return participants
+
+
+def _build_predictions_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Export trial-level stimulus predictions for selected windows.")
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
+    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.")
+    parser.add_argument("--window-centers", type=legacy_cli._parse_float_list, default=DEFAULT_PREDICTION_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
+    _add_model_args(parser, include_transfer_direction=True)
+    parser.add_argument("--output", default="outputs/stimulus_predictions.csv", help="Output CSV with one row per validation trial and window.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_prediction_summary.csv", help="Optional participant/window accuracy summary CSV.")
+    parser.add_argument("--accuracy-output", default=None, help="Optional participant/window accuracy CSV.")
+    parser.add_argument("--confusion-output", default=None, help="Optional confusion-count CSV.")
+    parser.add_argument("--per-stimulus-output", default=None, help="Optional per-stimulus recall CSV.")
+    return parser
+
+
+def stimulus_predictions(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_predictions_parser(prog=prog)
+    args = parser.parse_args(legacy_cli._normalize_argv(argv))
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = _participants_or_error(parser, args.participants, data_folder)
+    config = _base_config(args, window_centers=args.window_centers)
+
+    accuracy_rows = []
+    prediction_rows = []
+    for participant in participants:
+        print(f"START participant={participant}", flush=True)
+        participant_accuracy, participant_predictions = evaluate_participant_stimulus_decoding_diagnostics(
+            data_folder,
+            participant,
+            config=config,
+            diagnostic_window_centers=args.window_centers,
+        )
+        accuracy_rows.extend(participant_accuracy)
+        prediction_rows.extend(participant_predictions)
+        print(f"DONE participant={participant}", flush=True)
+
+    write_alpha_metrics_csv(prediction_rows, args.output)
+    print(f"Wrote {len(prediction_rows)} trial prediction rows to {args.output}")
+    summary_rows = summarize_stimulus_decoding(accuracy_rows)
+    if args.summary_output:
+        write_alpha_metrics_csv(summary_rows, args.summary_output)
+        print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+    if args.accuracy_output:
+        write_alpha_metrics_csv(accuracy_rows, args.accuracy_output)
+        print(f"Wrote {len(accuracy_rows)} participant/window rows to {args.accuracy_output}")
+    if args.confusion_output or args.per_stimulus_output:
+        confusion_rows, per_stimulus_rows = summarize_stimulus_prediction_diagnostics(prediction_rows)
+        if args.confusion_output:
+            write_alpha_metrics_csv(confusion_rows, args.confusion_output)
+            print(f"Wrote {len(confusion_rows)} confusion rows to {args.confusion_output}")
+        if args.per_stimulus_output:
+            write_alpha_metrics_csv(per_stimulus_rows, args.per_stimulus_output)
+            print(f"Wrote {len(per_stimulus_rows)} per-stimulus rows to {args.per_stimulus_output}")
+    return 0
+
+
+def _build_robustness_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Export two-window robustness controls for stimulus decoding.")
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
+    parser.add_argument("--participants", default=DEFAULT_ROBUSTNESS_PARTICIPANTS, help="Participant ids such as 1-4,6,8. Defaults to the full current analysis set.")
+    parser.add_argument("--window-centers", type=legacy_cli._parse_float_list, default=DEFAULT_PREDICTION_WINDOW_CENTERS, help="Comma-separated window centers in seconds.")
+    _add_model_args(parser, include_transfer_direction=False)
+    parser.add_argument("--predictions-output", default="outputs/stimulus_robustness_predictions.csv", help="Output CSV with one row per validation trial/window/control.")
+    parser.add_argument("--accuracy-output", default="outputs/stimulus_robustness_accuracy.csv", help="Output CSV with one row per participant/window/control.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_robustness_summary.csv", help="Output CSV summarized across participants by window/control.")
+    return parser
+
+
+def stimulus_robustness(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_robustness_parser(prog=prog)
+    args = parser.parse_args(legacy_cli._normalize_argv(argv))
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = _participants_or_error(parser, args.participants, data_folder)
+    base_config = _base_config(args, window_centers=args.window_centers, transfer_direction="main-to-cue")
+
+    def run_participant(control: RobustnessCondition, participant: int):
+        config = replace(base_config, **dict(control.parameters))
+        accuracy, predictions = evaluate_participant_stimulus_decoding_diagnostics(
+            data_folder,
+            participant,
+            config=config,
+            diagnostic_window_centers=args.window_centers,
+        )
+        return {"accuracy": accuracy, "predictions": predictions}
+
+    artifacts = run_participant_robustness_conditions(
+        ROBUSTNESS_CONTROLS,
+        participants,
+        run_participant,
+        progress=lambda message: print(message, flush=True),
+    )
+    accuracy_rows = artifacts.get("accuracy", [])
+    prediction_rows = artifacts.get("predictions", [])
+    write_alpha_metrics_csv(prediction_rows, args.predictions_output)
+    write_alpha_metrics_csv(accuracy_rows, args.accuracy_output)
+    summary_rows = summarize_stimulus_decoding(accuracy_rows)
+    write_alpha_metrics_csv(summary_rows, args.summary_output)
+    print(f"Wrote {len(prediction_rows)} trial prediction rows to {args.predictions_output}")
+    print(f"Wrote {len(accuracy_rows)} participant/window/control rows to {args.accuracy_output}")
+    print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
+    return 0
+
+
+def _build_temporal_generalization_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Export stimulus temporal generalization across train/test windows.")
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
+    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.")
+    parser.add_argument("--time-window", type=_parse_time_window, default=(-0.4, 0.8), help="Window-center range as start,stop in seconds.")
+    parser.add_argument("--window-step-s", type=float, default=0.025, help="Step between train/test window centers in seconds.")
+    _add_model_args(parser, include_transfer_direction=True)
+    parser.add_argument("--output", default="outputs/stimulus_temporal_generalization.csv", help="Output CSV with one row per participant/train-window/test-window.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_temporal_generalization_summary.csv", help="Output CSV summarized across participants by train/test window.")
+    return parser
+
+
+def stimulus_temporal_generalization(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_temporal_generalization_parser(prog=prog)
+    args = parser.parse_args(legacy_cli._normalize_argv(argv))
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = _participants_or_error(parser, args.participants, data_folder)
+    config = _base_config(args, window_centers=window_centers_from_range(args.time_window, args.window_step_s))
+    rows, summary_rows = export_stimulus_temporal_generalization(
+        data_folder,
+        participants,
+        args.output,
+        summary_output_path=args.summary_output,
+        config=config,
+        progress=lambda message: print(message, flush=True),
+    )
+    print(f"Wrote {len(rows)} participant/train/test rows to {args.output}")
+    print(f"Wrote {len(summary_rows)} train/test summary rows to {args.summary_output}")
+    return 0
+
+
+def _build_onset_scan_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Export onset-blind stimulus identity scans across validation windows.")
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
+    parser.add_argument("--participants", default=None, help="Participant ids such as 1-4,6,8. Defaults to all participants with main and cue files.")
+    parser.add_argument("--train-window-center", type=float, default=DEFAULT_ONSET_SCAN_TRAIN_WINDOW_CENTER, help="Known-onset training window center in seconds.")
+    parser.add_argument("--scan-time-window", type=_parse_time_window, default=DEFAULT_ONSET_SCAN_TIME_WINDOW, help="Validation scan center range as start,stop in seconds.")
+    parser.add_argument("--window-step-s", type=float, default=DEFAULT_ONSET_SCAN_STEP_S, help="Step between scan window centers in seconds.")
+    parser.add_argument("--threshold-window", type=_parse_time_window, default=DEFAULT_ONSET_THRESHOLD_WINDOW, help="Window-center range used to estimate the confidence threshold.")
+    parser.add_argument("--threshold-quantile", type=float, default=DEFAULT_ONSET_THRESHOLD_QUANTILE, help="Quantile of threshold-window scores used as detection threshold.")
+    parser.add_argument("--detection-start-s", type=legacy_cli._float_or_inf, default=None, help="Optional earliest scan center considered for first detection.")
+    _add_model_args(parser, include_transfer_direction=True)
+    parser.add_argument("--output", default="outputs/stimulus_onset_scan.csv", help="Output CSV with one row per validation trial and scan window.")
+    parser.add_argument("--events-output", default="outputs/stimulus_onset_events.csv", help="Output CSV with one first-detection row per validation trial.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_onset_scan_summary.csv", help="Optional participant/scan-window summary CSV.")
+    parser.add_argument("--event-summary-output", default="outputs/stimulus_onset_event_summary.csv", help="Optional participant first-detection summary CSV.")
+    return parser
+
+
+def stimulus_onset_scan(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_onset_scan_parser(prog=prog)
+    args = parser.parse_args(legacy_cli._normalize_argv(argv))
+    if not 0.0 <= args.threshold_quantile <= 1.0:
+        parser.error("--threshold-quantile must be between 0 and 1.")
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = _participants_or_error(parser, args.participants, data_folder)
+    config = _base_config(args, window_centers=window_centers_from_range(args.scan_time_window, args.window_step_s))
+    scan_rows, event_rows, summary_rows, event_summary_rows = export_stimulus_onset_scan(
+        data_folder,
+        participants,
+        args.output,
+        args.events_output,
+        summary_output_path=args.summary_output,
+        event_summary_output_path=args.event_summary_output,
+        config=config,
+        train_window_center=args.train_window_center,
+        threshold_window=args.threshold_window,
+        threshold_quantile=args.threshold_quantile,
+        detection_start_s=args.detection_start_s,
+        progress=lambda message: print(message, flush=True),
+    )
+    print(f"Wrote {len(scan_rows)} trial/window scan rows to {args.output}")
+    print(f"Wrote {len(event_rows)} first-detection rows to {args.events_output}")
+    print(f"Wrote {len(summary_rows)} scan summary rows to {args.summary_output}")
+    print(f"Wrote {len(event_summary_rows)} event summary rows to {args.event_summary_output}")
+    return 0


### PR DESCRIPTION
## Summary

Consolidates the remaining standalone PyMEGDec scripts into package-level grouped CLI commands.

Adds `pymegdec.grouped_cli` as the installed dispatcher, plus package command modules for alpha workflows, stimulus workflows, and MEG data-file retrieval. Historical Python scripts now delegate to package-level handlers instead of carrying their own argparse implementations.

New preferred command forms include:

- `pymegdec stimulus decoding`
- `pymegdec stimulus predictions`
- `pymegdec stimulus robustness`
- `pymegdec stimulus temporal-generalization`
- `pymegdec stimulus onset-scan`
- `pymegdec alpha metrics`
- `pymegdec alpha movement`
- `pymegdec alpha movement-results`
- `pymegdec alpha reaction-time`
- `pymegdec data download`

Compatibility aliases such as `pymegdec stimulus-decoding`, `pymegdec alpha-metrics`, and the top-level wrapper scripts remain available.

## Notes

`docs/cli.md` has been updated with the new command layout. CI should validate the existing unit, static, and docs workflows.