### PR TITLE
Add cross-subject stimulus smoke benchmark

### DIFF
--- a/.github/actions/prepare-meg-data/action.yml
+++ b/.github/actions/prepare-meg-data/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: WebDAV public share password.
     required: false
     default: ""
+  require-cue-files:
+    description: Whether prepared data must include Part*CueData.mat files.
+    required: false
+    default: "true"
 
 outputs:
   data-dir:
@@ -69,7 +73,7 @@ runs:
         mkdir -p "$(dirname "${data_dir}")" "${cache_data_dir}"
         main_count="$(find "${cache_data_dir}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
         cue_count="$(find "${cache_data_dir}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
-        if [ "${main_count}" -gt 0 ] && [ "${cue_count}" -gt 0 ]; then
+        if [ "${main_count}" -gt 0 ] && { [ "${{ inputs.require-cue-files }}" != "true" ] || [ "${cue_count}" -gt 0 ]; }; then
           echo "local-cache-hit=true" >> "$GITHUB_OUTPUT"
           echo "MEG data cache hit at ${cache_data_dir}: ${main_count} main files, ${cue_count} cue files"
         else
@@ -132,7 +136,7 @@ runs:
         fi
         main_count="$(find "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
         cue_count="$(find "${DATA_DIR}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
-        if [ "${main_count}" -eq 0 ] || [ "${cue_count}" -eq 0 ]; then
+        if [ "${main_count}" -eq 0 ] || { [ "${{ inputs.require-cue-files }}" = "true" ] && [ "${cue_count}" -eq 0 ]; }; then
           echo "Prepared MEG data is incomplete at ${DATA_DIR}: ${main_count} main files, ${cue_count} cue files" >&2
           exit 1
         fi

--- a/.github/workflows/stimulus-cross-subject-smoke.yml
+++ b/.github/workflows/stimulus-cross-subject-smoke.yml
@@ -1,0 +1,210 @@
+name: Manual stimulus cross-subject smoke
+#checkov:skip=CKV_GHA_7:Manual workflow inputs are constrained to analysis parameters and used only after shell quoting.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_label:
+        description: Runner label used for the full-data smoke benchmark.
+        required: true
+        default: self-hosted
+        type: string
+      python_version:
+        description: Python version used for the analysis environment.
+        required: true
+        default: "3.13"
+        type: string
+      use_nextcloud_data:
+        description: Restore/download/cache the MEG data before running.
+        required: true
+        default: true
+        type: boolean
+      data_cache_version:
+        description: MEG data cache version.
+        required: true
+        default: v2
+        type: string
+      data_dir:
+        description: Relative data directory to restore/populate.
+        required: true
+        default: .cache/meg-data-main
+        type: string
+      participants:
+        description: Participant ids such as 1-4,6,8.
+        required: true
+        default: "1-4,6,8,9,10,13-27"
+        type: string
+      window_center:
+        description: Stimulus decoding window center in seconds.
+        required: true
+        default: "0.175"
+        type: string
+      window_size:
+        description: Stimulus decoding window size in seconds.
+        required: true
+        default: "0.1"
+        type: string
+      baseline_window:
+        description: Baseline normalization window as start,stop in seconds.
+        required: true
+        default: "-0.5,0.0"
+        type: string
+      feature_mode:
+        description: Feature mode passed to the cross-subject smoke command.
+        required: true
+        default: sensor_mean
+        type: choice
+        options:
+          - sensor_mean
+          - sensor_flat
+      normalization:
+        description: Subject normalization mode.
+        required: true
+        default: subject_baseline_z
+        type: choice
+        options:
+          - subject_baseline_z
+          - subject_z
+          - none
+      classifier:
+        description: Classifier name.
+        required: true
+        default: multiclass-svm
+        type: string
+      components_pca:
+        description: Number of PCA components, or inf.
+        required: true
+        default: "64"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  cross-subject-smoke:
+    name: Cross-subject smoke
+    runs-on: ${{ inputs.runner_label }}
+    timeout-minutes: 720
+    env:
+      DATA_DIR: ${{ inputs.data_dir }}
+      USE_NEXTCLOUD_DATA: ${{ inputs.use_nextcloud_data }}
+      DATA_CACHE_VERSION: ${{ inputs.data_cache_version }}
+      PARTICIPANTS: ${{ inputs.participants }}
+      WINDOW_CENTER: ${{ inputs.window_center }}
+      WINDOW_SIZE: ${{ inputs.window_size }}
+      BASELINE_WINDOW: ${{ inputs.baseline_window }}
+      FEATURE_MODE: ${{ inputs.feature_mode }}
+      NORMALIZATION: ${{ inputs.normalization }}
+      CLASSIFIER: ${{ inputs.classifier }}
+      COMPONENTS_PCA: ${{ inputs.components_pca }}
+      MAIN_FILE_NAMES: >-
+        Part1Data.mat,Part2Data.mat,Part3Data.mat,Part4Data.mat,Part6Data.mat,
+        Part8Data.mat,Part9Data.mat,Part10Data.mat,Part13Data.mat,Part14Data.mat,
+        Part15Data.mat,Part16Data.mat,Part17Data.mat,Part18Data.mat,Part19Data.mat,
+        Part20Data.mat,Part21Data.mat,Part22Data.mat,Part23Data.mat,Part24Data.mat,
+        Part25Data.mat,Part26Data.mat,Part27Data.mat
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Prepare main MEG data
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
+        uses: ./.github/actions/prepare-meg-data
+        with:
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          file-names: ${{ env.MAIN_FILE_NAMES }}
+          require-cue-files: "false"
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Validate main data files
+        shell: bash
+        run: |
+          set -euo pipefail
+          main_count="$(find "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+          echo "Main files: ${main_count}"
+          test "${main_count}" -ge 23
+
+      - name: Run fixed-pipeline cross-subject smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs
+          python scripts/export_stimulus_cross_subject_smoke.py \
+            --data-dir "${DATA_DIR}" \
+            --participants "${PARTICIPANTS}" \
+            --window-center "${WINDOW_CENTER}" \
+            --window-size "${WINDOW_SIZE}" \
+            --baseline-window "${BASELINE_WINDOW}" \
+            --feature-mode "${FEATURE_MODE}" \
+            --normalization "${NORMALIZATION}" \
+            --classifier "${CLASSIFIER}" \
+            --components-pca "${COMPONENTS_PCA}" \
+            --outer-output outputs/stimulus_cross_subject_outer.csv \
+            --summary-output outputs/stimulus_cross_subject_group_summary.csv \
+            --predictions-output outputs/stimulus_cross_subject_predictions.csv \
+            --confusion-output outputs/stimulus_cross_subject_confusion.csv \
+            --per-stimulus-output outputs/stimulus_cross_subject_per_stimulus.csv
+
+      - name: Append workflow summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import csv
+          from pathlib import Path
+
+          summary_path = Path("outputs/stimulus_cross_subject_group_summary.csv")
+          outer_path = Path("outputs/stimulus_cross_subject_outer.csv")
+          summary = next(csv.DictReader(summary_path.open(newline="", encoding="utf-8")))
+          outer_rows = list(csv.DictReader(outer_path.open(newline="", encoding="utf-8")))
+          best = sorted(outer_rows, key=lambda row: float(row["balanced_accuracy"]), reverse=True)[:5]
+          worst = sorted(outer_rows, key=lambda row: float(row["balanced_accuracy"]))[:5]
+
+          lines = [
+              "# Stimulus cross-subject smoke",
+              "",
+              "Fixed-pipeline leave-one-subject-out image-identity decoding using only `Part*Data.mat`.",
+              "",
+              "| metric | value |",
+              "| --- | ---: |",
+              f"| folds | {summary['n_outer_folds']} |",
+              f"| chance | {float(summary['chance_percent']):.2f}% |",
+              f"| mean balanced accuracy | {float(summary['balanced_percent_mean']):.2f}% |",
+              f"| balanced accuracy SEM | {float(summary['balanced_percent_sem']):.2f}% |",
+              f"| participants above chance | {summary['participants_above_chance']} |",
+              f"| one-sided sign-flip p | {float(summary['one_sided_signflip_p_value']):.4g} |",
+              "",
+              "## Best held-out participants",
+              "",
+              "| participant | balanced accuracy | raw accuracy |",
+              "| ---: | ---: | ---: |",
+          ]
+          for row in best:
+              lines.append(f"| {row['test_participant']} | {100.0 * float(row['balanced_accuracy']):.2f}% | {100.0 * float(row['accuracy']):.2f}% |")
+          lines.extend(["", "## Worst held-out participants", "", "| participant | balanced accuracy | raw accuracy |", "| ---: | ---: | ---: |"])
+          for row in worst:
+              lines.append(f"| {row['test_participant']} | {100.0 * float(row['balanced_accuracy']):.2f}% | {100.0 * float(row['accuracy']):.2f}% |")
+          Path(__import__("os").environ["GITHUB_STEP_SUMMARY"]).write_text("\\n".join(lines) + "\\n", encoding="utf-8")
+          PY
+
+      - name: Upload cross-subject smoke outputs
+        uses: actions/upload-artifact@v5
+        with:
+          name: stimulus-cross-subject-smoke-outputs
+          path: outputs/stimulus_cross_subject_*.csv

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ ignored `.pymegdec-data-dir` file. Participant files are expected to follow the
 pymegdec cross-validate --data-dir /path/to/MEG-Data --participant 2
 pymegdec transfer --data-dir /path/to/MEG-Data --participant 2 --null-window-center nan
 pymegdec stimulus-decoding --data-dir /path/to/MEG-Data --participants 2 --output outputs/part2_stimulus_decoding.csv
