### PR TITLE
Add synthetic demo data generator

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,7 @@ Available subcommands:
 pymegdec cross-validate --participant 2
 pymegdec transfer --participant 2 --classifier multiclass-svm
 pymegdec stimulus-decoding --participants 2 --output outputs/part2_stimulus_decoding.csv
+pymegdec make-synthetic-data --out demo-data
 pymegdec alpha-movement-results --movement-summary outputs/part2_alpha_movement_summary.csv --effect-output outputs/part2_alpha_movement_effects.csv --condition-summary-output outputs/part2_alpha_movement_condition_summary.csv
 ```
 
@@ -27,6 +28,7 @@ pymegdec-cross-validate
 pymegdec-transfer
 pymegdec-stimulus-decoding
 pymegdec-alpha-movement-results
+pymegdec-make-synthetic-data
 ```
 
 Top-level Python wrappers remain available for existing workflows, for example:
@@ -53,6 +55,37 @@ The cross-validation and transfer commands share the core decoding options:
 | `--classifier-param` | Numeric, JSON, or Python literal parameter. | `1.0` |
 | `--components-pca` | PCA component count, or `inf`. | `100` |
 | `--frequency-range LOW HIGH` | Frequency range in Hz. | `0 inf` |
+
+## Synthetic demo data
+
+Generate balanced private-data-free MATLAB files for participant 2:
+
+```bash
+pymegdec make-synthetic-data --out demo-data
+```
+
+The generator writes `Part2Data.mat`, `Part2CueData.mat`, and
+`synthetic_data_manifest.json`. The generated files follow the same participant
+file naming convention as the private MEG data and can be used with the standard
+commands:
+
+```bash
+pymegdec cross-validate --data-dir demo-data --participant 2
+pymegdec transfer --data-dir demo-data --participant 2 --null-window-center nan
+```
+
+Customize the generated dataset when testing edge cases:
+
+```bash
+pymegdec make-synthetic-data \
+  --out demo-data \
+  --participant 3 \
+  --classes 4 \
+  --main-repeats 8 \
+  --cue-repeats 4 \
+  --channels 6 \
+  --overwrite
+```
 
 ## Cross-validation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,14 @@ python -m unittest discover -v
 Fast unit tests are designed to run without private MEG files. Data-dependent
 integration tests are skipped when the data directory cannot be resolved.
 
+Create a private-data-free demo directory when you want to exercise the command-line workflows without access to the real MEG files:
+
+```bash
+pymegdec make-synthetic-data --out demo-data
+pymegdec cross-validate --data-dir demo-data --participant 2
+pymegdec transfer --data-dir demo-data --participant 2 --null-window-center nan
+```
+
 To run the integration checks, configure a data directory containing files such
 as `Part2Data.mat` and `Part2CueData.mat` before invoking the same test command.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ pymegdec-cross-validate = "pymegdec.cli:cross_validate"
 pymegdec-transfer = "pymegdec.cli:transfer"
 pymegdec-stimulus-decoding = "pymegdec.cli:stimulus_decoding"
 pymegdec-alpha-movement-results = "pymegdec.cli:alpha_movement_results"
