### PR TITLE
Follow symlinked MEG data in workflow checks

### DIFF
--- a/.github/actions/prepare-meg-data/action.yml
+++ b/.github/actions/prepare-meg-data/action.yml
@@ -134,8 +134,8 @@ runs:
           mkdir -p "$(dirname "${DATA_DIR}")"
           ln -s "$(realpath "${CACHE_DATA_DIR}")" "${DATA_DIR}"
         fi
-        main_count="$(find "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
-        cue_count="$(find "${DATA_DIR}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+        main_count="$(find -L "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+        cue_count="$(find -L "${DATA_DIR}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
         if [ "${main_count}" -eq 0 ] || { [ "${{ inputs.require-cue-files }}" = "true" ] && [ "${cue_count}" -eq 0 ]; }; then
           echo "Prepared MEG data is incomplete at ${DATA_DIR}: ${main_count} main files, ${cue_count} cue files" >&2
           exit 1

--- a/.github/workflows/stimulus-cross-subject-smoke.yml
+++ b/.github/workflows/stimulus-cross-subject-smoke.yml
@@ -136,7 +136,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          main_count="$(find "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+          main_count="$(find -L "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
           echo "Main files: ${main_count}"
           test "${main_count}" -ge 23
 


### PR DESCRIPTION
## Summary
- follow symlinked workflow data directories when counting prepared MEG files
- fix the cross-subject smoke workflow validation for self-hosted runner cache symlinks

## Root cause
The failed run downloaded all 23 `Part*Data.mat` files successfully, then counted zero files because `DATA_DIR` was a symlink to the self-hosted cache and `find` does not traverse directory symlinks unless `-L` is used.

## Test plan
- `python -m ruff check`
- parsed `.github/actions/prepare-meg-data/action.yml` and `.github/workflows/stimulus-cross-subject-smoke.yml` with PyYAML
- `git diff --check`