### PR TITLE
Update cross-subject artifact upload action

### DIFF
--- a/.github/workflows/stimulus-cross-subject-smoke.yml
+++ b/.github/workflows/stimulus-cross-subject-smoke.yml
@@ -204,7 +204,7 @@ jobs:
           PY
 
       - name: Upload cross-subject smoke outputs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: stimulus-cross-subject-smoke-outputs
           path: outputs/stimulus_cross_subject_*.csv


### PR DESCRIPTION
## Summary
- update the manual cross-subject smoke workflow artifact upload step from `actions/upload-artifact@v5` to `@v7`
- align it with the newer artifact action already used in other PyMEGDec workflows
- avoid the Node.js 20 deprecation warning seen in the cross-subject benchmark runs

## Validation
- confirmed `.github/workflows/stimulus-cross-subject-smoke.yml` now references `actions/upload-artifact@v7` and no longer references `@v5`