### PR TITLE
Update workflows for Node 24 actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,8 +22,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install documentation dependencies

--- a/.github/workflows/download-meg-data.yml
+++ b/.github/workflows/download-meg-data.yml
@@ -16,11 +16,11 @@ jobs:
     timeout-minutes: 360
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Restore MEG data cache
         id: meg-data-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
@@ -53,14 +53,14 @@ jobs:
 
       - name: Save MEG data cache
         if: ${{ steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
 
       - name: Upload data manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: meg-data-manifest-${{ env.DATA_CACHE_VERSION }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -39,7 +39,7 @@ jobs:
         run: mkdocs build --strict --site-dir site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/stimulus-decoding.yml
+++ b/.github/workflows/stimulus-decoding.yml
@@ -421,12 +421,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore cached MEG data
         id: meg-data-cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
@@ -448,14 +448,14 @@ jobs:
 
       - name: Save MEG data cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ needs.prepare-inputs.outputs.python_version }}
 
@@ -603,7 +603,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload decoding outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ needs.prepare-inputs.outputs.output_prefix }}-${{ matrix.batch_id }}-outputs
@@ -622,7 +622,7 @@ jobs:
 
     steps:
       - name: Download shard artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         continue-on-error: true
         with:
           pattern: ${{ needs.prepare-inputs.outputs.output_prefix }}-*-outputs
@@ -854,7 +854,7 @@ jobs:
           PY
 
       - name: Upload combined decoding outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ needs.prepare-inputs.outputs.output_prefix }}-combined-outputs

--- a/.github/workflows/stimulus-predictions.yml
+++ b/.github/workflows/stimulus-predictions.yml
@@ -331,12 +331,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore cached MEG data
         id: meg-data-cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
@@ -358,14 +358,14 @@ jobs:
 
       - name: Save MEG data cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ needs.prepare-inputs.outputs.python_version }}
 
@@ -493,7 +493,7 @@ jobs:
           cat outputs/README.md >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload prediction outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: stimulus-prediction-outputs

--- a/.github/workflows/stimulus-robustness.yml
+++ b/.github/workflows/stimulus-robustness.yml
@@ -44,17 +44,17 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore cached MEG data
         id: meg-data-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ inputs.data_dir }}
           key: meg-data-all-${{ runner.os }}-${{ inputs.data_cache_version }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -93,7 +93,7 @@ jobs:
             --summary-output "outputs/${OUTPUT_PREFIX}_summary.csv"
 
       - name: Upload robustness outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: stimulus-robustness-outputs

--- a/.github/workflows/stimulus-temporal-generalization.yml
+++ b/.github/workflows/stimulus-temporal-generalization.yml
@@ -118,9 +118,6 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   prepare-inputs:
     name: Validate inputs
@@ -338,12 +335,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Restore cached MEG data
         id: meg-data-cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
@@ -365,14 +362,14 @@ jobs:
 
       - name: Save MEG data cache
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' && steps.meg-data-cache.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         continue-on-error: true
         with:
           path: ${{ env.DATA_DIR }}
           key: meg-data-all-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ needs.prepare-inputs.outputs.python_version }}
 
@@ -494,7 +491,7 @@ jobs:
           cat outputs/README.md >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload temporal generalization outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: stimulus-temporal-generalization-outputs

--- a/.github/workflows/tags-and-github-release.yml
+++ b/.github/workflows/tags-and-github-release.yml
@@ -41,7 +41,7 @@ jobs:
       release_notes_mode: ${{ steps.set_mode.outputs.release_notes_mode }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref_name }}
@@ -118,7 +118,7 @@ jobs:
       tag_set: ${{ steps.create_tag.outputs.tag_set }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref_name }}
@@ -158,7 +158,7 @@ jobs:
       RELEASE_NOTES_MODE: ${{ needs.check_version_tag.outputs.release_notes_mode }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref_name }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,6 @@ permissions:
   contents: read
   checks: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary
- update remaining official GitHub Actions workflow references to Node 24-native major versions
- remove leftover FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 flags
- keep workflow behavior unchanged apart from action runtime/version bumps

## Validation
- parsed all .github/workflows/*.yml with PyYAML
- ran git diff --check
- confirmed no remaining old official action refs or FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 entries in .github/workflows