+pymegdec stimulus cross-subject-smoke --data-dir /path/to/MEG-Data --participants 1-4,6,8,9,10,13-27
 ```
 
 ## Documentation

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,7 @@ pymegdec alpha-movement-results --movement-summary outputs/part2_alpha_movement_
 
 ```bash
 pymegdec stimulus decoding --participants 2 --output outputs/part2_stimulus_decoding.csv
+pymegdec stimulus cross-subject-smoke --participants 1-4,6,8,9,10,13-27 --outer-output outputs/stimulus_cross_subject_outer.csv
 pymegdec stimulus predictions --participants 2 --output outputs/stimulus_predictions.csv
 pymegdec stimulus robustness --participants 2 --predictions-output outputs/stimulus_robustness_predictions.csv
 pymegdec stimulus temporal-generalization --participants 2 --output outputs/stimulus_temporal_generalization.csv
@@ -54,6 +55,7 @@ not need to change immediately:
 
 ```bash
 pymegdec stimulus-decoding
+pymegdec stimulus-cross-subject-smoke
 pymegdec stimulus-predictions
 pymegdec stimulus-robustness
 pymegdec stimulus-temporal-generalization

--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -11,6 +11,27 @@ By default, stimulus decoding uses no null class because the cue validation
 files do not contain null trials; the direct question is which of the 16 stimuli
 was shown.
 
+## Cross-subject smoke test
+
+The cross-subject smoke workflow leaves one participant out, trains on all
+other participants, and tests 16-way image identity on the held-out participant.
+It uses `Part*Data.mat` files only; `Part*CueData.mat` files are not loaded.
+
+```bash
+pymegdec stimulus cross-subject-smoke \
+  --participants 1-4,6,8,9,10,13-27 \
+  --window-center 0.175 \
+  --window-size 0.1 \
+  --normalization subject_baseline_z \
+  --components-pca 64
+```
+
+The first-pass feature mode averages every sensor within the decoding window,
+then fits a linear multiclass SVM after training-fold PCA. The outputs include
+held-out participant scores, trial predictions, confusion counts, per-stimulus
+recall, and a group summary with a subject-level one-sided sign-flip test
+against 16-way chance.
+
 ## Time-resolved decoding curve
 
 ```powershell

