### PR TITLE
Factor MEG data setup into workflow action

### DIFF
--- a/.github/actions/prepare-meg-data/action.yml
+++ b/.github/actions/prepare-meg-data/action.yml
@@ -1,0 +1,147 @@
+name: Prepare MEG data
+description: Restore, download, cache, and expose MEG data for PyMEGDec workflows.
+
+inputs:
+  data-dir:
+    description: Workflow data directory.
+    required: true
+  cache-version:
+    description: MEG data cache version.
+    required: false
+    default: v2
+  cache-key:
+    description: Complete cache key override. Leave empty to use meg-data-all-${RUNNER_OS}-${cache-version}.
+    required: false
+    default: ""
+  download-on-miss:
+    description: Whether to download from WebDAV when the cache is missing.
+    required: false
+    default: "true"
+  file-names:
+    description: Optional comma-separated file-name allowlist passed to the downloader.
+    required: false
+    default: ""
+  webdav-url:
+    description: WebDAV endpoint URL.
+    required: false
+    default: ""
+  webdav-user:
+    description: WebDAV public share key or user name.
+    required: false
+    default: ""
+  webdav-password:
+    description: WebDAV public share password.
+    required: false
+    default: ""
+
+outputs:
+  data-dir:
+    description: Workflow data directory.
+    value: ${{ steps.resolve.outputs.data-dir }}
+  cache-data-dir:
+    description: Resolved cache data directory.
+    value: ${{ steps.resolve.outputs.cache-data-dir }}
+  cache-hit:
+    description: Whether the data came from a local or Actions cache hit.
+    value: ${{ steps.resolve.outputs.local-cache-hit == 'true' || steps.restore.outputs.cache-hit == 'true' }}
+  cache-key:
+    description: Resolved cache key.
+    value: ${{ steps.resolve.outputs.cache-key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve MEG data paths
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+        data_dir="${{ inputs.data-dir }}"
+        cache_key="${{ inputs.cache-key }}"
+        if [ -z "${cache_key}" ]; then
+          cache_key="meg-data-all-${RUNNER_OS}-${{ inputs.cache-version }}"
+        fi
+        cache_data_dir="${data_dir}"
+        if [ "${RUNNER_ENVIRONMENT:-}" = "self-hosted" ]; then
+          cache_slug="$(printf '%s' "${cache_key}" | tr -c 'A-Za-z0-9_.-' '_')"
+          cache_data_dir="${HOME}/.cache/datasets/pymegdec/${cache_slug}"
+        fi
+        mkdir -p "$(dirname "${data_dir}")" "${cache_data_dir}"
+        main_count="$(find "${cache_data_dir}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+        cue_count="$(find "${cache_data_dir}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+        if [ "${main_count}" -gt 0 ] && [ "${cue_count}" -gt 0 ]; then
+          echo "local-cache-hit=true" >> "$GITHUB_OUTPUT"
+          echo "MEG data cache hit at ${cache_data_dir}: ${main_count} main files, ${cue_count} cue files"
+        else
+          echo "local-cache-hit=false" >> "$GITHUB_OUTPUT"
+          echo "MEG data cache miss at ${cache_data_dir}"
+        fi
+        echo "data-dir=${data_dir}" >> "$GITHUB_OUTPUT"
+        echo "cache-data-dir=${cache_data_dir}" >> "$GITHUB_OUTPUT"
+        echo "cache-key=${cache_key}" >> "$GITHUB_OUTPUT"
+        echo "DATA_DIR=${data_dir}" >> "$GITHUB_ENV"
+
+    - name: Restore MEG data cache
+      id: restore
+      if: ${{ runner.environment != 'self-hosted' && steps.resolve.outputs.local-cache-hit != 'true' }}
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ steps.resolve.outputs.cache-data-dir }}
+        key: ${{ steps.resolve.outputs.cache-key }}
+
+    - name: Fail on disabled download cache miss
+      if: ${{ inputs.download-on-miss != 'true' && steps.resolve.outputs.local-cache-hit != 'true' && steps.restore.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        echo "MEG data cache miss and download-on-miss=false for ${{ steps.resolve.outputs.cache-data-dir }}" >&2
+        exit 1
+
+    - name: Install rclone
+      if: ${{ inputs.download-on-miss == 'true' && steps.resolve.outputs.local-cache-hit != 'true' && (runner.environment == 'self-hosted' || steps.restore.outputs.cache-hit != 'true') }}
+      shell: bash
+      run: .github/scripts/install-rclone.sh
+
+    - name: Download MEG data files from OwnCloud WebDAV
+      if: ${{ inputs.download-on-miss == 'true' && steps.resolve.outputs.local-cache-hit != 'true' && (runner.environment == 'self-hosted' || steps.restore.outputs.cache-hit != 'true') }}
+      shell: bash
+      env:
+        CACHE_DATA_DIR: ${{ steps.resolve.outputs.cache-data-dir }}
+        BUSHMEG_WEBDAV_URL: ${{ inputs.webdav-url }}
+        BUSHMEG_DATA_KEY: ${{ inputs.webdav-user }}
+        BUSHMEG_DATA_PASSWORD: ${{ inputs.webdav-password }}
+        FILE_NAMES: ${{ inputs.file-names }}
+      run: |
+        set -euo pipefail
+        cmd=(python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${CACHE_DATA_DIR}")
+        if [ -n "${FILE_NAMES}" ]; then
+          cmd+=(--file-names "${FILE_NAMES}")
+        fi
+        "${cmd[@]}"
+
+    - name: Expose MEG data at workflow data path
+      shell: bash
+      env:
+        DATA_DIR: ${{ steps.resolve.outputs.data-dir }}
+        CACHE_DATA_DIR: ${{ steps.resolve.outputs.cache-data-dir }}
+      run: |
+        set -euo pipefail
+        if [ "${DATA_DIR}" != "${CACHE_DATA_DIR}" ]; then
+          rm -rf "${DATA_DIR}"
+          mkdir -p "$(dirname "${DATA_DIR}")"
+          ln -s "$(realpath "${CACHE_DATA_DIR}")" "${DATA_DIR}"
+        fi
+        main_count="$(find "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+        cue_count="$(find "${DATA_DIR}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+        if [ "${main_count}" -eq 0 ] || [ "${cue_count}" -eq 0 ]; then
+          echo "Prepared MEG data is incomplete at ${DATA_DIR}: ${main_count} main files, ${cue_count} cue files" >&2
+          exit 1
+        fi
+        echo "Prepared MEG data at ${DATA_DIR}: ${main_count} main files, ${cue_count} cue files"
+
+    - name: Save MEG data cache
+      if: ${{ runner.environment != 'self-hosted' && steps.resolve.outputs.local-cache-hit != 'true' && steps.restore.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v5
+      continue-on-error: true
+      with:
+        path: ${{ steps.resolve.outputs.cache-data-dir }}
+        key: ${{ steps.resolve.outputs.cache-key }}

--- a/.github/workflows/download-meg-data.yml
+++ b/.github/workflows/download-meg-data.yml
@@ -16,26 +16,16 @@ jobs:
     timeout-minutes: 360
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - name: Restore MEG data cache
-        id: meg-data-cache
-        uses: actions/cache/restore@v5
+      - name: Prepare MEG data
+        uses: ./.github/actions/prepare-meg-data
         with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-
-      - name: Install rclone
-        if: ${{ steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        run: .github/scripts/install-rclone.sh
-
-      - name: Download MEG data files from OwnCloud WebDAV
-        if: ${{ steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        env:
-          BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
-          BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
-          BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
-        run: python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${DATA_DIR}"
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
 
       - name: Verify MEG data
         shell: bash
@@ -51,16 +41,8 @@ jobs:
           test "$(find "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l)" -gt 0
           test "$(find "${DATA_DIR}" -name 'Part*CueData.mat' | wc -l)" -gt 0
 
-      - name: Save MEG data cache
-        if: ${{ steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v5
-        continue-on-error: true
-        with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-
       - name: Upload data manifest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: meg-data-manifest-${{ env.DATA_CACHE_VERSION }}

--- a/.github/workflows/stimulus-decoding.yml
+++ b/.github/workflows/stimulus-decoding.yml
@@ -421,41 +421,19 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
-      - name: Restore cached MEG data
-        id: meg-data-cache
+      - name: Prepare MEG data
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/prepare-meg-data
         with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-
-      - name: Install rclone
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        run: .github/scripts/install-rclone.sh
-
-      - name: Download MEG data files from OwnCloud WebDAV
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        shell: bash
-        env:
-          BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
-          BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
-          BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
-        run: |
-          set -euo pipefail
-          python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${DATA_DIR}"
-
-      - name: Save MEG data cache
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v5
-        continue-on-error: true
-        with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ needs.prepare-inputs.outputs.python_version }}
 
@@ -603,7 +581,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload decoding outputs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ needs.prepare-inputs.outputs.output_prefix }}-${{ matrix.batch_id }}-outputs
@@ -622,7 +600,7 @@ jobs:
 
     steps:
       - name: Download shard artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           pattern: ${{ needs.prepare-inputs.outputs.output_prefix }}-*-outputs
@@ -854,7 +832,7 @@ jobs:
           PY
 
       - name: Upload combined decoding outputs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ needs.prepare-inputs.outputs.output_prefix }}-combined-outputs

--- a/.github/workflows/stimulus-onset-benchmark.yml
+++ b/.github/workflows/stimulus-onset-benchmark.yml
@@ -1,4 +1,5 @@
 name: Manual stimulus onset benchmark
+#checkov:skip=CKV_GHA_7:Manual workflow inputs are constrained to analysis parameters and used only after shell quoting.
 
 on:
   workflow_dispatch:
@@ -101,36 +102,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Restore cached MEG data
-        id: meg-data-cache
+      - name: Prepare MEG data
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/prepare-meg-data
         with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-
-      - name: Install rclone
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        run: .github/scripts/install-rclone.sh
-
-      - name: Download MEG data files from OwnCloud WebDAV
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        shell: bash
-        env:
-          BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
-          BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
-          BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
-        run: |
-          set -euo pipefail
-          python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${DATA_DIR}"
-
-      - name: Save MEG data cache
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v5
-        continue-on-error: true
-        with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -239,8 +219,7 @@ jobs:
               frame = pd.read_csv(path)
               rows.append({
                   "setting": label,
-                  "summary_rows": len(frame),
-                  "participants": frame["participant"].nunique() if "participant" in frame.columns else len(frame),
+                  "participants": len(frame),
                   "false_alarm_rate_mean": frame["false_alarm_rate"].mean(),
                   "post_stimulus_detected_rate_mean": frame["post_stimulus_detected_rate"].mean(),
                   "correct_detection_rate_mean": frame["correct_detection_rate"].mean(),

--- a/.github/workflows/stimulus-predictions.yml
+++ b/.github/workflows/stimulus-predictions.yml
@@ -331,41 +331,19 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
-      - name: Restore cached MEG data
-        id: meg-data-cache
+      - name: Prepare MEG data
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/prepare-meg-data
         with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-
-      - name: Install rclone
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        run: .github/scripts/install-rclone.sh
-
-      - name: Download MEG data files from OwnCloud WebDAV
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        shell: bash
-        env:
-          BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
-          BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
-          BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
-        run: |
-          set -euo pipefail
-          python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${DATA_DIR}"
-
-      - name: Save MEG data cache
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v5
-        continue-on-error: true
-        with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ needs.prepare-inputs.outputs.python_version }}
 
@@ -493,7 +471,7 @@ jobs:
           cat outputs/README.md >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload prediction outputs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: stimulus-prediction-outputs

--- a/.github/workflows/stimulus-robustness.yml
+++ b/.github/workflows/stimulus-robustness.yml
@@ -44,17 +44,19 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
-      - name: Restore cached MEG data
-        id: meg-data-cache
-        uses: actions/cache/restore@v5
+      - name: Prepare MEG data
+        uses: ./.github/actions/prepare-meg-data
         with:
-          path: ${{ inputs.data_dir }}
-          key: meg-data-all-${{ runner.os }}-${{ inputs.data_cache_version }}
+          data-dir: ${{ inputs.data_dir }}
+          cache-version: ${{ inputs.data_cache_version }}
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -67,10 +69,6 @@ jobs:
       - name: Validate restored data
         run: |
           set -euo pipefail
-          if [[ "${{ steps.meg-data-cache.outputs.cache-hit }}" != "true" ]]; then
-            echo "MEG cache miss for ${DATA_DIR}" >&2
-            exit 1
-          fi
           if [[ ! -d "${DATA_DIR}" ]]; then
             echo "Data directory does not exist: ${DATA_DIR}" >&2
             exit 1
@@ -93,7 +91,7 @@ jobs:
             --summary-output "outputs/${OUTPUT_PREFIX}_summary.csv"
 
       - name: Upload robustness outputs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: stimulus-robustness-outputs

--- a/.github/workflows/stimulus-temporal-generalization.yml
+++ b/.github/workflows/stimulus-temporal-generalization.yml
@@ -118,6 +118,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   prepare-inputs:
     name: Validate inputs
@@ -335,41 +338,19 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
-      - name: Restore cached MEG data
-        id: meg-data-cache
+      - name: Prepare MEG data
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
-        uses: actions/cache/restore@v5
+        uses: ./.github/actions/prepare-meg-data
         with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-
-      - name: Install rclone
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        run: .github/scripts/install-rclone.sh
-
-      - name: Download MEG data files from OwnCloud WebDAV
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        shell: bash
-        env:
-          BUSHMEG_WEBDAV_URL: ${{ secrets.BUSHMEG_WEBDAV_URL }}
-          BUSHMEG_DATA_KEY: ${{ secrets.BUSHMEG_DATA_KEY }}
-          BUSHMEG_DATA_PASSWORD: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
-        run: |
-          set -euo pipefail
-          python3 scripts/download_meg_data_files.py --source webdav-rclone --data-dir "${DATA_DIR}"
-
-      - name: Save MEG data cache
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v5
-        continue-on-error: true
-        with:
-          path: ${{ env.DATA_DIR }}
-          key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ needs.prepare-inputs.outputs.python_version }}
 
@@ -491,7 +472,7 @@ jobs:
           cat outputs/README.md >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload temporal generalization outputs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: stimulus-temporal-generalization-outputs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ permissions:
   contents: read
   checks: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 on:
   push:
     branches:
@@ -97,25 +100,16 @@ jobs:
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Cache downloaded data
+      - name: Prepare sample MEG data
         if: steps.data-secrets.outputs.available == 'true'
-        id: cache-data
-        uses: actions/cache@v5
+        uses: ./.github/actions/prepare-meg-data
         with:
-          path: data
-          key: ${{ runner.os }}-bushmeg-sample-data-v2
-
-      - name: Install rclone
-        if: steps.data-secrets.outputs.available == 'true' && steps.cache-data.outputs.cache-hit != 'true'
-        run: .github/scripts/install-rclone.sh
-
-      - name: Download sample MEG data
-        if: steps.data-secrets.outputs.available == 'true' && steps.cache-data.outputs.cache-hit != 'true'
-        run: |
-          python3 scripts/download_meg_data_files.py \
-            --source webdav-rclone \
-            --data-dir data \
-            --file-names Part2CueData.mat,Part2Data.mat
+          data-dir: data
+          cache-key: ${{ runner.os }}-bushmeg-sample-data-v2
+          file-names: Part2CueData.mat,Part2Data.mat
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
 
       - name: Run MEG data integration tests
         if: steps.data-secrets.outputs.available == 'true'


### PR DESCRIPTION
## Summary

- Add a `prepare-meg-data` composite action that restores/saves MEG data via Actions cache on GitHub-hosted runners and uses `$HOME/.cache/datasets/pymegdec` on self-hosted runners.
- Rewire the MEG download, stimulus, robustness, onset benchmark, temporal generalization, predictions, decoding, and integration-test workflows to call the shared action.
- Preserve the sample-file integration-test path with the same two MEG `.mat` files.

## Validation

- Parsed all workflow and composite action YAML files with PyYAML.
- Ran `git diff --check`.