+pymegdec-make-synthetic-data = "pymegdec.cli:make_synthetic_data"
 
 [tool.poetry]
 packages = [{ include = "pymegdec", from = "src" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,12 @@ dev = [
 ]
 
 [project.scripts]
-pymegdec = "pymegdec.cli:main"
+pymegdec = "pymegdec.cli_with_synthetic:main"
 pymegdec-cross-validate = "pymegdec.cli:cross_validate"
 pymegdec-transfer = "pymegdec.cli:transfer"
 pymegdec-stimulus-decoding = "pymegdec.cli:stimulus_decoding"
 pymegdec-alpha-movement-results = "pymegdec.cli:alpha_movement_results"
-pymegdec-make-synthetic-data = "pymegdec.cli:make_synthetic_data"
+pymegdec-make-synthetic-data = "pymegdec.synthetic_data_cli:main"
 
 [tool.poetry]
 packages = [{ include = "pymegdec", from = "src" }]

--- a/src/pymegdec/cli_with_synthetic.py
+++ b/src/pymegdec/cli_with_synthetic.py
@@ -1,0 +1,52 @@
+"""Grouped PyMEGDec CLI wrapper with synthetic demo-data support."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from . import cli as legacy_cli
+from .synthetic_data_cli import make_synthetic_data
+
+COMMANDS = (
+    "cross-validate",
+    "transfer",
+    "stimulus-decoding",
+    "make-synthetic-data",
+    "alpha-movement-results",
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Dispatch grouped PyMEGDec commands.
+
+    Existing workflow implementations remain in :mod:`pymegdec.cli`; this
+    wrapper adds the synthetic data generator while preserving the legacy
+    command behavior and compatibility entry points.
+    """
+
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(description="PyMEGDec command-line interface.")
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=COMMANDS,
+        help="Workflow to run.",
+    )
+    args, remaining = parser.parse_known_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    if args.command == "make-synthetic-data":
+        return make_synthetic_data(remaining, prog="pymegdec make-synthetic-data")
+
+    return legacy_cli.main([args.command, *remaining])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pymegdec/synthetic_data.py
+++ b/src/pymegdec/synthetic_data.py
@@ -10,6 +10,9 @@ import numpy as np
 import scipy.io as sio
 
 
+# This config intentionally keeps all generator knobs in one immutable value
+# object so tests, docs, and CLI output can serialize the exact configuration.
+# pylint: disable-next=too-many-instance-attributes
 @dataclass(frozen=True)
 class SyntheticDataConfig:
     """Configuration for a private-data-free PyMEGDec demo dataset.
@@ -52,34 +55,37 @@ class SyntheticDataOutput:
     n_times: int
 
 
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
 def _validate_config(config: SyntheticDataConfig) -> None:
-    if config.participant_id < 1:
-        raise ValueError("participant_id must be positive.")
-    if config.n_classes < 2:
-        raise ValueError("n_classes must be at least 2 for decoding demos.")
-    if config.main_repeats_per_class < 1:
-        raise ValueError("main_repeats_per_class must be at least 1.")
-    if config.cue_repeats_per_class < 1:
-        raise ValueError("cue_repeats_per_class must be at least 1.")
-    if config.n_channels < 3:
-        raise ValueError("n_channels must be at least 3 so sensor geometry is usable.")
-    if config.n_times < 3:
-        raise ValueError("n_times must be at least 3.")
-    if config.tmin >= config.tmax:
-        raise ValueError("tmin must be smaller than tmax.")
+    for field_name, minimum, message in (
+        ("participant_id", 1, "participant_id must be positive."),
+        ("n_classes", 2, "n_classes must be at least 2 for decoding demos."),
+        ("main_repeats_per_class", 1, "main_repeats_per_class must be at least 1."),
+        ("cue_repeats_per_class", 1, "cue_repeats_per_class must be at least 1."),
+        ("n_channels", 3, "n_channels must be at least 3 so sensor geometry is usable."),
+        ("n_times", 3, "n_times must be at least 3."),
+    ):
+        _require(getattr(config, field_name) >= minimum, message)
+
     window_start, window_stop = config.stimulus_window
-    if window_start >= window_stop:
-        raise ValueError("stimulus_window start must be smaller than stop.")
-    if window_stop < config.tmin or window_start > config.tmax:
-        raise ValueError("stimulus_window must overlap the generated time vector.")
-    if config.signal_scale <= 0:
-        raise ValueError("signal_scale must be positive.")
-    if config.noise_scale < 0:
-        raise ValueError("noise_scale must be non-negative.")
-    if config.alpha_scale < 0:
-        raise ValueError("alpha_scale must be non-negative.")
-    if config.cue_shift_scale < 0:
-        raise ValueError("cue_shift_scale must be non-negative.")
+    _require(config.tmin < config.tmax, "tmin must be smaller than tmax.")
+    _require(window_start < window_stop, "stimulus_window start must be smaller than stop.")
+    _require(
+        window_stop >= config.tmin and window_start <= config.tmax,
+        "stimulus_window must overlap the generated time vector.",
+    )
+    for field_name, message in (
+        ("signal_scale", "signal_scale must be positive."),
+        ("noise_scale", "noise_scale must be non-negative."),
+        ("alpha_scale", "alpha_scale must be non-negative."),
+        ("cue_shift_scale", "cue_shift_scale must be non-negative."),
+    ):
+        lower_bound = 0.0 if field_name != "signal_scale" else np.finfo(float).tiny
+        _require(getattr(config, field_name) >= lower_bound, message)
 
 
 def _balanced_labels(n_classes: int, repeats_per_class: int) -> np.ndarray:

--- a/src/pymegdec/synthetic_data.py
+++ b/src/pymegdec/synthetic_data.py
@@ -12,9 +12,8 @@ import scipy.io as sio
 
 # This config intentionally keeps all generator knobs in one immutable value
 # object so tests, docs, and CLI output can serialize the exact configuration.
-# pylint: disable-next=too-many-instance-attributes
 @dataclass(frozen=True)
-class SyntheticDataConfig:
+class SyntheticDataConfig:  # pylint: disable=too-many-instance-attributes
     """Configuration for a private-data-free PyMEGDec demo dataset.
 
     The generated files mimic the FieldTrip-like MATLAB structs expected by the

--- a/src/pymegdec/synthetic_data.py
+++ b/src/pymegdec/synthetic_data.py
@@ -1,0 +1,233 @@
+"""Synthetic MATLAB fixtures for PyMEGDec smoke tests and demos."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+import scipy.io as sio
+
+
+@dataclass(frozen=True)
+class SyntheticDataConfig:
+    """Configuration for a private-data-free PyMEGDec demo dataset.
+
+    The generated files mimic the FieldTrip-like MATLAB structs expected by the
+    existing PyMEGDec loaders: ``trial``, ``time``, ``trialinfo``, ``label``, and
+    ``grad.chanpos``. Labels are one-based stimulus ids so that the data can be
+    used with the legacy cross-validation and transfer workflows.
+    """
+
+    participant_id: int = 2
+    n_classes: int = 16
+    main_repeats_per_class: int = 10
+    cue_repeats_per_class: int = 5
+    n_channels: int = 8
+    n_times: int = 261
+    tmin: float = -0.5
+    tmax: float = 0.8
+    stimulus_window: tuple[float, float] = (0.15, 0.25)
+    signal_scale: float = 6.0
+    noise_scale: float = 0.05
+    alpha_scale: float = 0.02
+    cue_shift_scale: float = 0.15
+    random_seed: int = 13
+
+
+@dataclass(frozen=True)
+class SyntheticDataOutput:
+    """Paths and dimensions written by :func:`write_synthetic_dataset`."""
+
+    data_dir: Path
+    participant_id: int
+    main_path: Path
+    cue_path: Path
+    manifest_path: Path | None
+    main_trials: int
+    cue_trials: int
+    n_classes: int
+    n_channels: int
+    n_times: int
+
+
+def _validate_config(config: SyntheticDataConfig) -> None:
+    if config.participant_id < 1:
+        raise ValueError("participant_id must be positive.")
+    if config.n_classes < 2:
+        raise ValueError("n_classes must be at least 2 for decoding demos.")
+    if config.main_repeats_per_class < 1:
+        raise ValueError("main_repeats_per_class must be at least 1.")
+    if config.cue_repeats_per_class < 1:
+        raise ValueError("cue_repeats_per_class must be at least 1.")
+    if config.n_channels < 3:
+        raise ValueError("n_channels must be at least 3 so sensor geometry is usable.")
+    if config.n_times < 3:
+        raise ValueError("n_times must be at least 3.")
+    if config.tmin >= config.tmax:
+        raise ValueError("tmin must be smaller than tmax.")
+    window_start, window_stop = config.stimulus_window
+    if window_start >= window_stop:
+        raise ValueError("stimulus_window start must be smaller than stop.")
+    if window_stop < config.tmin or window_start > config.tmax:
+        raise ValueError("stimulus_window must overlap the generated time vector.")
+    if config.signal_scale <= 0:
+        raise ValueError("signal_scale must be positive.")
+    if config.noise_scale < 0:
+        raise ValueError("noise_scale must be non-negative.")
+    if config.alpha_scale < 0:
+        raise ValueError("alpha_scale must be non-negative.")
+    if config.cue_shift_scale < 0:
+        raise ValueError("cue_shift_scale must be non-negative.")
+
+
+def _balanced_labels(n_classes: int, repeats_per_class: int) -> np.ndarray:
+    """Return cyclic one-based labels with contiguous-fold friendly ordering."""
+
+    return np.tile(np.arange(1, n_classes + 1, dtype=int), repeats_per_class)
+
+
+def _class_prototypes(rng: np.random.Generator, n_classes: int, n_channels: int) -> np.ndarray:
+    prototypes = rng.normal(size=(n_classes, n_channels))
+    norms = np.linalg.norm(prototypes, axis=1, keepdims=True)
+    return prototypes / np.maximum(norms, np.finfo(float).eps)
+
+
+def _channel_names(n_channels: int) -> np.ndarray:
+    prefixes = ("MLO", "MRO", "MZO", "MLT", "MRT", "MZT", "MLF", "MRF")
+    return np.asarray(
+        [[f"{prefixes[index % len(prefixes)]}{index + 1:03d}" for index in range(n_channels)]],
+        dtype=object,
+    )
+
+
+def _channel_positions(n_channels: int) -> np.ndarray:
+    angles = np.linspace(0.0, 2.0 * np.pi, n_channels, endpoint=False)
+    radius_mm = 80.0
+    return np.column_stack(
+        [
+            radius_mm * np.cos(angles),
+            radius_mm * np.sin(angles),
+            20.0 * np.sin(2.0 * angles),
+        ]
+    )
+
+
+def _synthetic_part_data(
+    labels: np.ndarray,
+    *,
+    time_vector: np.ndarray,
+    prototypes: np.ndarray,
+    rng: np.random.Generator,
+    config: SyntheticDataConfig,
+    cue: bool = False,
+) -> dict[str, object]:
+    stimulus_mask = (time_vector >= config.stimulus_window[0]) & (time_vector <= config.stimulus_window[1])
+    channel_phase = np.linspace(0.0, np.pi, config.n_channels, endpoint=False)[:, None]
+    alpha_carrier = np.sin(2.0 * np.pi * 10.0 * time_vector[None, :] + channel_phase)
+    cue_shift = rng.normal(scale=config.cue_shift_scale, size=(config.n_channels, 1)) if cue else 0.0
+
+    trials = np.empty((1, labels.size), dtype=object)
+    times = np.empty((1, labels.size), dtype=object)
+    for trial_index, label in enumerate(labels):
+        trial = rng.normal(scale=config.noise_scale, size=(config.n_channels, config.n_times))
+        trial += config.alpha_scale * alpha_carrier
+        class_pattern = prototypes[int(label) - 1][:, None]
+        trial[:, stimulus_mask] += config.signal_scale * class_pattern + cue_shift
+        # Add a tiny deterministic trial offset so tests can detect accidental
+        # trial reordering while keeping class structure dominant.
+        trial += 1e-4 * (trial_index + 1)
+        trials[0, trial_index] = trial.astype(float, copy=False)
+        times[0, trial_index] = time_vector[None, :]
+
+    return {
+        "trial": trials,
+        "time": times,
+        "trialinfo": labels[None, :],
+        "label": _channel_names(config.n_channels),
+        "grad": {"chanpos": _channel_positions(config.n_channels)},
+    }
+
+
+def _manifest(output: SyntheticDataOutput, config: SyntheticDataConfig) -> dict[str, object]:
+    return {
+        "participant_id": output.participant_id,
+        "main_file": output.main_path.name,
+        "cue_file": output.cue_path.name,
+        "main_trials": output.main_trials,
+        "cue_trials": output.cue_trials,
+        "n_classes": output.n_classes,
+        "n_channels": output.n_channels,
+        "n_times": output.n_times,
+        "config": asdict(config),
+    }
+
+
+def write_synthetic_dataset(
+    data_dir: str | Path,
+    config: SyntheticDataConfig | None = None,
+    *,
+    overwrite: bool = False,
+    write_manifest: bool = True,
+) -> SyntheticDataOutput:
+    """Write balanced ``Part*Data.mat`` and ``Part*CueData.mat`` demo files.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory that receives the generated MAT files.
+    config:
+        Synthetic dataset parameters. Defaults are chosen to support the
+        package's cross-validation and transfer commands without private data.
+    overwrite:
+        Replace existing output files when true.
+    write_manifest:
+        Write a small JSON manifest next to the MAT files when true.
+    """
+
+    config = config or SyntheticDataConfig()
+    _validate_config(config)
+
+    output_dir = Path(data_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    main_path = output_dir / f"Part{config.participant_id}Data.mat"
+    cue_path = output_dir / f"Part{config.participant_id}CueData.mat"
+    manifest_path = output_dir / "synthetic_data_manifest.json" if write_manifest else None
+
+    existing = [path for path in (main_path, cue_path, manifest_path) if path is not None and path.exists()]
+    if existing and not overwrite:
+        names = ", ".join(str(path) for path in existing)
+        raise FileExistsError(f"Synthetic data output already exists: {names}. Pass overwrite=True to replace it.")
+
+    rng = np.random.default_rng(config.random_seed)
+    prototypes = _class_prototypes(rng, config.n_classes, config.n_channels)
+    time_vector = np.linspace(config.tmin, config.tmax, config.n_times)
+    main_labels = _balanced_labels(config.n_classes, config.main_repeats_per_class)
+    cue_labels = _balanced_labels(config.n_classes, config.cue_repeats_per_class)
+
+    sio.savemat(
+        main_path,
+        {"data": _synthetic_part_data(main_labels, time_vector=time_vector, prototypes=prototypes, rng=rng, config=config)},
+    )
+    sio.savemat(
+        cue_path,
+        {"data": _synthetic_part_data(cue_labels, time_vector=time_vector, prototypes=prototypes, rng=rng, config=config, cue=True)},
+    )
+
+    output = SyntheticDataOutput(
+        data_dir=output_dir,
+        participant_id=config.participant_id,
+        main_path=main_path,
+        cue_path=cue_path,
+        manifest_path=manifest_path,
+        main_trials=int(main_labels.size),
+        cue_trials=int(cue_labels.size),
+        n_classes=config.n_classes,
+        n_channels=config.n_channels,
+        n_times=config.n_times,
+    )
+    if manifest_path is not None:
+        manifest_path.write_text(json.dumps(_manifest(output, config), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return output

--- a/src/pymegdec/synthetic_data_cli.py
+++ b/src/pymegdec/synthetic_data_cli.py
@@ -1,0 +1,96 @@
+"""Command-line interface for generating PyMEGDec synthetic demo data."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+from .synthetic_data import SyntheticDataConfig, write_synthetic_dataset
+
+
+def _parse_float_list(value: str) -> tuple[float, ...]:
+    values = tuple(float(token.strip()) for token in value.split(",") if token.strip())
+    if not values:
+        raise argparse.ArgumentTypeError("At least one value is required.")
+    return values
+
+
+def _parse_float_range(value: str) -> tuple[float, float]:
+    values = _parse_float_list(value)
+    if len(values) != 2:
+        raise argparse.ArgumentTypeError("Expected exactly two comma-separated values: start,stop.")
+    return values
+
+
+def build_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    """Build the synthetic-data generator parser."""
+
+    defaults = SyntheticDataConfig()
+    parser = argparse.ArgumentParser(prog=prog, description="Create private-data-free synthetic Part*Data.mat demo files.")
+    parser.add_argument("--out", "--out-dir", dest="out_dir", required=True, help="Output directory for generated MAT files.")
+    parser.add_argument("--participant", type=int, default=defaults.participant_id, help="Participant id used in Part* file names.")
+    parser.add_argument("--classes", type=int, default=defaults.n_classes, help="Number of one-based stimulus classes.")
+    parser.add_argument("--main-repeats", type=int, default=defaults.main_repeats_per_class, help="Main-experiment repeats per class.")
+    parser.add_argument("--cue-repeats", type=int, default=defaults.cue_repeats_per_class, help="Cue-experiment repeats per class.")
+    parser.add_argument("--channels", type=int, default=defaults.n_channels, help="Number of MEG channels.")
+    parser.add_argument("--times", type=int, default=defaults.n_times, help="Number of time samples per trial.")
+    parser.add_argument("--tmin", type=float, default=defaults.tmin, help="First sample time in seconds.")
+    parser.add_argument("--tmax", type=float, default=defaults.tmax, help="Last sample time in seconds.")
+    parser.add_argument(
+        "--stimulus-window",
+        type=_parse_float_range,
+        default=defaults.stimulus_window,
+        help="Class-informative window as start,stop in seconds.",
+    )
+    parser.add_argument("--signal-scale", type=float, default=defaults.signal_scale, help="Class-pattern amplitude in the stimulus window.")
+    parser.add_argument("--noise-scale", type=float, default=defaults.noise_scale, help="Gaussian observation noise scale.")
+    parser.add_argument("--alpha-scale", type=float, default=defaults.alpha_scale, help="Background 10 Hz carrier amplitude.")
+    parser.add_argument("--cue-shift-scale", type=float, default=defaults.cue_shift_scale, help="Small cue-domain shift scale.")
+    parser.add_argument("--seed", type=int, default=defaults.random_seed, help="Random seed for reproducible data.")
+    parser.add_argument("--overwrite", action="store_true", help="Replace existing generated files.")
+    parser.add_argument("--no-manifest", action="store_true", help="Do not write synthetic_data_manifest.json.")
+    return parser
+
+
+def make_synthetic_data(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    """Generate private-data-free PyMEGDec demo MAT files."""
+
+    parser = build_parser(prog=prog)
+    args = parser.parse_args(argv)
+    config = SyntheticDataConfig(
+        participant_id=args.participant,
+        n_classes=args.classes,
+        main_repeats_per_class=args.main_repeats,
+        cue_repeats_per_class=args.cue_repeats,
+        n_channels=args.channels,
+        n_times=args.times,
+        tmin=args.tmin,
+        tmax=args.tmax,
+        stimulus_window=args.stimulus_window,
+        signal_scale=args.signal_scale,
+        noise_scale=args.noise_scale,
+        alpha_scale=args.alpha_scale,
+        cue_shift_scale=args.cue_shift_scale,
+        random_seed=args.seed,
+    )
+    output = write_synthetic_dataset(
+        args.out_dir,
+        config,
+        overwrite=args.overwrite,
+        write_manifest=not args.no_manifest,
+    )
+    print(f"Wrote main data: {output.main_path}")
+    print(f"Wrote cue data: {output.cue_path}")
+    if output.manifest_path is not None:
+        print(f"Wrote manifest: {output.manifest_path}")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Console entry point for ``pymegdec-make-synthetic-data``."""
+
+    return make_synthetic_data(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_synthetic_data_generator.py
+++ b/tests/test_synthetic_data_generator.py
@@ -1,0 +1,88 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import scipy.io as sio
+
+from pymegdec.cli import make_synthetic_data
+from pymegdec.synthetic_data import SyntheticDataConfig, write_synthetic_dataset
+
+
+class TestSyntheticDataGenerator(unittest.TestCase):
+    def test_write_synthetic_dataset_creates_participant_mat_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output = write_synthetic_dataset(
+                tmp_dir,
+                SyntheticDataConfig(
+                    participant_id=7,
+                    n_classes=2,
+                    main_repeats_per_class=4,
+                    cue_repeats_per_class=2,
+                    n_channels=4,
+                    n_times=101,
+                    tmax=0.5,
+                    noise_scale=0.01,
+                    alpha_scale=0.0,
+                ),
+            )
+
+            self.assertTrue(output.main_path.exists())
+            self.assertTrue(output.cue_path.exists())
+            self.assertTrue(output.manifest_path.exists())
+            self.assertEqual(output.main_trials, 8)
+            self.assertEqual(output.cue_trials, 4)
+
+            data = sio.loadmat(output.main_path)["data"][0]
+            self.assertIn("trial", data.dtype.names)
+            self.assertIn("time", data.dtype.names)
+            self.assertIn("trialinfo", data.dtype.names)
+            self.assertIn("label", data.dtype.names)
+            self.assertIn("grad", data.dtype.names)
+            self.assertEqual(len(data["trial"][0][0]), 8)
+            self.assertEqual(data["trial"][0][0][0].shape, (4, 101))
+            self.assertEqual(data["trialinfo"][0][0].tolist(), [1, 2, 1, 2, 1, 2, 1, 2])
+
+    def test_write_synthetic_dataset_refuses_to_overwrite_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = SyntheticDataConfig(n_classes=2, main_repeats_per_class=1, cue_repeats_per_class=1)
+            write_synthetic_dataset(tmp_dir, config)
+
+            with self.assertRaises(FileExistsError):
+                write_synthetic_dataset(tmp_dir, config)
+
+            output = write_synthetic_dataset(tmp_dir, config, overwrite=True)
+            self.assertTrue(output.main_path.exists())
+
+    def test_make_synthetic_data_cli(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            exit_code = make_synthetic_data(
+                [
+                    "--out",
+                    tmp_dir,
+                    "--participant",
+                    "3",
+                    "--classes",
+                    "2",
+                    "--main-repeats",
+                    "3",
+                    "--cue-repeats",
+                    "2",
+                    "--channels",
+                    "4",
+                    "--times",
+                    "101",
+                    "--tmax",
+                    "0.5",
+                    "--seed",
+                    "11",
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue((Path(tmp_dir) / "Part3Data.mat").exists())
+            self.assertTrue((Path(tmp_dir) / "Part3CueData.mat").exists())
+            self.assertTrue((Path(tmp_dir) / "synthetic_data_manifest.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_synthetic_data_generator.py
+++ b/tests/test_synthetic_data_generator.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 import scipy.io as sio
 
-from pymegdec.cli import make_synthetic_data
 from pymegdec.synthetic_data import SyntheticDataConfig, write_synthetic_dataset
+from pymegdec.synthetic_data_cli import make_synthetic_data
 
 
 class TestSyntheticDataGenerator(unittest.TestCase):

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -1,3 +1,4 @@
+import importlib.util
 import unittest
 
 import numpy as np
@@ -22,11 +23,9 @@ class TestMLPClassifierTorch(unittest.TestCase):
         self.assertEqual(optimizer.param_groups[0]["lr"], 0.123)
 
     def test_seeded_data_loaders_are_reproducible(self):
-        try:
-            import torch  # noqa: F401
-            from pymegdec.classifiers import _build_pytorch_data_loaders
-        except ImportError as exc:
-            self.skipTest(f"PyTorch dependencies are not installed: {exc}")
+        if importlib.util.find_spec("torch") is None:
+            self.skipTest("PyTorch dependencies are not installed: No module named 'torch'")
+        from pymegdec.classifiers import _build_pytorch_data_loaders
 
         features = np.arange(40).reshape(20, 2)
         labels = np.arange(20)

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -23,6 +23,7 @@ class TestMLPClassifierTorch(unittest.TestCase):
 
     def test_seeded_data_loaders_are_reproducible(self):
         try:
+            import torch  # noqa: F401
             from pymegdec.classifiers import _build_pytorch_data_loaders
         except ImportError as exc:
             self.skipTest(f"PyTorch dependencies are not installed: {exc}")


### PR DESCRIPTION
## Summary

- add `pymegdec.synthetic_data` for generating private-data-free `Part*Data.mat` and `Part*CueData.mat` MATLAB demo fixtures
- add `pymegdec make-synthetic-data` and `pymegdec-make-synthetic-data` entry points
- document the synthetic smoke workflow in the CLI and getting-started docs
- add unit tests for generated MAT structure, overwrite protection, and the CLI wrapper

## Usage

```bash
pymegdec make-synthetic-data --out demo-data
pymegdec cross-validate --data-dir demo-data --participant 2
pymegdec transfer --data-dir demo-data --participant 2 --null-window-center nan
```

## Validation

Not run in the connector environment. CI should run:

```bash
python -m unittest tests.test_synthetic_data_generator -v
python -m unittest discover -v
```
