### PR TITLE
Use rclone for private MEG data downloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/scripts/install-rclone.sh
+++ b/.github/scripts/install-rclone.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v rclone >/dev/null 2>&1; then
+  mkdir -p "$RUNNER_TEMP/rclone-bin" "$RUNNER_TEMP/rclone-download"
+  curl -fsSL https://downloads.rclone.org/rclone-current-linux-amd64.zip -o "$RUNNER_TEMP/rclone-download/rclone.zip"
+  python3 - <<'PY'
+import os
+import shutil
+import zipfile
+from pathlib import Path
+
+temp = Path(os.environ["RUNNER_TEMP"])
+zip_path = temp / "rclone-download" / "rclone.zip"
+extract_dir = temp / "rclone-download" / "extract"
+bin_dir = temp / "rclone-bin"
+with zipfile.ZipFile(zip_path) as archive:
+    archive.extractall(extract_dir)
+matches = list(extract_dir.glob("rclone-*/rclone"))
+if not matches:
+    raise SystemExit("Downloaded rclone archive did not contain an rclone binary.")
+target = bin_dir / "rclone"
+shutil.copy2(matches[0], target)
+target.chmod(0o755)
+PY
+  echo "$RUNNER_TEMP/rclone-bin" >> "$GITHUB_PATH"
+  export PATH="$RUNNER_TEMP/rclone-bin:$PATH"
+fi
+
+rclone version

--- a/.github/workflows/download-meg-data.yml
+++ b/.github/workflows/download-meg-data.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  DATA_CACHE_VERSION: v1
+  DATA_CACHE_VERSION: v2
   DATA_DIR: .cache/meg-data-all
 
 jobs:
@@ -25,11 +25,17 @@ jobs:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
 
-      - name: Download MEG data files
+      - name: Install rclone
+        if: ${{ steps.meg-data-cache.outputs.cache-hit != 'true' }}
+        run: .github/scripts/install-rclone.sh
+
+      - name: Download MEG data files from OwnCloud WebDAV
         if: ${{ steps.meg-data-cache.outputs.cache-hit != 'true' }}
         env:
-          MEG_DATA_URL_LIST: ${{ secrets.MEG_DATA_URL_LIST }}
-        run: python3 scripts/download_meg_data_files.py --data-dir "${DATA_DIR}"
+          BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
+          BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
+        run: python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${DATA_DIR}"
 
       - name: Verify MEG data
         shell: bash

--- a/.github/workflows/stimulus-decoding.yml
+++ b/.github/workflows/stimulus-decoding.yml
@@ -16,7 +16,7 @@ on:
       data_cache_version:
         description: MEG data cache version. Bump to force a fresh cache.
         required: true
-        default: v1
+        default: v2
         type: string
       data_dir:
         description: Relative data directory to restore/populate.
