### PR TITLE
Exclude workflows from JSCPD duplicate checks

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,4 +1,7 @@
 {
   "gitignore": true,
+  "ignore": [
+    "**/.github/workflows/**"
+  ],
   "threshold": 1
 }


### PR DESCRIPTION
## Summary
- configure JSCPD to ignore `.github/workflows/**`
- keep workflow files available to the GitHub Actions/YAML linters while excluding them from duplicate-code detection

## Validation
- parsed `.jscpd.json` as JSON
- ran `git diff --check`