### PR TITLE
Add cross-subject baseline classifiers

### DIFF
--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -32,6 +32,12 @@ held-out participant scores, trial predictions, confusion counts, per-stimulus
 recall, and a group summary with a subject-level one-sided sign-flip test
 against 16-way chance.
 
+Useful follow-up classifiers for this cross-subject benchmark are
+`correlation-prototype`, `multinomial-logistic`, and `shrinkage-lda`.
+`correlation-prototype` classifies each held-out trial by correlation to the
+training-set class-average pattern, which is a simple baseline for shared
+stimulus topographies across participants.
+
 ## Time-resolved decoding curve
 
 ```powershell

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -22,8 +22,13 @@ from reptrace.decoding.classifiers import (
     train_gradient_boosting,
     train_lasso_logistic,
 )
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
+from sklearn.linear_model import LogisticRegression
 
 _PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS = {
+    "correlation-prototype": None,
+    "multinomial-logistic": 1.0,
+    "shrinkage-lda": None,
     "xgboost": 100,
     "pytorch-mlp": {
         "hidden_dim": 720,
@@ -70,6 +75,61 @@ def _build_xgboost(_features, _labels, classifier_param, random_state):
     )
 
 
+class CorrelationPrototypeClassifier:
+    """Classify by correlation to class-average feature prototypes."""
+
+    def __init__(self):
+        self.classes_: np.ndarray | None = None
+        self.prototypes_: np.ndarray | None = None
+        self.normalized_prototypes_: np.ndarray | None = None
+
+    def fit(self, features, labels):
+        features = np.asarray(features, dtype=float)
+        labels = np.asarray(labels).ravel()
+        self.classes_ = np.unique(labels)
+        if self.classes_.size == 0:
+            raise ValueError("At least one class is required.")
+        self.prototypes_ = np.vstack([np.mean(features[labels == class_label], axis=0) for class_label in self.classes_])
+        self.normalized_prototypes_ = self._row_center_normalize(self.prototypes_)
+        return self
+
+    def decision_function(self, features):
+        if self.normalized_prototypes_ is None:
+            raise RuntimeError("CorrelationPrototypeClassifier must be fitted before scoring.")
+        features = np.asarray(features, dtype=float)
+        return self._row_center_normalize(features) @ self.normalized_prototypes_.T
+
+    def predict(self, features):
+        if self.classes_ is None:
+            raise RuntimeError("CorrelationPrototypeClassifier must be fitted before prediction.")
+        scores = self.decision_function(features)
+        return self.classes_[np.argmax(scores, axis=1)]
+
+    @staticmethod
+    def _row_center_normalize(values):
+        values = np.asarray(values, dtype=float)
+        centered = values - np.mean(values, axis=1, keepdims=True)
+        norms = np.linalg.norm(centered, axis=1, keepdims=True)
+        norms = np.where(norms < 1e-12, 1.0, norms)
+        return centered / norms
+
+
+def _build_correlation_prototype(_features, _labels, _classifier_param, _random_state):
+    return CorrelationPrototypeClassifier()
+
+
+def _build_multinomial_logistic(_features, _labels, classifier_param, random_state):
+    return LogisticRegression(
+        C=float(classifier_param),
+        max_iter=1000,
+        random_state=random_state,
+    )
+
+
+def _build_shrinkage_lda(_features, _labels, _classifier_param, _random_state):
+    return LinearDiscriminantAnalysis(solver="lsqr", shrinkage="auto")
+
+
 def _build_pytorch_mlp_classifier(features, labels, classifier_param, random_state):
     return _train_pytorch_mlp(
         features,
@@ -81,6 +141,9 @@ def _build_pytorch_mlp_classifier(features, labels, classifier_param, random_sta
 
 CLASSIFIER_REGISTRY = {
     **REPTRACE_CLASSIFIER_REGISTRY,
+    "correlation-prototype": ClassifierSpec(_build_correlation_prototype),
+    "multinomial-logistic": ClassifierSpec(_build_multinomial_logistic),
+    "shrinkage-lda": ClassifierSpec(_build_shrinkage_lda),
     "xgboost": ClassifierSpec(_build_xgboost),
     "pytorch-mlp": ClassifierSpec(_build_pytorch_mlp_classifier, fits_in_builder=True),
 }

--- a/tests/test_classifier_registry.py
+++ b/tests/test_classifier_registry.py
@@ -29,14 +29,17 @@ class TestClassifierRegistry(unittest.TestCase):
         self.assertEqual(
             {
                 "always1Dummy",
+                "correlation-prototype",
                 "gradient-boosting",
                 "knn",
                 "mostFrequentDummy",
+                "multinomial-logistic",
                 "multiclass-svm",
                 "multiclass-svm-weighted",
                 "pytorch-mlp",
                 "random-forest",
                 "scikit-mlp",
+                "shrinkage-lda",
                 "xgboost",
             },
             set(CLASSIFIER_REGISTRY),
@@ -45,13 +48,16 @@ class TestClassifierRegistry(unittest.TestCase):
     def test_registry_trains_fast_sklearn_classifiers(self):
         classifier_params = {
             "always1Dummy": None,
+            "correlation-prototype": None,
             "gradient-boosting": 5,
             "knn": 1,
             "mostFrequentDummy": None,
+            "multinomial-logistic": 1.0,
             "multiclass-svm": 1.0,
             "multiclass-svm-weighted": 1.0,
             "random-forest": 5,
             "scikit-mlp": (5, 50),
+            "shrinkage-lda": None,
         }
 
         with warnings.catch_warnings():
@@ -67,6 +73,29 @@ class TestClassifierRegistry(unittest.TestCase):
                     )
                     predictions = model.predict(self.features)
                     self.assertEqual(len(predictions), len(self.labels))
+
+    def test_correlation_prototype_predicts_by_nearest_class_pattern(self):
+        features = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [1.0, 0.1, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.1],
+                [0.0, 0.0, 1.0],
+                [0.1, 0.0, 1.0],
+            ]
+        )
+        labels = np.array([0, 0, 1, 1, 2, 2])
+        model = train_multiclass_classifier(
+            features,
+            labels,
+            "correlation-prototype",
+            None,
+        )
+
+        predictions = model.predict(np.array([[0.9, 0.1, 0.0], [0.0, 0.2, 1.0]]))
+
+        np.testing.assert_array_equal(predictions, np.array([0, 2]))
 
     def test_random_state_reproduces_stochastic_classifier_predictions(self):
         model_a = train_multiclass_classifier(self.features, self.labels, "random-forest", 5, random_state=7)

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -35,6 +35,11 @@ class TestClassifiers(unittest.TestCase):
 
         self.assertEqual(len(predictions), len(self.labels))
 
+    def test_default_params_for_cross_subject_baseline_classifiers(self):
+        self.assertIsNone(get_default_classifier_param("correlation-prototype"))
+        self.assertEqual(get_default_classifier_param("multinomial-logistic"), 1.0)
+        self.assertIsNone(get_default_classifier_param("shrinkage-lda"))
+
     def test_optional_ml_dependencies_are_lazy_imported(self):
         env = os.environ.copy()
         src_path = str(Path(__file__).resolve().parents[1] / "src")


### PR DESCRIPTION
## Summary
- add correlation-prototype, multinomial-logistic, and shrinkage-lda classifier options to the PyMEGDec classifier registry
- document the new cross-subject follow-up classifiers for the stimulus benchmark
- add synthetic registry/default-parameter tests for the new classifier options

## Validation
- `python -m pytest tests\test_classifiers.py tests\test_classifier_registry.py tests\test_stimulus_cross_subject.py -q`
- `python -m ruff check src\pymegdec\classifiers.py tests\test_classifiers.py tests\test_classifier_registry.py`
- `python -m ruff check`
- `$env:MPLBACKEND='Agg'; python -m pytest -q`

Note: a plain `python -m pytest -q` on this Windows checkout fails in `tests/test_alpha_signal_visualization.py` because the local Tk backend is incomplete; forcing Matplotlib to `Agg` passes the full suite.