### PR TITLE
Add max-run onset operating-point sweep

### DIFF
--- a/.github/workflows/stimulus-onset-benchmark.yml
+++ b/.github/workflows/stimulus-onset-benchmark.yml
@@ -242,6 +242,32 @@ jobs:
           fi
           "${args[@]}"
 
+      - name: Run max-run operating-point sweep
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(
+            python scripts/export_stimulus_onset_operating_point_sweep.py
+            --scan-input outputs/stimulus_onset_scan_robust.csv
+            --threshold-method max_run
+            "--threshold-window=${THRESHOLD_WINDOW}"
+            --threshold-quantiles 0.955,0.96,0.965,0.97,0.975
+            --min-consecutives 2
+            --min-durations 0.05
+            --require-stable-prediction-values true,false
+            --max-false-alarm-rate 0.05
+            --events-output outputs/stimulus_onset_events_max_run_sweep.csv
+            --event-summary-output outputs/stimulus_onset_event_summary_max_run_sweep.csv
+            --summary-output outputs/stimulus_onset_operating_point_sweep_max_run.csv
+            --selected-output outputs/stimulus_onset_operating_point_selected_max_run.csv
+            --selected-events-output outputs/stimulus_onset_events_max_run_selected.csv
+            --selected-event-summary-output outputs/stimulus_onset_event_summary_max_run_selected.csv
+          )
+          if [[ -n "${DETECTION_START_S}" ]]; then
+            args+=(--detection-start-s "${DETECTION_START_S}")
+          fi
+          "${args[@]}"
+
       - name: Summarize onset quality
         shell: bash
         run: |