--- a/scripts/export_stimulus_cross_subject_smoke.py
+++ b/scripts/export_stimulus_cross_subject_smoke.py
@@ -1,0 +1,14 @@
+"""Backward-compatible wrapper for the cross-subject stimulus smoke command."""
+
+from pathlib import Path
+import sys
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from pymegdec.stimulus_cli import stimulus_cross_subject_smoke  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(stimulus_cross_subject_smoke())

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -47,6 +47,12 @@ from pymegdec.stimulus_decoding import (
     summarize_stimulus_prediction_diagnostics,
     summarize_stimulus_temporal_generalization,
 )
+from pymegdec.stimulus_cross_subject import (
+    CrossSubjectStimulusConfig,
+    evaluate_cross_subject_stimulus_smoke,
+    export_cross_subject_stimulus_smoke,
+    summarize_cross_subject_stimulus_smoke,
+)
 
 __version__ = "0.1.0"
 
@@ -60,6 +66,7 @@ __all__ = [
     "ReactionTimeCsvConfig",
     "ReactionTimeUnavailableError",
     "StimulusDecodingConfig",
+    "CrossSubjectStimulusConfig",
     "TRANSFER_DIRECTIONS",
     "analyze_alpha_reaction_times",
     "analyze_alpha_movement_windows",
@@ -69,6 +76,7 @@ __all__ = [
     "evaluate_participant_stimulus_decoding_diagnostics",
     "evaluate_participant_stimulus_onset_scan",
     "evaluate_participant_stimulus_temporal_generalization",
+    "evaluate_cross_subject_stimulus_smoke",
     "evaluate_model_transfer",
     "evaluate_time_resolved_stimulus_transfer",
     "export_alpha_movement",
@@ -77,6 +85,7 @@ __all__ = [
     "export_stimulus_onset_scan",
     "export_stimulus_temporal_generalization",
     "export_time_resolved_stimulus_decoding",
+    "export_cross_subject_stimulus_smoke",
     "extract_phase",
     "extract_time_basis",
     "get_original_feature_importance",
@@ -88,5 +97,6 @@ __all__ = [
     "summarize_stimulus_onset_scan",
     "summarize_stimulus_prediction_diagnostics",
     "summarize_stimulus_temporal_generalization",
+    "summarize_cross_subject_stimulus_smoke",
     "summarize_alpha_movement_effects",
 ]

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -80,6 +80,7 @@ def _parse_float_list(value: str) -> tuple[float, ...]:
 
 
 _VALUE_OPTIONS_THAT_CAN_START_WITH_DASH = {
+    "--baseline-window",
     "--window-centers",
     "--time-window",
     "--scan-time-window",

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -31,6 +31,7 @@ def _dispatch_group(group: str, description: str, handlers: dict[str, CommandHan
 
 def _stimulus_handlers() -> dict[str, CommandHandler]:
     return {
+        "cross-subject-smoke": stimulus_cli.stimulus_cross_subject_smoke,
         "decoding": legacy_cli.stimulus_decoding,
         "predictions": stimulus_cli.stimulus_predictions,
         "robustness": stimulus_cli.stimulus_robustness,
@@ -60,6 +61,7 @@ def _top_level_handlers() -> dict[str, CommandHandler]:
         "make-synthetic-data": make_synthetic_data,
         # Backward-compatible top-level aliases. Prefer grouped forms in new docs.
         "stimulus-decoding": legacy_cli.stimulus_decoding,
+        "stimulus-cross-subject-smoke": stimulus_cli.stimulus_cross_subject_smoke,
         "stimulus-predictions": stimulus_cli.stimulus_predictions,
         "stimulus-robustness": stimulus_cli.stimulus_robustness,
         "stimulus-temporal-generalization": stimulus_cli.stimulus_temporal_generalization,
@@ -79,7 +81,7 @@ def _print_main_help() -> None:
     parser.print_help()
     print(
         "\nCommand groups:\n"
-        "  pymegdec stimulus <decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
+        "  pymegdec stimulus <cross-subject-smoke|decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
         "  pymegdec alpha <metrics|movement|movement-results|reaction-time|rt>\n"
         "  pymegdec data <download>\n"
         "\nCore commands:\n"

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -39,6 +39,19 @@ from pymegdec.stimulus_decoding import (
     summarize_stimulus_prediction_diagnostics,
     window_centers_from_range,
 )
+from pymegdec.stimulus_cross_subject import (
+    DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW,
+    DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES,
+    DEFAULT_CROSS_SUBJECT_CLASSIFIER,
+    DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA,
+    DEFAULT_CROSS_SUBJECT_FEATURE_MODE,
+    DEFAULT_CROSS_SUBJECT_NORMALIZATION,
+    DEFAULT_CROSS_SUBJECT_PARTICIPANTS,
+    DEFAULT_CROSS_SUBJECT_WINDOW_CENTER,
+    DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
+    CrossSubjectStimulusConfig,
+    export_cross_subject_stimulus_smoke,
+)
 from reptrace.decoding.robustness import (
     RobustnessCondition,
     run_participant_robustness_conditions,
@@ -71,6 +84,14 @@ def _parse_time_window(value: str) -> tuple[float, float]:
     if parts[0] > parts[1]:
         raise argparse.ArgumentTypeError("Time window start must be before stop.")
     return parts
+
+
+def _normalization_token(value: str) -> str:
+    return value.strip().lower().replace("-", "_")
+
+
+def _feature_mode_token(value: str) -> str:
+    return value.strip().lower().replace("-", "_")
 
 
 def _add_model_args(parser: argparse.ArgumentParser, *, include_transfer_direction: bool = True) -> None:
@@ -161,6 +182,76 @@ def stimulus_predictions(argv: Sequence[str] | None = None, prog: str | None = N
         if args.per_stimulus_output:
             write_alpha_metrics_csv(per_stimulus_rows, args.per_stimulus_output)
             print(f"Wrote {len(per_stimulus_rows)} per-stimulus rows to {args.per_stimulus_output}")
+    return 0
+
+
+def _build_cross_subject_smoke_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Run a fixed-pipeline leave-one-subject-out stimulus decoding smoke test using Part*Data.mat files only.")
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat files.")
+    parser.add_argument("--participants", default=DEFAULT_CROSS_SUBJECT_PARTICIPANTS, help="Participant ids such as 1-4,6,8.")
+    parser.add_argument("--window-center", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_CENTER, help="Stimulus decoding window center in seconds.")
+    parser.add_argument("--window-size", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE, help="Stimulus decoding window size in seconds.")
+    parser.add_argument("--baseline-window", type=_parse_time_window, default=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW, help="Baseline window as start,stop in seconds.")
+    parser.add_argument("--feature-mode", type=_feature_mode_token, default=DEFAULT_CROSS_SUBJECT_FEATURE_MODE, choices=("sensor_mean", "sensor_flat"), help="Feature extraction mode.")
+    parser.add_argument(
+        "--normalization",
+        type=_normalization_token,
+        default=DEFAULT_CROSS_SUBJECT_NORMALIZATION,
+        choices=("none", "subject_z", "subject_baseline_z"),
+        help="Subject-level normalization mode.",
+    )
+    parser.add_argument("--classifier", default=DEFAULT_CROSS_SUBJECT_CLASSIFIER, help="Classifier name.")
+    parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
+    parser.add_argument("--components-pca", type=parse_int_or_inf, default=DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA, help="Number of PCA components, or inf.")
+    parser.add_argument("--chance-classes", type=int, default=DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES, help="Number of stimulus classes used for chance level.")
+    parser.add_argument("--random-state", type=int, default=0, help="Random state passed to the classifier.")
+    parser.add_argument("--signflip-permutations", type=int, default=10000, help="Monte Carlo sign-flip permutations for the group summary.")
+    parser.add_argument("--signflip-seed", type=int, default=0, help="Random seed for sign-flip permutations.")
+    parser.add_argument("--outer-output", default="outputs/stimulus_cross_subject_outer.csv", help="Held-out participant score CSV.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_cross_subject_group_summary.csv", help="Group summary CSV.")
+    parser.add_argument("--predictions-output", default="outputs/stimulus_cross_subject_predictions.csv", help="Trial prediction CSV.")
+    parser.add_argument("--confusion-output", default="outputs/stimulus_cross_subject_confusion.csv", help="Confusion-count CSV.")
+    parser.add_argument("--per-stimulus-output", default="outputs/stimulus_cross_subject_per_stimulus.csv", help="Per-stimulus recall CSV.")
+    return parser
+
+
+def stimulus_cross_subject_smoke(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_cross_subject_smoke_parser(prog=prog)
+    args = parser.parse_args(normalize_argv(argv))
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = parse_participant_spec(args.participants)
+    if not participants:
+        parser.error("At least one participant is required.")
+    config = CrossSubjectStimulusConfig(
+        window_center=args.window_center,
+        window_size=args.window_size,
+        baseline_window=args.baseline_window,
+        feature_mode=args.feature_mode,
+        normalization=args.normalization,
+        classifier=args.classifier,
+        classifier_param=parse_classifier_param(args.classifier_param),
+        components_pca=args.components_pca,
+        chance_classes=args.chance_classes,
+        random_state=args.random_state,
+        signflip_permutations=args.signflip_permutations,
+        signflip_seed=args.signflip_seed,
+    )
+    artifacts = export_cross_subject_stimulus_smoke(
+        data_folder,
+        participants,
+        outer_output_path=args.outer_output,
+        group_summary_output_path=args.summary_output,
+        predictions_output_path=args.predictions_output,
+        confusion_output_path=args.confusion_output,
+        per_stimulus_output_path=args.per_stimulus_output,
+        config=config,
+        progress=lambda message: print(message, flush=True),
+    )
+    print(f"Wrote {len(artifacts['outer'])} held-out participant rows to {args.outer_output}")
+    print(f"Wrote {len(artifacts['group_summary'])} group summary rows to {args.summary_output}")
+    print(f"Wrote {len(artifacts['predictions'])} trial prediction rows to {args.predictions_output}")
+    print(f"Wrote {len(artifacts['confusion'])} confusion rows to {args.confusion_output}")
+    print(f"Wrote {len(artifacts['per_stimulus'])} per-stimulus rows to {args.per_stimulus_output}")
     return 0
 
 

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -1,0 +1,504 @@
+"""Cross-subject stimulus decoding smoke benchmarks."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import scipy.io as sio
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+from pymegdec.alpha_signal import get_data_field
+from pymegdec.classifiers import (
+    get_default_classifier_param,
+    should_use_default_classifier_param,
+    train_multiclass_classifier,
+)
+from pymegdec.data_config import resolve_data_folder
+from reptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
+from reptrace.decoding.windowed import predict_window_model as predict_reptrace_window_model
+from reptrace.metrics.confusion import confusion_counts, per_class_accuracy
+from sklearn.metrics import accuracy_score, balanced_accuracy_score
+
+DEFAULT_CROSS_SUBJECT_PARTICIPANTS = "1-4,6,8,9,10,13-27"
+DEFAULT_CROSS_SUBJECT_WINDOW_CENTER = 0.175
+DEFAULT_CROSS_SUBJECT_WINDOW_SIZE = 0.1
+DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW = (-0.5, 0.0)
+DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES = 16
+DEFAULT_CROSS_SUBJECT_FEATURE_MODE = "sensor_mean"
+DEFAULT_CROSS_SUBJECT_NORMALIZATION = "subject_baseline_z"
+DEFAULT_CROSS_SUBJECT_CLASSIFIER = "multiclass-svm"
+DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA = 64
+FEATURE_MODES = ("sensor_mean", "sensor_flat")
+NORMALIZATION_MODES = ("none", "subject_z", "subject_baseline_z")
+
+
+@dataclass(frozen=True)
+class CrossSubjectStimulusConfig:
+    """Parameters for the fixed-pipeline cross-subject stimulus smoke test."""
+
+    window_center: float = DEFAULT_CROSS_SUBJECT_WINDOW_CENTER
+    window_size: float = DEFAULT_CROSS_SUBJECT_WINDOW_SIZE
+    baseline_window: tuple[float, float] = DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW
+    feature_mode: str = DEFAULT_CROSS_SUBJECT_FEATURE_MODE
+    normalization: str = DEFAULT_CROSS_SUBJECT_NORMALIZATION
+    classifier: str = DEFAULT_CROSS_SUBJECT_CLASSIFIER
+    classifier_param: object = float("nan")
+    components_pca: int | float = DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA
+    chance_classes: int = DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES
+    random_state: int | None = 0
+    signflip_permutations: int = 10_000
+    signflip_seed: int | None = 0
+
+
+@dataclass(frozen=True)
+class ParticipantFeatureSet:
+    """Windowed features for one participant."""
+
+    participant: int
+    labels: np.ndarray
+    features: np.ndarray
+    baseline_features: np.ndarray | None
+    n_channels: int
+    n_window_samples: int
+    n_baseline_samples: int
+
+
+def evaluate_cross_subject_stimulus_smoke(data_folder, participants, *, config=None, progress=None):
+    """Run fixed-pipeline leave-one-subject-out stimulus decoding on ``Part*Data.mat`` files only."""
+
+    config = _normalized_config(config or CrossSubjectStimulusConfig())
+    data_folder = resolve_data_folder(data_folder)
+    participants = tuple(int(participant) for participant in participants)
+    if len(participants) < 3:
+        raise ValueError("At least three participants are required for a cross-subject smoke benchmark.")
+
+    classifier_param = config.classifier_param
+    if should_use_default_classifier_param(classifier_param):
+        classifier_param = get_default_classifier_param(config.classifier)
+
+    feature_sets = []
+    for participant in participants:
+        if progress is not None:
+            progress(f"LOAD participant={participant}")
+        feature_sets.append(load_participant_stimulus_features(data_folder, participant, config=config))
+
+    outer_rows = []
+    prediction_rows = []
+    for test_participant in participants:
+        if progress is not None:
+            progress(f"START outer_test_participant={test_participant}")
+        train_sets = [feature_set for feature_set in feature_sets if feature_set.participant != test_participant]
+        test_set = next(feature_set for feature_set in feature_sets if feature_set.participant == test_participant)
+        outer_row, participant_predictions = _evaluate_outer_fold(
+            train_sets,
+            test_set,
+            config=config,
+            classifier_param=classifier_param,
+        )
+        outer_rows.append(outer_row)
+        prediction_rows.extend(participant_predictions)
+        if progress is not None:
+            progress(f"DONE outer_test_participant={test_participant} balanced_accuracy={outer_row['balanced_accuracy']:.4f}")
+
+    group_summary_rows = summarize_cross_subject_stimulus_smoke(outer_rows, config=config)
+    confusion_rows, per_stimulus_rows = summarize_cross_subject_predictions(prediction_rows)
+    return {
+        "outer": outer_rows,
+        "predictions": prediction_rows,
+        "group_summary": group_summary_rows,
+        "confusion": confusion_rows,
+        "per_stimulus": per_stimulus_rows,
+    }
+
+
+def load_participant_stimulus_features(data_folder, participant, *, config=None):
+    """Load one participant's main ``Part*Data.mat`` file and extract fixed-window features."""
+
+    config = _normalized_config(config or CrossSubjectStimulusConfig())
+    data_path = Path(resolve_data_folder(data_folder)) / f"Part{int(participant)}Data.mat"
+    data = sio.loadmat(data_path)["data"][0]
+    labels = _trialinfo_labels(data)
+    features, n_window_samples = _extract_window_features(
+        data,
+        _centered_window(config.window_center, config.window_size),
+        feature_mode=config.feature_mode,
+    )
+    baseline_features = None
+    n_baseline_samples = 0
+    if config.normalization == "subject_baseline_z":
+        baseline_features, n_baseline_samples = _extract_window_features(data, config.baseline_window, feature_mode=config.feature_mode)
+        if baseline_features.shape[1] != features.shape[1]:
+            raise ValueError("subject_baseline_z requires baseline and decoding features with matching dimensions.")
+    if labels.shape[0] != features.shape[0]:
+        raise ValueError(f"Participant {participant} has {labels.shape[0]} labels but {features.shape[0]} feature rows.")
+    return ParticipantFeatureSet(
+        participant=int(participant),
+        labels=labels,
+        features=features,
+        baseline_features=baseline_features,
+        n_channels=int(_trial_signal(data, 0).shape[0]),
+        n_window_samples=int(n_window_samples),
+        n_baseline_samples=int(n_baseline_samples),
+    )
+
+
+def summarize_cross_subject_stimulus_smoke(outer_rows, *, config=None):
+    """Summarize held-out participant scores with a one-sided subject-level sign-flip test."""
+
+    if not outer_rows:
+        return []
+
+    config = _normalized_config(config or CrossSubjectStimulusConfig())
+    balanced = np.asarray([float(row["balanced_accuracy"]) for row in outer_rows], dtype=float)
+    raw = np.asarray([float(row["accuracy"]) for row in outer_rows], dtype=float)
+    chance = float(outer_rows[0]["chance_accuracy"])
+    differences = balanced - chance
+    p_value = _one_sided_signflip_p_value(differences, n_permutations=config.signflip_permutations, seed=config.signflip_seed)
+    return [
+        {
+            "n_outer_folds": len(outer_rows),
+            "n_test_participants": len(outer_rows),
+            "window_center_s": config.window_center,
+            "window_size_s": config.window_size,
+            "window_start_s": _centered_window(config.window_center, config.window_size)[0],
+            "window_stop_s": _centered_window(config.window_center, config.window_size)[1],
+            "baseline_window_start_s": config.baseline_window[0],
+            "baseline_window_stop_s": config.baseline_window[1],
+            "feature_mode": config.feature_mode,
+            "normalization": config.normalization,
+            "classifier": config.classifier,
+            "components_pca": config.components_pca,
+            "chance_accuracy": chance,
+            "chance_percent": 100.0 * chance,
+            "accuracy_mean": float(np.mean(raw)),
+            "accuracy_median": float(np.median(raw)),
+            "accuracy_sem": _sem(raw),
+            "percent_mean": float(100.0 * np.mean(raw)),
+            "balanced_accuracy_mean": float(np.mean(balanced)),
+            "balanced_accuracy_median": float(np.median(balanced)),
+            "balanced_accuracy_sem": _sem(balanced),
+            "balanced_percent_mean": float(100.0 * np.mean(balanced)),
+            "balanced_percent_median": float(100.0 * np.median(balanced)),
+            "balanced_percent_sem": float(100.0 * _sem(balanced)),
+            "mean_above_chance": float(np.mean(differences)),
+            "percent_above_chance": float(100.0 * np.mean(differences)),
+            "participants_above_chance": int(np.sum(balanced > chance)),
+            "participants_at_or_below_chance": int(np.sum(balanced <= chance)),
+            "one_sided_signflip_p_value": p_value,
+        }
+    ]
+
+
+def summarize_cross_subject_predictions(prediction_rows):
+    """Return confusion-count and per-stimulus recall summaries for cross-subject predictions."""
+
+    if not prediction_rows:
+        return [], []
+
+    import pandas as pd
+
+    frame = pd.DataFrame(prediction_rows)
+    group_columns = (
+        "window_center_s",
+        "feature_mode",
+        "normalization",
+        "classifier",
+        "components_pca",
+    )
+    confusion = confusion_counts(
+        frame,
+        true_column="true_stimulus",
+        predicted_column="predicted_stimulus",
+        group_columns=group_columns,
+    )
+    per_stimulus = per_class_accuracy(
+        frame,
+        true_column="true_stimulus",
+        predicted_column="predicted_stimulus",
+        participant_column="test_participant",
+        group_columns=group_columns,
+    )
+    return confusion.to_dict(orient="records"), per_stimulus.to_dict(orient="records")
+
+
+def export_cross_subject_stimulus_smoke(
+    data_folder,
+    participants,
+    *,
+    outer_output_path,
+    group_summary_output_path=None,
+    predictions_output_path=None,
+    confusion_output_path=None,
+    per_stimulus_output_path=None,
+    config=None,
+    progress=None,
+):
+    """Run the cross-subject smoke benchmark and write compact CSV artifacts."""
+
+    artifacts = evaluate_cross_subject_stimulus_smoke(data_folder, participants, config=config, progress=progress)
+    write_alpha_metrics_csv(artifacts["outer"], outer_output_path)
+    if group_summary_output_path:
+        write_alpha_metrics_csv(artifacts["group_summary"], group_summary_output_path)
+    if predictions_output_path:
+        write_alpha_metrics_csv(artifacts["predictions"], predictions_output_path)
+    if confusion_output_path:
+        write_alpha_metrics_csv(artifacts["confusion"], confusion_output_path)
+    if per_stimulus_output_path:
+        write_alpha_metrics_csv(artifacts["per_stimulus"], per_stimulus_output_path)
+    return artifacts
+
+
+def _evaluate_outer_fold(train_sets, test_set, *, config, classifier_param):
+    train_features = np.vstack([_normalized_subject_features(feature_set, config) for feature_set in train_sets])
+    train_labels_one_based = np.concatenate([feature_set.labels for feature_set in train_sets])
+    test_features = _normalized_subject_features(test_set, config)
+    test_labels_one_based = test_set.labels
+    train_labels = train_labels_one_based - 1
+    test_labels = test_labels_one_based - 1
+
+    train_window = _centered_window(config.window_center, config.window_size)
+    model_bundle = fit_reptrace_window_model(
+        train_features,
+        train_labels,
+        fit_model=lambda features, labels: train_multiclass_classifier(
+            features,
+            labels,
+            config.classifier,
+            classifier_param,
+            random_state=config.random_state,
+        ),
+        components_pca=config.components_pca,
+        train_window=train_window,
+    )
+    predictions, _scores = predict_reptrace_window_model(model_bundle, test_features)
+    accuracy = float(accuracy_score(test_labels, predictions))
+    balanced_accuracy = float(balanced_accuracy_score(test_labels, predictions))
+    chance_accuracy = 1.0 / config.chance_classes
+    train_class_counts = Counter(train_labels_one_based.tolist())
+    test_class_counts = Counter(test_labels_one_based.tolist())
+    train_participants = tuple(feature_set.participant for feature_set in train_sets)
+
+    outer_row = {
+        "outer_fold": int(test_set.participant),
+        "test_participant": int(test_set.participant),
+        "train_participants": ",".join(str(participant) for participant in train_participants),
+        "n_train_participants": len(train_sets),
+        "n_test_participants": 1,
+        "window_center_s": config.window_center,
+        "window_size_s": config.window_size,
+        "window_start_s": train_window[0],
+        "window_stop_s": train_window[1],
+        "baseline_window_start_s": config.baseline_window[0],
+        "baseline_window_stop_s": config.baseline_window[1],
+        "feature_mode": config.feature_mode,
+        "normalization": config.normalization,
+        "accuracy": accuracy,
+        "percent": 100.0 * accuracy,
+        "balanced_accuracy": balanced_accuracy,
+        "balanced_percent": 100.0 * balanced_accuracy,
+        "chance_accuracy": chance_accuracy,
+        "chance_percent": 100.0 * chance_accuracy,
+        "above_chance": bool(balanced_accuracy > chance_accuracy),
+        "n_train_trials": int(train_labels.shape[0]),
+        "n_test_trials": int(test_labels.shape[0]),
+        "n_train_classes": int(len(train_class_counts)),
+        "n_test_classes": int(len(test_class_counts)),
+        "min_train_trials_per_class": int(min(train_class_counts.values())),
+        "min_test_trials_per_class": int(min(test_class_counts.values())),
+        "classifier": config.classifier,
+        "classifier_param": classifier_param,
+        "components_pca": config.components_pca,
+        "actual_components_pca": model_bundle.actual_components_pca,
+        "pca_explained_variance_percent": model_bundle.explained_variance_percent,
+        "n_channels": test_set.n_channels,
+        "n_window_samples": test_set.n_window_samples,
+        "n_baseline_samples": test_set.n_baseline_samples,
+    }
+    prediction_rows = _prediction_rows(test_set, test_labels, predictions, config=config, actual_components_pca=model_bundle.actual_components_pca)
+    return outer_row, prediction_rows
+
+
+def _prediction_rows(test_set, test_labels, predictions, *, config, actual_components_pca):
+    train_window = _centered_window(config.window_center, config.window_size)
+    rows = []
+    for trial_idx, (true_label, predicted_label) in enumerate(zip(test_labels, predictions)):
+        true_stimulus = int(true_label) + 1
+        predicted_stimulus = int(predicted_label) + 1
+        rows.append(
+            {
+                "outer_fold": int(test_set.participant),
+                "test_participant": int(test_set.participant),
+                "window_center_s": config.window_center,
+                "window_start_s": train_window[0],
+                "window_stop_s": train_window[1],
+                "feature_mode": config.feature_mode,
+                "normalization": config.normalization,
+                "classifier": config.classifier,
+                "components_pca": config.components_pca,
+                "actual_components_pca": actual_components_pca,
+                "trial": int(trial_idx),
+                "test_trial_index": int(trial_idx),
+                "test_trial_number": int(trial_idx + 1),
+                "true_label": int(true_label),
+                "predicted_label": int(predicted_label),
+                "true_stimulus": true_stimulus,
+                "predicted_stimulus": predicted_stimulus,
+                "correct": bool(predicted_label == true_label),
+            }
+        )
+    return rows
+
+
+def _extract_window_features(data, time_window, *, feature_mode):
+    feature_mode = _normalize_feature_mode(feature_mode)
+    time_vector = _time_vector(data, 0)
+    mask = _time_mask(time_vector, time_window)
+    features = []
+    for trial_idx in range(_count_trials(data)):
+        signal = _trial_signal(data, trial_idx)
+        window_signal = signal[:, mask]
+        if feature_mode == "sensor_mean":
+            feature = np.mean(window_signal, axis=1)
+        elif feature_mode == "sensor_flat":
+            feature = window_signal.reshape(-1, order="F")
+        else:
+            raise ValueError(f"Unsupported feature_mode: {feature_mode}")
+        features.append(feature)
+    return np.vstack(features), int(np.sum(mask))
+
+
+def _trialinfo_labels(data):
+    trialinfo = _unwrap_singleton(get_data_field(data, "trialinfo"))
+    return np.asarray(trialinfo, dtype=int).ravel()
+
+
+def _count_trials(data):
+    trial_field = _unwrap_outer_cell(get_data_field(data, "trial"))
+    values = np.asarray(trial_field, dtype=object)
+    if values.ndim == 2 and values.shape[0] == 1:
+        return int(values.shape[1])
+    if values.ndim == 2 and values.shape[1] == 1:
+        return int(values.shape[0])
+    return int(values.size)
+
+
+def _time_vector(data, trial_idx):
+    return np.asarray(_cell_item(get_data_field(data, "time"), trial_idx), dtype=float).ravel()
+
+
+def _trial_signal(data, trial_idx):
+    return np.asarray(_cell_item(get_data_field(data, "trial"), trial_idx), dtype=float)
+
+
+def _cell_item(cell, index):
+    values = np.asarray(_unwrap_outer_cell(cell), dtype=object)
+    if values.ndim == 0:
+        return _unwrap_singleton(values.item())
+    if values.ndim == 2 and values.shape[0] == 1:
+        return _unwrap_singleton(values[0, index])
+    if values.ndim == 2 and values.shape[1] == 1:
+        return _unwrap_singleton(values[index, 0])
+    return _unwrap_singleton(values[index])
+
+
+def _unwrap_outer_cell(value):
+    while isinstance(value, np.ndarray) and value.dtype == object and value.size == 1:
+        value = value.item()
+    return value
+
+
+def _unwrap_singleton(value):
+    while isinstance(value, np.ndarray) and value.dtype == object and value.size == 1:
+        value = value.item()
+    return value
+
+
+def _time_mask(time_vector, time_window):
+    start, stop = time_window
+    if start >= stop:
+        raise ValueError("time_window start must be before stop.")
+    tolerance = 1e-12
+    mask = (time_vector >= start - tolerance) & (time_vector <= stop + tolerance)
+    if not np.any(mask):
+        raise ValueError(f"time_window {time_window} does not overlap the data.")
+    return mask
+
+
+def _normalized_subject_features(feature_set, config):
+    if config.normalization == "none":
+        return feature_set.features
+    if config.normalization == "subject_z":
+        reference = feature_set.features
+    elif config.normalization == "subject_baseline_z":
+        if feature_set.baseline_features is None:
+            raise ValueError("subject_baseline_z requires baseline features.")
+        reference = feature_set.baseline_features
+    else:
+        raise ValueError(f"Unsupported normalization: {config.normalization}")
+    mean = np.mean(reference, axis=0, keepdims=True)
+    std = np.std(reference, axis=0, keepdims=True)
+    std = np.where(std < 1e-12, 1.0, std)
+    return (feature_set.features - mean) / std
+
+
+def _centered_window(center, size):
+    return float(np.round(center - size / 2, 10)), float(np.round(center + size / 2, 10))
+
+
+def _sem(values):
+    values = np.asarray(values, dtype=float)
+    values = values[np.isfinite(values)]
+    if values.size <= 1:
+        return 0.0
+    return float(np.std(values, ddof=1) / np.sqrt(values.size))
+
+
+def _one_sided_signflip_p_value(differences, *, n_permutations, seed):
+    differences = np.asarray(differences, dtype=float)
+    differences = differences[np.isfinite(differences)]
+    if differences.size == 0:
+        return np.nan
+    observed = float(np.mean(differences))
+    if observed <= 0:
+        return 1.0
+    if differences.size <= 16:
+        signs = np.array(np.meshgrid(*[[-1.0, 1.0]] * differences.size)).T.reshape(-1, differences.size)
+        null_means = signs @ differences / differences.size
+        return float(np.mean(null_means >= observed))
+    rng = np.random.default_rng(seed)
+    signs = rng.choice(np.array([-1.0, 1.0]), size=(int(n_permutations), differences.size))
+    null_means = signs @ differences / differences.size
+    return float((np.sum(null_means >= observed) + 1) / (int(n_permutations) + 1))
+
+
+def _normalized_config(config):
+    return CrossSubjectStimulusConfig(
+        window_center=config.window_center,
+        window_size=config.window_size,
+        baseline_window=config.baseline_window,
+        feature_mode=_normalize_feature_mode(config.feature_mode),
+        normalization=_normalize_normalization(config.normalization),
+        classifier=config.classifier,
+        classifier_param=config.classifier_param,
+        components_pca=config.components_pca,
+        chance_classes=config.chance_classes,
+        random_state=config.random_state,
+        signflip_permutations=config.signflip_permutations,
+        signflip_seed=config.signflip_seed,
+    )
+
+
+def _normalize_feature_mode(value):
+    normalized = str(value).strip().lower().replace("-", "_")
+    if normalized not in FEATURE_MODES:
+        raise ValueError(f"feature_mode must be one of {FEATURE_MODES}.")
+    return normalized
+
+
+def _normalize_normalization(value):
+    normalized = str(value).strip().lower().replace("-", "_")
+    if normalized not in NORMALIZATION_MODES:
+        raise ValueError(f"normalization must be one of {NORMALIZATION_MODES}.")
+    return normalized

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1,0 +1,100 @@
+import re
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from pymegdec.stimulus_cross_subject import (
+    CrossSubjectStimulusConfig,
+    evaluate_cross_subject_stimulus_smoke,
+    load_participant_stimulus_features,
+    summarize_cross_subject_stimulus_smoke,
+)
+from tests.matlab_fixtures import cell_array
+
+
+def _mat_data(labels, values):
+    trialinfo = np.empty((1, 1), dtype=object)
+    trialinfo[0, 0] = np.asarray(labels, dtype=int)
+    time = np.asarray([-0.5, 0.0, 0.1, 0.15, 0.2, 1.5], dtype=float)
+    trials = []
+    for label, value in zip(labels, values):
+        signal = np.zeros((2, time.size), dtype=float)
+        signal[:, (time >= 0.15) & (time <= 0.25)] = value
+        signal[:, (time >= -0.5) & (time <= 0.0)] = 0.1 * label
+        trials.append(signal)
+    return {
+        "trial": cell_array(trials),
+        "time": cell_array([time for _ in trials]),
+        "trialinfo": trialinfo,
+    }
+
+
+def _loadmat_side_effect(data_by_participant):
+    def loadmat(path):
+        match = re.search(r"Part(\d+)Data\.mat$", str(path))
+        if not match:
+            raise AssertionError(f"Unexpected MAT path: {path}")
+        participant = int(match.group(1))
+        return {"data": np.array([data_by_participant[participant]], dtype=object)}
+
+    return loadmat
+
+
+class TestStimulusCrossSubject(unittest.TestCase):
+    def test_load_participant_stimulus_features_uses_main_data_only(self):
+        data_by_participant = {1: _mat_data([1, 2, 1, 2], [-1.0, 1.0, -1.0, 1.0])}
+        config = CrossSubjectStimulusConfig(window_center=0.2, window_size=0.1, normalization="none", components_pca=float("inf"), chance_classes=2)
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)) as loadmat:
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (4, 2))
+        self.assertEqual(feature_set.n_window_samples, 2)
+        self.assertEqual(feature_set.labels.tolist(), [1, 2, 1, 2])
+        self.assertTrue(str(loadmat.call_args.args[0]).endswith("Part1Data.mat"))
+        self.assertNotIn("CueData", str(loadmat.call_args.args[0]))
+
+    def test_evaluate_cross_subject_stimulus_smoke(self):
+        data_by_participant = {
+            1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),
+            2: _mat_data([1, 2, 1, 2], [-1.0, 1.0, -0.9, 0.9]),
+            3: _mat_data([1, 2, 1, 2], [-1.3, 1.3, -1.2, 1.2]),
+        }
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.1,
+            normalization="none",
+            classifier="multiclass-svm",
+            classifier_param=0.5,
+            components_pca=float("inf"),
+            chance_classes=2,
+            signflip_permutations=128,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            artifacts = evaluate_cross_subject_stimulus_smoke("unused", [1, 2, 3], config=config)
+
+        self.assertEqual(len(artifacts["outer"]), 3)
+        self.assertEqual(len(artifacts["predictions"]), 12)
+        self.assertEqual(len(artifacts["group_summary"]), 1)
+        self.assertEqual({row["balanced_accuracy"] for row in artifacts["outer"]}, {1.0})
+        self.assertEqual(artifacts["group_summary"][0]["participants_above_chance"], 3)
+        self.assertEqual({row["true_stimulus"] for row in artifacts["predictions"]}, {1, 2})
+        self.assertEqual({row["predicted_stimulus"] for row in artifacts["predictions"]}, {1, 2})
+
+    def test_summarize_cross_subject_stimulus_smoke_signflip(self):
+        config = CrossSubjectStimulusConfig(chance_classes=2, signflip_permutations=128)
+        rows = [
+            {"balanced_accuracy": 0.75, "accuracy": 0.75, "chance_accuracy": 0.5},
+            {"balanced_accuracy": 1.0, "accuracy": 1.0, "chance_accuracy": 0.5},
+        ]
+
+        summary = summarize_cross_subject_stimulus_smoke(rows, config=config)
+
+        self.assertEqual(summary[0]["n_outer_folds"], 2)
+        self.assertAlmostEqual(summary[0]["balanced_accuracy_mean"], 0.875)
+        self.assertLessEqual(summary[0]["one_sided_signflip_p_value"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a fixed-pipeline leave-one-subject-out stimulus smoke benchmark using only `Part*Data.mat`
- export held-out participant scores, trial predictions, confusion counts, per-stimulus recall, and a group summary
- add a manual self-hosted workflow that downloads only main data files and uploads compact smoke outputs

## Test plan
- `python -m ruff check`
- `python -m pytest tests\\test_stimulus_cross_subject.py tests\\test_stimulus_decoding.py tests\\test_data_download.py tests\\test_data_config.py -q`
- `MPLBACKEND=Agg python -m pytest -q`
- parsed the new workflow/action YAML with PyYAML
- ran the smoke CLI on a tiny synthetic 3-participant dataset