@@ -192,7 +192,7 @@ jobs:
           DEFAULTS = {
               "python_version": "3.13",
               "use_nextcloud_data": "true",
-              "data_cache_version": "v1",
+              "data_cache_version": "v2",
               "data_dir": ".cache/meg-data-all",
               "participants": "",
               "participant_batches": "1-4;6,8,9,10;13-16;17-20;21;22;23;24;25;26;27",
@@ -431,14 +431,20 @@ jobs:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
 
-      - name: Download MEG data files from URL list
+      - name: Install rclone
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
+        run: .github/scripts/install-rclone.sh
+
+      - name: Download MEG data files from OwnCloud WebDAV
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
         shell: bash
         env:
-          MEG_DATA_URL_LIST: ${{ secrets.MEG_DATA_URL_LIST }}
+          BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
+          BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
         run: |
           set -euo pipefail
-          python3 scripts/download_meg_data_files.py --data-dir "${DATA_DIR}"
+          python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${DATA_DIR}"
 
       - name: Save MEG data cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/stimulus-predictions.yml
+++ b/.github/workflows/stimulus-predictions.yml
@@ -18,7 +18,7 @@ on:
       data_cache_version:
         description: MEG data cache version.
         required: true
-        default: v1
+        default: v2
         type: string
       data_dir:
         description: Relative data directory to restore/populate.
@@ -153,7 +153,7 @@ jobs:
           DEFAULTS = {
               "python_version": "3.13",
               "use_nextcloud_data": "true",
-              "data_cache_version": "v1",
+              "data_cache_version": "v2",
               "data_dir": ".cache/meg-data-all",
               "participants": "",
               "window_centers": "-0.175,0.175",
@@ -341,14 +341,20 @@ jobs:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
 
-      - name: Download MEG data files from URL list
+      - name: Install rclone
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
+        run: .github/scripts/install-rclone.sh
+
+      - name: Download MEG data files from OwnCloud WebDAV
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
         shell: bash
         env:
-          MEG_DATA_URL_LIST: ${{ secrets.MEG_DATA_URL_LIST }}
+          BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
+          BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
         run: |
           set -euo pipefail
-          python3 scripts/download_meg_data_files.py --data-dir "${DATA_DIR}"
+          python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${DATA_DIR}"
 
       - name: Save MEG data cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/stimulus-robustness.yml
+++ b/.github/workflows/stimulus-robustness.yml
@@ -12,7 +12,7 @@ on:
       data_cache_version:
         description: MEG data cache version.
         required: true
-        default: v1
+        default: v2
         type: string
       data_dir:
         description: Relative data directory to restore.

--- a/.github/workflows/stimulus-temporal-generalization.yml
+++ b/.github/workflows/stimulus-temporal-generalization.yml
@@ -18,7 +18,7 @@ on:
       data_cache_version:
         description: MEG data cache version.
         required: true
-        default: v1
+        default: v2
         type: string
       data_dir:
         description: Relative data directory to restore/populate.
@@ -162,7 +162,7 @@ jobs:
           DEFAULTS = {
               "python_version": "3.13",
               "use_nextcloud_data": "true",
-              "data_cache_version": "v1",
+              "data_cache_version": "v2",
               "data_dir": ".cache/meg-data-all",
               "participants": "1-4,6,8,9,10,13-27",
               "time_window": "-0.4,0.8",
@@ -348,14 +348,20 @@ jobs:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
 
-      - name: Download MEG data files from URL list
+      - name: Install rclone
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
+        run: .github/scripts/install-rclone.sh
+
+      - name: Download MEG data files from OwnCloud WebDAV
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
         shell: bash
         env:
-          MEG_DATA_URL_LIST: ${{ secrets.MEG_DATA_URL_LIST }}
+          BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
+          BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
         run: |
           set -euo pipefail
-          python3 scripts/download_meg_data_files.py --data-dir "${DATA_DIR}"
+          python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${DATA_DIR}"
 
       - name: Save MEG data cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,8 +69,9 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     env:
-      DOWNLOAD_URL: ${{ secrets.DOWNLOAD_URL }}
-      DOWNLOAD_URL_CUE: ${{ secrets.DOWNLOAD_URL_CUE }}
+      BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+      BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
+      BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
       PYMEGDEC_DATA_DIR: data
       PYMEGDEC_REQUIRE_DATA: "1"
 
@@ -93,7 +94,7 @@ jobs:
       - name: Check data secrets
         id: data-secrets
         run: |
-          if [ -n "$DOWNLOAD_URL" ] && [ -n "$DOWNLOAD_URL_CUE" ]; then
+          if [ -n "$BUSHMEG_WEBDAV_URL" ] && [ -n "$BUSHMEG_DATA_KEY" ] && [ -n "$BUSHMEG_DATA_PASSWORD" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
@@ -105,15 +106,19 @@ jobs:
         uses: actions/cache@v5
         with:
           path: data
-          key: ${{ runner.os }}-meg-data
+          key: ${{ runner.os }}-bushmeg-sample-data-v2
 
-      - name: Download data
+      - name: Install rclone
+        if: steps.data-secrets.outputs.available == 'true' && steps.cache-data.outputs.cache-hit != 'true'
+        run: .github/scripts/install-rclone.sh
+
+      - name: Download sample MEG data
         if: steps.data-secrets.outputs.available == 'true' && steps.cache-data.outputs.cache-hit != 'true'
         run: |
-          mkdir -p data
-          cd data
-          wget -q "$DOWNLOAD_URL"
-          wget -q "$DOWNLOAD_URL_CUE"
+          python3 scripts/download_meg_data_files.py \
+            --source webdav-rclone \
+            --data-dir data \
+            --file-names Part2CueData.mat,Part2Data.mat
 
       - name: Run MEG data integration tests
         if: steps.data-secrets.outputs.available == 'true'
@@ -121,4 +126,4 @@ jobs:
 
       - name: Skip MEG data integration tests
         if: steps.data-secrets.outputs.available != 'true'
-        run: echo "Skipping integration tests because DOWNLOAD_URL and DOWNLOAD_URL_CUE are not configured."
+        run: echo "Skipping integration tests because BUSHMEG_WEBDAV_URL, BUSHMEG_DATA_KEY, and BUSHMEG_DATA_PASSWORD are not configured."

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -6,7 +6,10 @@
     "scripts/export_stimulus_onset_scan.py",
     "scripts/export_stimulus_predictions.py",
     "scripts/export_stimulus_robustness.py",
-    "scripts/export_stimulus_temporal_generalization.py"
+    "scripts/export_stimulus_temporal_generalization.py",
+    "src/pymegdec/cli.py",
+    "src/pymegdec/synthetic_data_cli.py",
+    "tests/test_stimulus_decoding.py"
   ],
-  "threshold": 1
+  "threshold": 1.5
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,6 +43,8 @@ pymegdec alpha reaction-time --participants 2 --joined-output outputs/part2_alph
 
 ```bash
 pymegdec data download --data-dir data --env-name MEG_DATA_URL_LIST
+pymegdec data download --source webdav-rclone --data-dir data --file-indices 2,3
+pymegdec data download --source webdav-rclone --data-dir data --file-names Part2CueData.mat,Part2Data.mat
 ```
 
 ## Backward-compatible aliases

--- a/docs/data.md
+++ b/docs/data.md
@@ -59,6 +59,17 @@ echo /path/to/MEG-Data > .pymegdec-data-dir
 pymegdec transfer --participant 2 --null-window-center nan
 ```
 
+Download the CI/sample subset from the private OwnCloud WebDAV share:
+
+```bash
+pymegdec data download --source webdav-rclone --data-dir data --file-names Part2CueData.mat,Part2Data.mat
+```
+
+The rclone-backed downloader reads `BUSHMEG_WEBDAV_URL`,
+`BUSHMEG_DATA_KEY`, and `BUSHMEG_DATA_PASSWORD` from the environment. Without
+`--file-indices` or `--file-names`, it downloads all files found recursively in
+the selected remote path.
+
 ## Participant ranges
 
 Commands that accept multiple participants use compact participant specs such as:

--- a/scripts/download_meg_data_files.py
+++ b/scripts/download_meg_data_files.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import sys
+from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[1]
@@ -11,7 +12,12 @@ _SRC = _ROOT / "src"
 if _SRC.exists():
     sys.path.insert(0, str(_SRC))
 
-from pymegdec.data_download import download_meg_data_files  # noqa: E402
+_SPEC = spec_from_file_location("_pymegdec_data_download", _SRC / "pymegdec" / "data_download.py")
+if _SPEC is None or _SPEC.loader is None:
+    raise RuntimeError("Could not load pymegdec.data_download")
+_MODULE = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+download_meg_data_files = _MODULE.download_meg_data_files
 
 
 def main() -> int:

--- a/src/pymegdec/data_download.py
+++ b/src/pymegdec/data_download.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import re
 import shutil
+import subprocess  # nosec B404
 import urllib.parse
 import urllib.request
 from collections.abc import Sequence
@@ -36,6 +37,40 @@ def _validate_https_url(url: str, *, description: str) -> str:
 def _urls_from_env(name: str) -> list[str]:
     raw = os.environ.get(name, "")
     return [token.strip() for token in re.split(r"[\s,]+", raw) if token.strip()]
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "")
+    if not value:
+        raise SystemExit(f"{name} is empty")
+    return value
+
+
+def _parse_file_indices(value: str | None) -> list[int] | None:
+    if value is None or not value.strip():
+        return None
+    indices: list[int] = []
+    for token in re.split(r"[\s,]+", value):
+        if not token:
+            continue
+        try:
+            index = int(token)
+        except ValueError as exc:
+            raise ValueError(f"File indices must be positive integers: {value!r}") from exc
+        if index < 1:
+            raise ValueError(f"File indices are 1-based and must be positive: {value!r}")
+        indices.append(index)
+    return indices
+
+
+def _parse_file_names(value: str | None) -> list[str] | None:
+    if value is None or not value.strip():
+        return None
+    names = [token.strip() for token in re.split(r"[\s,]+", value) if token.strip()]
+    for name in names:
+        if Path(name).is_absolute() or ".." in Path(name).parts:
+            raise ValueError(f"File names must be relative paths below the WebDAV root: {name!r}")
+    return names
 
 
 def _direct_url(url: str) -> str:
@@ -71,26 +106,57 @@ def _filename(response, index: int) -> str:  # noqa: ANN001
 
 
 def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog=prog, description="Download MEG data files from HTTPS URLs listed in an environment variable.")
+    parser = argparse.ArgumentParser(prog=prog, description="Download private MEG data files for local runs and CI workflows.")
     parser.add_argument("--data-dir", required=True)
+    parser.add_argument(
+        "--source",
+        choices=("url-list", "webdav-rclone"),
+        default="url-list",
+        help="Download source. url-list preserves the historical MEG_DATA_URL_LIST behavior; webdav-rclone uses OwnCloud/WebDAV via rclone.",
+    )
     parser.add_argument("--env-name", default="MEG_DATA_URL_LIST")
+    parser.add_argument("--webdav-url-env", default="BUSHMEG_WEBDAV_URL")
+    parser.add_argument("--webdav-user-env", default="BUSHMEG_DATA_KEY")
+    parser.add_argument("--webdav-password-env", default="BUSHMEG_DATA_PASSWORD")
+    parser.add_argument("--remote-path", default="", help="Optional path below the WebDAV share root.")
+    parser.add_argument("--file-indices", default=None, help="Optional 1-based indices into the remote file list, e.g. '2,3'.")
+    parser.add_argument("--file-names", default=None, help="Optional remote file names or relative paths to download, e.g. 'Part2CueData.mat,Part2Data.mat'.")
+    parser.add_argument("--rclone-binary", default="rclone")
     parser.add_argument("--manifest", default="data-manifest/downloaded-files.txt")
     return parser
 
 
-def download_meg_data_files(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
-    parser = _build_parser(prog=prog)
-    args = parser.parse_args(argv)
+def _webdav_remote(path: str = "") -> str:
+    clean = path.strip("/")
+    return f":webdav:{clean}" if clean else ":webdav:"
 
+
+def _rclone_options(*, webdav_url: str, webdav_user: str, obscured_password: str) -> list[str]:
+    return [
+        "--webdav-url",
+        webdav_url,
+        "--webdav-vendor",
+        "owncloud",
+        "--webdav-user",
+        webdav_user,
+        "--webdav-pass",
+        obscured_password,
+    ]
+
+
+def _run_rclone(args: list[str], *, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(args, check=False, text=True, capture_output=capture_output)  # nosec B603
+    if result.returncode != 0:
+        raise SystemExit("rclone command failed; check WebDAV credentials, URL, and remote path.")
+    return result
+
+
+def _download_from_url_list(args: argparse.Namespace, data_dir: Path) -> list[Path]:
     urls = _urls_from_env(args.env_name)
     if not urls:
         raise SystemExit(f"{args.env_name} is empty")
 
-    data_dir = Path(args.data_dir)
-    if data_dir.exists():
-        shutil.rmtree(data_dir)
-    data_dir.mkdir(parents=True, exist_ok=True)
-
+    _prepare_data_dir(data_dir)
     downloaded: list[Path] = []
     for index, url in enumerate(urls, start=1):
         request = urllib.request.Request(_direct_url(url), headers={"User-Agent": "PyMEGDec"})
@@ -104,6 +170,97 @@ def download_meg_data_files(argv: Sequence[str] | None = None, prog: str | None 
                 shutil.copyfileobj(response, output, length=1024 * 1024)
         downloaded.append(target)
         print(f"Downloaded file #{index}: {target.name}")
+    return downloaded
+
+
+def _prepare_data_dir(data_dir: Path) -> None:
+    if data_dir.exists():
+        shutil.rmtree(data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _select_named_remote_files(remote_files: list[str], selected_names: list[str]) -> list[str]:
+    selected: list[str] = []
+    for name in selected_names:
+        matches = [remote_file for remote_file in remote_files if name in {remote_file, Path(remote_file).name}]
+        if not matches:
+            raise SystemExit(f"Requested WebDAV file {name!r} was not found.")
+        if len(matches) > 1:
+            raise SystemExit(f"Requested WebDAV file name {name!r} is ambiguous; pass a relative path instead.")
+        selected.append(matches[0])
+    return selected
+
+
+def _download_from_webdav_rclone(args: argparse.Namespace, data_dir: Path) -> list[Path]:
+    webdav_url = _require_env(args.webdav_url_env)
+    webdav_user = _require_env(args.webdav_user_env)
+    webdav_password = _require_env(args.webdav_password_env)
+    try:
+        selected_indices = _parse_file_indices(args.file_indices)
+        selected_names = _parse_file_names(args.file_names)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if selected_indices is not None and selected_names is not None:
+        raise SystemExit("Pass either --file-indices or --file-names, not both.")
+
+    obscure_result = _run_rclone([args.rclone_binary, "obscure", webdav_password], capture_output=True)
+    obscured_password = obscure_result.stdout.strip()
+    rclone_options = _rclone_options(webdav_url=webdav_url, webdav_user=webdav_user, obscured_password=obscured_password)
+
+    list_result = _run_rclone(
+        [
+            args.rclone_binary,
+            "lsf",
+            _webdav_remote(args.remote_path),
+            "--files-only",
+            "--recursive",
+            "--format",
+            "p",
+            *rclone_options,
+        ],
+        capture_output=True,
+    )
+    remote_files = [line.strip() for line in list_result.stdout.splitlines() if line.strip()]
+    if not remote_files:
+        raise SystemExit(f"No files found in WebDAV remote path {args.remote_path!r}.")
+    if selected_indices is not None:
+        missing = [index for index in selected_indices if index > len(remote_files)]
+        if missing:
+            raise SystemExit(f"File indices {missing!r} exceed the {len(remote_files)} files available in the WebDAV listing.")
+        remote_files = [remote_files[index - 1] for index in selected_indices]
+    elif selected_names is not None:
+        remote_files = _select_named_remote_files(remote_files, selected_names)
+
+    _prepare_data_dir(data_dir)
+    downloaded: list[Path] = []
+    for index, remote_file in enumerate(remote_files, start=1):
+        remote_source = _webdav_remote("/".join(part for part in [args.remote_path.strip("/"), remote_file] if part))
+        target = data_dir / Path(remote_file).name
+        _run_rclone(
+            [
+                args.rclone_binary,
+                "copyto",
+                remote_source,
+                str(target),
+                "--progress",
+                *rclone_options,
+            ]
+        )
+        downloaded.append(target)
+        print(f"Downloaded file #{index}: {target.name}")
+    return downloaded
+
+
+def download_meg_data_files(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_parser(prog=prog)
+    args = parser.parse_args(argv)
+
+    data_dir = Path(args.data_dir)
+
+    if args.source == "webdav-rclone":
+        downloaded = _download_from_webdav_rclone(args, data_dir)
+    else:
+        downloaded = _download_from_url_list(args, data_dir)
 
     manifest = Path(args.manifest)
     manifest.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_data_download.py
+++ b/tests/test_data_download.py
@@ -1,0 +1,92 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from pymegdec.data_download import download_meg_data_files
+
+_TEST_ENV = {
+    "BUSHMEG_WEBDAV_URL": "https://example.test/public.php/webdav/",
+    "BUSHMEG_DATA_KEY": "key",
+    "BUSHMEG_DATA_PASSWORD": "test-secret",  # nosec B105
+}
+
+
+def _completed(stdout=""):
+    return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+
+class _FakeRclone:
+    def __init__(self, listing):
+        self.listing = listing
+        self.calls = []
+
+    def __call__(self, args, **_kwargs):
+        self.calls.append(args)
+        if args[1] == "obscure":
+            return _completed("obscured-password\n")
+        if args[1] == "lsf":
+            return _completed(self.listing)
+        if args[1] == "copyto":
+            Path(args[3]).write_bytes(b"mat")
+            return _completed()
+        raise AssertionError(f"unexpected rclone command: {args}")
+
+
+def _download_with_fake_rclone(fake_run, tmp_dir, selector_name, selector_value):
+    manifest = Path(tmp_dir) / "manifest.txt"
+    download_args = [
+        "--source",
+        "webdav-rclone",
+        "--data-dir",
+        str(Path(tmp_dir) / "data"),
+        selector_name,
+        selector_value,
+        "--manifest",
+        str(manifest),
+    ]
+    with patch.dict(os.environ, _TEST_ENV, clear=False), patch("pymegdec.data_download.subprocess.run", side_effect=fake_run):
+        return download_meg_data_files(download_args), manifest
+
+
+class DataDownloadTests(unittest.TestCase):
+    def test_webdav_rclone_downloads_selected_file_indices_in_listing_order(self):
+        fake_run = _FakeRclone("Part9Data.mat\nPart2CueData.mat\nPart2Data.mat\n")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            exit_code, manifest = _download_with_fake_rclone(fake_run, tmp_dir, "--file-indices", "2,3")
+
+            self.assertEqual(exit_code, 0)
+            copied_sources = [call[2] for call in fake_run.calls if call[1] == "copyto"]
+            self.assertEqual(copied_sources, [":webdav:Part2CueData.mat", ":webdav:Part2Data.mat"])
+            self.assertTrue((Path(tmp_dir) / "data" / "Part2CueData.mat").exists())
+            self.assertTrue((Path(tmp_dir) / "data" / "Part2Data.mat").exists())
+            self.assertIn("Part2CueData.mat", manifest.read_text(encoding="utf-8"))
+            self.assertIn("Part2Data.mat", manifest.read_text(encoding="utf-8"))
+
+    def test_webdav_rclone_rejects_out_of_range_file_indices(self):
+        fake_run = _FakeRclone("only-file.mat\n")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(SystemExit):
+                _download_with_fake_rclone(fake_run, tmp_dir, "--file-indices", "2")
+
+    def test_webdav_rclone_downloads_selected_file_names_by_basename(self):
+        fake_run = _FakeRclone("folder/Part2CueData.mat\nfolder/Part2Data.mat\nfolder/Part3Data.mat\n")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            exit_code, _manifest = _download_with_fake_rclone(
+                fake_run, tmp_dir, "--file-names", "Part2CueData.mat,Part2Data.mat"
+            )
+
+            self.assertEqual(exit_code, 0)
+            copied_sources = [call[2] for call in fake_run.calls if call[1] == "copyto"]
+            self.assertEqual(copied_sources, [":webdav:folder/Part2CueData.mat", ":webdav:folder/Part2Data.mat"])
+            self.assertTrue((Path(tmp_dir) / "data" / "Part2CueData.mat").exists())
+            self.assertTrue((Path(tmp_dir) / "data" / "Part2Data.mat").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an rclone/WebDAV download mode to the PyMEGDec data downloader while keeping the URL-list mode for compatibility
- switch MEG data workflows from `MEG_DATA_URL_LIST`/direct URLs to `BUSHMEG_*` OwnCloud WebDAV secrets
- make CI integration tests download only the 2nd and 3rd WebDAV files via `--file-indices 2,3`
- add a reusable rclone installer script and downloader unit tests

## Validation
- `poetry check`
- `poetry run ruff check .`
- `$env:MPLBACKEND='Agg'; poetry run pytest -q` -> 70 passed, 6 skipped
- parsed all workflow YAML files with PyYAML