@@ -302,7 +328,7 @@ jobs:
                   return
               selected = frame.iloc[0].to_dict()
               rows.append({
-                  "setting": "point_sweep_selected",
+                  "setting": selected.get("setting", "selected_operating_point"),
                   "threshold_quantile": selected.get("threshold_quantile", np.nan),
                   "min_consecutive": selected.get("min_consecutive", np.nan),
                   "min_duration_s": selected.get("min_duration_s", np.nan),
@@ -321,6 +347,7 @@ jobs:
           add_event_summary("robust_max_run", "outputs/stimulus_onset_event_summary_robust.csv")
           add_event_summary("point_baseline", "outputs/stimulus_onset_event_summary_point.csv")
           add_selected_operating_point("outputs/stimulus_onset_operating_point_selected.csv")
+          add_selected_operating_point("outputs/stimulus_onset_operating_point_selected_max_run.csv")
 
           table = pd.DataFrame(rows)
           table.to_csv("outputs/stimulus_onset_quality_summary.csv", index=False)
@@ -336,17 +363,26 @@ jobs:
               table_block = f"```\n{plain_table}\n```"
 
           selected_line = ""
-          selected_path = Path("outputs/stimulus_onset_operating_point_selected.csv")
-          if selected_path.exists():
+          selected_lines = []
+          for selected_path in (
+              Path("outputs/stimulus_onset_operating_point_selected.csv"),
+              Path("outputs/stimulus_onset_operating_point_selected_max_run.csv"),
+          ):
+              if not selected_path.exists():
+                  continue
               selected_frame = pd.read_csv(selected_path)
-              if not selected_frame.empty:
-                  selected = selected_frame.iloc[0]
-                  selected_line = (
-                      "Selected point sweep operating point: "
-                      f"`threshold_quantile={selected['threshold_quantile']}`, "
-                      f"`min_consecutive={selected['min_consecutive']}`, "
-                      f"`min_duration_s={selected['min_duration_s']}`."
-                  )
+              if selected_frame.empty:
+                  continue
+              selected = selected_frame.iloc[0]
+              selected_lines.append(
+                  f"Selected `{selected['setting']}` operating point: "
+                  f"`threshold_quantile={selected['threshold_quantile']}`, "
+                  f"`min_consecutive={selected['min_consecutive']}`, "
+                  f"`min_duration_s={selected['min_duration_s']}`, "
+                  f"`require_stable_prediction={selected['require_stable_prediction']}`."
+              )
+          if selected_lines:
+              selected_line = "\n".join(selected_lines)
 
           text = "\n".join([
               "# Stimulus onset benchmark",

--- a/scripts/export_stimulus_onset_operating_point_sweep.py
+++ b/scripts/export_stimulus_onset_operating_point_sweep.py
@@ -1,4 +1,4 @@
-"""Sweep point onset detector settings from an exported point scan."""
+"""Sweep onset detector settings from an exported stimulus-onset scan."""
 
 from __future__ import annotations
 
@@ -66,6 +66,21 @@ def _optional_float(text: str | None) -> float | None:
     return float(text)
 
 
+def _bool_list(text: str) -> tuple[bool, ...]:
+    values = []
+    for item in text.split(","):
+        token = item.strip().lower()
+        if not token:
+            continue
+        if token in {"true", "1", "yes", "y"}:
+            values.append(True)
+        elif token in {"false", "0", "no", "n"}:
+            values.append(False)
+        else:
+            raise argparse.ArgumentTypeError(f"invalid boolean value: {item!r}")
+    return tuple(values)
+
+
 def _stable(value):
     try:
         if pd.isna(value):
@@ -90,8 +105,10 @@ def _grouped_event_rows(
     *,
     threshold_window: tuple[float, float],
     threshold_quantile: float,
+    threshold_method: str,
     min_consecutive: int,
     min_duration: float,
+    require_stable_prediction: bool,
     detection_start: float | None,
 ) -> list[dict]:
     grouped_events: list[dict] = []
@@ -101,10 +118,10 @@ def _grouped_event_rows(
                 group.to_dict(orient="records"),
                 threshold_window=threshold_window,
                 threshold_quantile=threshold_quantile,
-                threshold_method="point",
+                threshold_method=threshold_method,
                 min_consecutive=min_consecutive,
                 min_duration=min_duration,
-                require_stable_prediction=False,
+                require_stable_prediction=require_stable_prediction,
                 detection_start_s=detection_start,
             )
         )
@@ -119,18 +136,27 @@ def _median(frame: pd.DataFrame, column: str) -> float:
     return float(pd.to_numeric(frame[column], errors="coerce").median()) if column in frame else np.nan
 
 
-def _aggregate(rows: list[dict], q: float, n: int, duration: float, max_fa: float) -> dict:
+def _aggregate(
+    rows: list[dict],
+    *,
+    threshold_method: str,
+    threshold_quantile: float,
+    min_consecutive: int,
+    min_duration: float,
+    require_stable_prediction: bool,
+    max_false_alarm_rate: float,
+) -> dict:
     frame = pd.DataFrame(rows)
     fa = _mean(frame, "false_alarm_rate")
     post = _mean(frame, "post_stimulus_detected_rate")
     correct = _mean(frame, "correct_detection_rate")
     return {
-        "setting": "point_sweep",
-        "threshold_method": "point",
-        "threshold_quantile": q,
-        "min_consecutive": n,
-        "min_duration_s": duration,
-        "require_stable_prediction": False,
+        "setting": f"{threshold_method}_sweep",
+        "threshold_method": threshold_method,
+        "threshold_quantile": threshold_quantile,
+        "min_consecutive": min_consecutive,
+        "min_duration_s": min_duration,
+        "require_stable_prediction": bool(require_stable_prediction),
         "summary_rows": len(frame),
         "participants": frame["participant"].nunique() if "participant" in frame else len(frame),
         "false_alarm_rate_mean": fa,
@@ -139,8 +165,8 @@ def _aggregate(rows: list[dict], q: float, n: int, duration: float, max_fa: floa
         "conditional_correct_detection_rate": correct / post if np.isfinite(correct) and np.isfinite(post) and post else np.nan,
         "median_latency_s": _median(frame, "post_detection_latency_median_s"),
         "mean_latency_s": _mean(frame, "post_detection_latency_mean_s"),
-        "meets_false_alarm_constraint": bool(np.isfinite(fa) and fa <= max_fa),
-        "selection_max_false_alarm_rate": max_fa,
+        "meets_false_alarm_constraint": bool(np.isfinite(fa) and fa <= max_false_alarm_rate),
+        "selection_max_false_alarm_rate": max_false_alarm_rate,
     }
 
 
@@ -153,11 +179,16 @@ def _ranking(row: dict, feasible: bool) -> tuple:
     post = post if np.isfinite(post) else -np.inf
     correct = correct if np.isfinite(correct) else -np.inf
     latency = latency if np.isfinite(latency) else np.inf
-    tail = (row["threshold_quantile"], row["min_consecutive"], row["min_duration_s"])
+    tail = (
+        row["threshold_quantile"],
+        row["min_consecutive"],
+        row["min_duration_s"],
+        int(bool(row.get("require_stable_prediction", False))),
+    )
     return (-post, -correct, latency, *tail) if feasible else (fa, -post, -correct, latency, *tail)
 
 
-def _select(rows: list[dict]) -> dict:
+def _select(rows: list[dict], *, threshold_method: str) -> dict:
     feasible = [row for row in rows if row.get("meets_false_alarm_constraint")]
     if feasible:
         selected = min(feasible, key=lambda row: _ranking(row, True))
@@ -166,7 +197,7 @@ def _select(rows: list[dict]) -> dict:
         selected = min(rows, key=lambda row: _ranking(row, False))
         selected_feasible = False
     selected = dict(selected)
-    selected["setting"] = "point_sweep_selected"
+    selected["setting"] = f"{threshold_method}_sweep_selected"
     selected["selected_feasible"] = selected_feasible
     selected["selection_rule"] = (
         "false_alarm_rate_mean <= max_false_alarm_rate; then maximize post_stimulus_detected_rate_mean; "
@@ -178,10 +209,12 @@ def _select(rows: list[dict]) -> dict:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scan-input", required=True)
+    parser.add_argument("--threshold-method", choices=("point", "max_run"), default="point")
     parser.add_argument("--threshold-window", type=_window, default=(-0.35, -0.05))
     parser.add_argument("--threshold-quantiles", type=_float_list, default=(0.95, 0.975, 0.99))
     parser.add_argument("--min-consecutives", type=_int_list, default=(1, 2, 3))
     parser.add_argument("--min-durations", type=_float_list, default=(0.025, 0.05, 0.075))
+    parser.add_argument("--require-stable-prediction-values", type=_bool_list, default=(False,))
     parser.add_argument("--max-false-alarm-rate", type=float, default=0.05)
     parser.add_argument("--detection-start-s", default=None)
     parser.add_argument("--events-output", default="outputs/stimulus_onset_events_point_sweep.csv")
@@ -199,23 +232,43 @@ def main(argv: list[str] | None = None) -> int:
     base_frame = pd.read_csv(args.scan_input)
     all_events, all_summaries, aggregate_rows = [], [], []
     by_key = {}
-    for q, n, duration in itertools.product(args.threshold_quantiles, args.min_consecutives, args.min_durations):
+    for q, n, duration, require_stable_prediction in itertools.product(
+        args.threshold_quantiles,
+        args.min_consecutives,
+        args.min_durations,
+        args.require_stable_prediction_values,
+    ):
         events = _grouped_event_rows(
             base_frame,
             threshold_window=args.threshold_window,
             threshold_quantile=q,
+            threshold_method=args.threshold_method,
             min_consecutive=n,
             min_duration=duration,
+            require_stable_prediction=require_stable_prediction,
             detection_start=detection_start,
         )
         summaries = _stable_rows(summarize_stimulus_onset_events(events))
-        row = _aggregate(summaries, q, n, duration, args.max_false_alarm_rate)
-        by_key[(q, n, duration)] = (events, summaries)
+        row = _aggregate(
+            summaries,
+            threshold_method=args.threshold_method,
+            threshold_quantile=q,
+            min_consecutive=n,
+            min_duration=duration,
+            require_stable_prediction=require_stable_prediction,
+            max_false_alarm_rate=args.max_false_alarm_rate,
+        )
+        by_key[(q, n, duration, require_stable_prediction)] = (events, summaries)
         all_events.extend(events)
         all_summaries.extend(summaries)
         aggregate_rows.append(row)
-    selected = _select(aggregate_rows)
-    selected_key = (selected["threshold_quantile"], selected["min_consecutive"], selected["min_duration_s"])
+    selected = _select(aggregate_rows, threshold_method=args.threshold_method)
+    selected_key = (
+        selected["threshold_quantile"],
+        selected["min_consecutive"],
+        selected["min_duration_s"],
+        bool(selected.get("require_stable_prediction", False)),
+    )
     selected_events, selected_summaries = by_key[selected_key]
     write_alpha_metrics_csv(all_events, args.events_output)
     write_alpha_metrics_csv(all_summaries, args.event_summary_output)
@@ -226,10 +279,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Wrote {len(aggregate_rows)} operating-point rows to {args.summary_output}")
     print(f"Wrote selected operating point to {args.selected_output}")
     print(
-        "Selected point operating point: "
+        f"Selected {args.threshold_method} operating point: "
         f"threshold_quantile={selected['threshold_quantile']}, "
         f"min_consecutive={selected['min_consecutive']}, "
         f"min_duration_s={selected['min_duration_s']}, "
+        f"require_stable_prediction={selected['require_stable_prediction']}, "
         f"false_alarm_rate_mean={selected['false_alarm_rate_mean']:.4f}, "
         f"post_stimulus_detected_rate_mean={selected['post_stimulus_detected_rate_mean']:.4f}, "
         f"correct_detection_rate_mean={selected['correct_detection_rate_mean']:.4f}"


### PR DESCRIPTION
## Summary
- generalize the onset operating-point sweep helper so it can sweep either `point` or `max_run`
- add a narrow `max_run` operating-point sweep to the manual stimulus onset benchmark workflow
- include both selected sweep operating points in the benchmark summary artifact

## Testing
- `python -m py_compile scripts/export_stimulus_onset_operating_point_sweep.py`
- `python scripts/export_stimulus_onset_operating_point_sweep.py --help`

## Notes
- Local end-to-end validation against real scan artifacts is blocked in this workspace by an older installed `reptrace` package signature; the repository code path already assumes the newer onset API used on CI/main.