### PR TITLE
Add nested cross-subject LOSO benchmark

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -1,0 +1,208 @@
+name: Manual stimulus cross-subject nested
+#checkov:skip=CKV_GHA_7:Manual workflow inputs are constrained to analysis parameters and used only after shell quoting.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_label:
+        description: Runner label used for the full-data nested benchmark.
+        required: true
+        default: self-hosted
+        type: string
+      python_version:
+        description: Python version used for the analysis environment.
+        required: true
+        default: "3.13"
+        type: string
+      use_nextcloud_data:
+        description: Restore/download/cache the MEG data before running.
+        required: true
+        default: true
+        type: boolean
+      data_cache_version:
+        description: MEG data cache version.
+        required: true
+        default: v2
+        type: string
+      data_dir:
+        description: Relative data directory to restore/populate.
+        required: true
+        default: .cache/meg-data-main
+        type: string
+      participants:
+        description: Participant ids such as 1-4,6,8.
+        required: true
+        default: "1-4,6,8,9,10,13-27"
+        type: string
+      window_centers:
+        description: Candidate window centers in seconds.
+        required: true
+        default: "0.150,0.175,0.200"
+        type: string
+      window_size:
+        description: Stimulus decoding window size in seconds.
+        required: true
+        default: "0.1"
+        type: string
+      baseline_window:
+        description: Baseline normalization window as start,stop in seconds.
+        required: true
+        default: "-0.5,0.0"
+        type: string
+      feature_modes:
+        description: Candidate feature modes.
+        required: true
+        default: sensor_flat
+        type: string
+      normalizations:
+        description: Candidate normalization modes.
+        required: true
+        default: subject_baseline_z
+        type: string
+      classifiers:
+        description: Candidate classifier names.
+        required: true
+        default: multinomial-logistic,shrinkage-lda,multiclass-svm
+        type: string
+      classifier_params:
+        description: Candidate classifier parameters; use default for classifier defaults.
+        required: true
+        default: default
+        type: string
+      components_pca_values:
+        description: Candidate PCA component counts, or inf.
+        required: true
+        default: "64"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  cross-subject-nested:
+    name: Cross-subject nested
+    runs-on: ${{ inputs.runner_label }}
+    timeout-minutes: 720
+    env:
+      DATA_DIR: ${{ inputs.data_dir }}
+      USE_NEXTCLOUD_DATA: ${{ inputs.use_nextcloud_data }}
+      DATA_CACHE_VERSION: ${{ inputs.data_cache_version }}
+      PARTICIPANTS: ${{ inputs.participants }}
+      WINDOW_CENTERS: ${{ inputs.window_centers }}
+      WINDOW_SIZE: ${{ inputs.window_size }}
+      BASELINE_WINDOW: ${{ inputs.baseline_window }}
+      FEATURE_MODES: ${{ inputs.feature_modes }}
+      NORMALIZATIONS: ${{ inputs.normalizations }}
+      CLASSIFIERS: ${{ inputs.classifiers }}
+      CLASSIFIER_PARAMS: ${{ inputs.classifier_params }}
+      COMPONENTS_PCA_VALUES: ${{ inputs.components_pca_values }}
+      MAIN_FILE_NAMES: >-
+        Part1Data.mat,Part2Data.mat,Part3Data.mat,Part4Data.mat,Part6Data.mat,
+        Part8Data.mat,Part9Data.mat,Part10Data.mat,Part13Data.mat,Part14Data.mat,
+        Part15Data.mat,Part16Data.mat,Part17Data.mat,Part18Data.mat,Part19Data.mat,
+        Part20Data.mat,Part21Data.mat,Part22Data.mat,Part23Data.mat,Part24Data.mat,
+        Part25Data.mat,Part26Data.mat,Part27Data.mat
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Prepare main MEG data
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
+        uses: ./.github/actions/prepare-meg-data
+        with:
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          file-names: ${{ env.MAIN_FILE_NAMES }}
+          require-cue-files: "false"
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Validate main data files
+        shell: bash
+        run: |
+          set -euo pipefail
+          main_count="$(find -L "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+          echo "Main files: ${main_count}"
+          test "${main_count}" -ge 23
+
+      - name: Run nested cross-subject benchmark
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs
+          python scripts/export_stimulus_cross_subject_nested.py \
+            --data-dir "${DATA_DIR}" \
+            --participants "${PARTICIPANTS}" \
+            --window-centers "${WINDOW_CENTERS}" \
+            --window-size "${WINDOW_SIZE}" \
+            --baseline-window "${BASELINE_WINDOW}" \
+            --feature-modes "${FEATURE_MODES}" \
+            --normalizations "${NORMALIZATIONS}" \
+            --classifiers "${CLASSIFIERS}" \
+            --classifier-params "${CLASSIFIER_PARAMS}" \
+            --components-pca-values "${COMPONENTS_PCA_VALUES}" \
+            --outer-output outputs/stimulus_cross_subject_nested_outer.csv \
+            --summary-output outputs/stimulus_cross_subject_nested_group_summary.csv \
+            --inner-validation-output outputs/stimulus_cross_subject_nested_inner_validation.csv \
+            --selected-output outputs/stimulus_cross_subject_nested_selected.csv \
+            --predictions-output outputs/stimulus_cross_subject_nested_predictions.csv \
+            --confusion-output outputs/stimulus_cross_subject_nested_confusion.csv \
+            --per-stimulus-output outputs/stimulus_cross_subject_nested_per_stimulus.csv
+
+      - name: Append workflow summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import csv
+          from pathlib import Path
+
+          summary = next(csv.DictReader(Path("outputs/stimulus_cross_subject_nested_group_summary.csv").open(newline="", encoding="utf-8")))
+          selected_rows = list(csv.DictReader(Path("outputs/stimulus_cross_subject_nested_selected.csv").open(newline="", encoding="utf-8")))
+          lines = [
+              "# Stimulus cross-subject nested",
+              "",
+              "Nested leave-one-subject-out image-identity decoding using only `Part*Data.mat`.",
+              "",
+              "| metric | value |",
+              "| --- | ---: |",
+              f"| outer folds | {summary['n_outer_folds']} |",
+              f"| candidates | {summary['n_candidates']} |",
+              f"| chance | {float(summary['chance_percent']):.2f}% |",
+              f"| mean balanced accuracy | {float(summary['balanced_percent_mean']):.2f}% |",
+              f"| balanced accuracy SEM | {float(summary['balanced_percent_sem']):.2f}% |",
+              f"| participants above chance | {summary['participants_above_chance']} |",
+              f"| one-sided sign-flip p | {float(summary['one_sided_signflip_p_value']):.4g} |",
+              "",
+              "## Selected candidates",
+              "",
+              "| participant | candidate | classifier | window center | inner balanced accuracy |",
+              "| ---: | ---: | --- | ---: | ---: |",
+          ]
+          for row in selected_rows:
+              lines.append(
+                  f"| {row['test_participant']} | {row['selected_candidate_index']} | {row['selected_classifier']} | "
+                  f"{float(row['selected_window_center_s']):.3f} | {100.0 * float(row['selected_inner_balanced_accuracy_mean']):.2f}% |"
+              )
+          Path(__import__("os").environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload nested cross-subject outputs
+        uses: actions/upload-artifact@v7
+        with:
+          name: stimulus-cross-subject-nested-outputs
+          path: outputs/stimulus_cross_subject_nested_*.csv

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,7 @@ pymegdec alpha-movement-results --movement-summary outputs/part2_alpha_movement_
 ```bash
 pymegdec stimulus decoding --participants 2 --output outputs/part2_stimulus_decoding.csv
 pymegdec stimulus cross-subject-smoke --participants 1-4,6,8,9,10,13-27 --outer-output outputs/stimulus_cross_subject_outer.csv
+pymegdec stimulus cross-subject-nested --participants 1-4,6,8,9,10,13-27 --window-centers 0.150,0.175,0.200 --classifiers multinomial-logistic,shrinkage-lda,multiclass-svm
 pymegdec stimulus predictions --participants 2 --output outputs/stimulus_predictions.csv
 pymegdec stimulus robustness --participants 2 --predictions-output outputs/stimulus_robustness_predictions.csv
 pymegdec stimulus temporal-generalization --participants 2 --output outputs/stimulus_temporal_generalization.csv
@@ -55,6 +56,7 @@ not need to change immediately:
 
 ```bash
 pymegdec stimulus-decoding
+pymegdec stimulus-cross-subject-nested
 pymegdec stimulus-cross-subject-smoke
 pymegdec stimulus-predictions
 pymegdec stimulus-robustness

--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -38,6 +38,30 @@ Useful follow-up classifiers for this cross-subject benchmark are
 training-set class-average pattern, which is a simple baseline for shared
 stimulus topographies across participants.
 
+## Nested cross-subject benchmark
+
+Use nested LOSO when choosing among windows, classifiers, or PCA settings. For
+each outer participant, PyMEGDec leaves that participant untouched, selects the
+best candidate by inner leave-one-subject-out validation on the remaining
+participants, then refits the selected candidate on all outer-training
+participants before scoring the held-out participant.
+
+```bash
+pymegdec stimulus cross-subject-nested \
+  --participants 1-4,6,8,9,10,13-27 \
+  --window-centers 0.150,0.175,0.200 \
+  --window-size 0.1 \
+  --feature-modes sensor_flat \
+  --normalizations subject_baseline_z \
+  --classifiers multinomial-logistic,shrinkage-lda,multiclass-svm \
+  --classifier-params default \
+  --components-pca-values 64
+```
+
+The nested outputs include untouched outer-fold scores, one row per inner
+validation fold and candidate, selected hyperparameters per outer fold, trial
+predictions, confusion counts, per-stimulus accuracy, and a group summary.
+
 ## Time-resolved decoding curve
 
 ```powershell

--- a/scripts/export_stimulus_cross_subject_nested.py
+++ b/scripts/export_stimulus_cross_subject_nested.py
@@ -1,0 +1,13 @@
+"""Backward-compatible wrapper for the nested cross-subject stimulus command."""
+
+import sys
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from pymegdec.stimulus_cli import stimulus_cross_subject_nested  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(stimulus_cross_subject_nested())

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -50,8 +50,12 @@ from pymegdec.stimulus_decoding import (
 from pymegdec.stimulus_cross_subject import (
     CrossSubjectStimulusConfig,
     evaluate_cross_subject_stimulus_smoke,
+    evaluate_nested_cross_subject_stimulus,
     export_cross_subject_stimulus_smoke,
+    export_nested_cross_subject_stimulus,
+    make_cross_subject_candidate_configs,
     summarize_cross_subject_stimulus_smoke,
+    summarize_nested_cross_subject_stimulus,
 )
 
 __version__ = "0.1.0"
@@ -77,6 +81,7 @@ __all__ = [
     "evaluate_participant_stimulus_onset_scan",
     "evaluate_participant_stimulus_temporal_generalization",
     "evaluate_cross_subject_stimulus_smoke",
+    "evaluate_nested_cross_subject_stimulus",
     "evaluate_model_transfer",
     "evaluate_time_resolved_stimulus_transfer",
     "export_alpha_movement",
@@ -86,10 +91,12 @@ __all__ = [
     "export_stimulus_temporal_generalization",
     "export_time_resolved_stimulus_decoding",
     "export_cross_subject_stimulus_smoke",
+    "export_nested_cross_subject_stimulus",
     "extract_phase",
     "extract_time_basis",
     "get_original_feature_importance",
     "join_alpha_reaction_times",
+    "make_cross_subject_candidate_configs",
     "resolve_data_folder",
     "summarize_stimulus_decoding",
     "summarize_stimulus_decoding_peaks",
@@ -98,5 +105,6 @@ __all__ = [
     "summarize_stimulus_prediction_diagnostics",
     "summarize_stimulus_temporal_generalization",
     "summarize_cross_subject_stimulus_smoke",
+    "summarize_nested_cross_subject_stimulus",
     "summarize_alpha_movement_effects",
 ]

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -31,6 +31,7 @@ def _dispatch_group(group: str, description: str, handlers: dict[str, CommandHan
 
 def _stimulus_handlers() -> dict[str, CommandHandler]:
     return {
+        "cross-subject-nested": stimulus_cli.stimulus_cross_subject_nested,
         "cross-subject-smoke": stimulus_cli.stimulus_cross_subject_smoke,
         "decoding": legacy_cli.stimulus_decoding,
         "predictions": stimulus_cli.stimulus_predictions,
@@ -61,6 +62,7 @@ def _top_level_handlers() -> dict[str, CommandHandler]:
         "make-synthetic-data": make_synthetic_data,
         # Backward-compatible top-level aliases. Prefer grouped forms in new docs.
         "stimulus-decoding": legacy_cli.stimulus_decoding,
+        "stimulus-cross-subject-nested": stimulus_cli.stimulus_cross_subject_nested,
         "stimulus-cross-subject-smoke": stimulus_cli.stimulus_cross_subject_smoke,
         "stimulus-predictions": stimulus_cli.stimulus_predictions,
         "stimulus-robustness": stimulus_cli.stimulus_robustness,
@@ -81,7 +83,7 @@ def _print_main_help() -> None:
     parser.print_help()
     print(
         "\nCommand groups:\n"
-        "  pymegdec stimulus <cross-subject-smoke|decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
+        "  pymegdec stimulus <cross-subject-nested|cross-subject-smoke|decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
         "  pymegdec alpha <metrics|movement|movement-results|reaction-time|rt>\n"
         "  pymegdec data <download>\n"
         "\nCore commands:\n"

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -6,6 +6,11 @@ import argparse
 from collections.abc import Sequence
 from dataclasses import replace
 
+from reptrace.decoding.robustness import (
+    RobustnessCondition,
+    run_participant_robustness_conditions,
+)
+
 from pymegdec.alpha_metrics import write_alpha_metrics_csv
 from pymegdec.cli import (
     normalize_argv,
@@ -18,6 +23,22 @@ from pymegdec.data_config import resolve_data_folder
 from pymegdec.reaction_time_analysis import (
     available_participants,
     parse_participant_spec,
+)
+from pymegdec.stimulus_cross_subject import (
+    DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW,
+    DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES,
+    DEFAULT_CROSS_SUBJECT_CLASSIFIER,
+    DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA,
+    DEFAULT_CROSS_SUBJECT_FEATURE_MODE,
+    DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS,
+    DEFAULT_CROSS_SUBJECT_NORMALIZATION,
+    DEFAULT_CROSS_SUBJECT_PARTICIPANTS,
+    DEFAULT_CROSS_SUBJECT_WINDOW_CENTER,
+    DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
+    CrossSubjectStimulusConfig,
+    export_cross_subject_stimulus_smoke,
+    export_nested_cross_subject_stimulus,
+    make_cross_subject_candidate_configs,
 )
 from pymegdec.stimulus_decoding import (
     DEFAULT_ONSET_MIN_CONSECUTIVE,
@@ -38,23 +59,6 @@ from pymegdec.stimulus_decoding import (
     summarize_stimulus_decoding,
     summarize_stimulus_prediction_diagnostics,
     window_centers_from_range,
-)
-from pymegdec.stimulus_cross_subject import (
-    DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW,
-    DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES,
-    DEFAULT_CROSS_SUBJECT_CLASSIFIER,
-    DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA,
-    DEFAULT_CROSS_SUBJECT_FEATURE_MODE,
-    DEFAULT_CROSS_SUBJECT_NORMALIZATION,
-    DEFAULT_CROSS_SUBJECT_PARTICIPANTS,
-    DEFAULT_CROSS_SUBJECT_WINDOW_CENTER,
-    DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
-    CrossSubjectStimulusConfig,
-    export_cross_subject_stimulus_smoke,
-)
-from reptrace.decoding.robustness import (
-    RobustnessCondition,
-    run_participant_robustness_conditions,
 )
 
 DEFAULT_PREDICTION_WINDOW_CENTERS = (-0.175, 0.175)
@@ -92,6 +96,43 @@ def _normalization_token(value: str) -> str:
 
 def _feature_mode_token(value: str) -> str:
     return value.strip().lower().replace("-", "_")
+
+
+def _parse_token_list(value: str) -> tuple[str, ...]:
+    values = tuple(token.strip() for token in value.split(",") if token.strip())
+    if not values:
+        raise argparse.ArgumentTypeError("At least one value is required.")
+    return values
+
+
+def _parse_feature_mode_list(value: str) -> tuple[str, ...]:
+    return tuple(_feature_mode_token(token) for token in _parse_token_list(value))
+
+
+def _parse_normalization_list(value: str) -> tuple[str, ...]:
+    return tuple(_normalization_token(token) for token in _parse_token_list(value))
+
+
+def _parse_int_or_inf_list(value: str) -> tuple[int | float, ...]:
+    values = tuple(parse_int_or_inf(token.strip()) for token in value.split(",") if token.strip())
+    if not values:
+        raise argparse.ArgumentTypeError("At least one value is required.")
+    return values
+
+
+def _parse_classifier_param_grid(value: str) -> tuple[object, ...]:
+    values = []
+    for token in value.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if token.lower() in {"default", "defaults"}:
+            values.append(float("nan"))
+        else:
+            values.append(parse_classifier_param(token))
+    if not values:
+        raise argparse.ArgumentTypeError("At least one classifier parameter value is required.")
+    return tuple(values)
 
 
 def _add_model_args(parser: argparse.ArgumentParser, *, include_transfer_direction: bool = True) -> None:
@@ -192,7 +233,9 @@ def _build_cross_subject_smoke_parser(prog: str | None = None) -> argparse.Argum
     parser.add_argument("--window-center", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_CENTER, help="Stimulus decoding window center in seconds.")
     parser.add_argument("--window-size", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE, help="Stimulus decoding window size in seconds.")
     parser.add_argument("--baseline-window", type=_parse_time_window, default=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW, help="Baseline window as start,stop in seconds.")
-    parser.add_argument("--feature-mode", type=_feature_mode_token, default=DEFAULT_CROSS_SUBJECT_FEATURE_MODE, choices=("sensor_mean", "sensor_flat"), help="Feature extraction mode.")
+    parser.add_argument(
+        "--feature-mode", type=_feature_mode_token, default=DEFAULT_CROSS_SUBJECT_FEATURE_MODE, choices=("sensor_mean", "sensor_flat"), help="Feature extraction mode."
+    )
     parser.add_argument(
         "--normalization",
         type=_normalization_token,
@@ -248,6 +291,109 @@ def stimulus_cross_subject_smoke(argv: Sequence[str] | None = None, prog: str | 
         progress=lambda message: print(message, flush=True),
     )
     print(f"Wrote {len(artifacts['outer'])} held-out participant rows to {args.outer_output}")
+    print(f"Wrote {len(artifacts['group_summary'])} group summary rows to {args.summary_output}")
+    print(f"Wrote {len(artifacts['predictions'])} trial prediction rows to {args.predictions_output}")
+    print(f"Wrote {len(artifacts['confusion'])} confusion rows to {args.confusion_output}")
+    print(f"Wrote {len(artifacts['per_stimulus'])} per-stimulus rows to {args.per_stimulus_output}")
+    return 0
+
+
+def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description="Run nested leave-one-subject-out stimulus decoding with inner LOSO model selection.",
+    )
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat files.")
+    parser.add_argument("--participants", default=DEFAULT_CROSS_SUBJECT_PARTICIPANTS, help="Participant ids such as 1-4,6,8.")
+    parser.add_argument(
+        "--window-centers",
+        type=parse_float_list,
+        default=DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS,
+        help="Comma-separated candidate window centers in seconds.",
+    )
+    parser.add_argument("--window-size", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE, help="Candidate window size in seconds.")
+    parser.add_argument("--baseline-window", type=_parse_time_window, default=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW, help="Baseline window as start,stop in seconds.")
+    parser.add_argument(
+        "--feature-modes",
+        type=_parse_feature_mode_list,
+        default=(DEFAULT_CROSS_SUBJECT_FEATURE_MODE,),
+        help="Comma-separated feature modes, e.g. sensor_mean,sensor_flat.",
+    )
+    parser.add_argument(
+        "--normalizations",
+        type=_parse_normalization_list,
+        default=(DEFAULT_CROSS_SUBJECT_NORMALIZATION,),
+        help="Comma-separated subject normalization modes.",
+    )
+    parser.add_argument(
+        "--classifiers",
+        type=_parse_token_list,
+        default=(DEFAULT_CROSS_SUBJECT_CLASSIFIER,),
+        help="Comma-separated classifier names.",
+    )
+    parser.add_argument(
+        "--classifier-params",
+        type=_parse_classifier_param_grid,
+        default=(float("nan"),),
+        help="Comma-separated classifier parameters. Use default to use each classifier default.",
+    )
+    parser.add_argument(
+        "--components-pca-values",
+        type=_parse_int_or_inf_list,
+        default=(DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA,),
+        help="Comma-separated PCA component counts, or inf.",
+    )
+    parser.add_argument("--chance-classes", type=int, default=DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES, help="Number of stimulus classes used for chance level.")
+    parser.add_argument("--random-state", type=int, default=0, help="Random state passed to classifiers.")
+    parser.add_argument("--signflip-permutations", type=int, default=10000, help="Monte Carlo sign-flip permutations for the group summary.")
+    parser.add_argument("--signflip-seed", type=int, default=0, help="Random seed for sign-flip permutations.")
+    parser.add_argument("--outer-output", default="outputs/stimulus_cross_subject_nested_outer.csv", help="Untouched outer participant score CSV.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_cross_subject_nested_group_summary.csv", help="Group summary CSV.")
+    parser.add_argument("--inner-validation-output", default="outputs/stimulus_cross_subject_nested_inner_validation.csv", help="Inner validation score CSV.")
+    parser.add_argument("--selected-output", default="outputs/stimulus_cross_subject_nested_selected.csv", help="Selected hyperparameter CSV.")
+    parser.add_argument("--predictions-output", default="outputs/stimulus_cross_subject_nested_predictions.csv", help="Trial prediction CSV.")
+    parser.add_argument("--confusion-output", default="outputs/stimulus_cross_subject_nested_confusion.csv", help="Confusion-count CSV.")
+    parser.add_argument("--per-stimulus-output", default="outputs/stimulus_cross_subject_nested_per_stimulus.csv", help="Per-stimulus recall CSV.")
+    return parser
+
+
+def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    parser = _build_cross_subject_nested_parser(prog=prog)
+    args = parser.parse_args(normalize_argv(argv))
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = parse_participant_spec(args.participants)
+    if not participants:
+        parser.error("At least one participant is required.")
+    candidate_configs = make_cross_subject_candidate_configs(
+        window_centers=args.window_centers,
+        window_size=args.window_size,
+        baseline_window=args.baseline_window,
+        feature_modes=args.feature_modes,
+        normalizations=args.normalizations,
+        classifiers=args.classifiers,
+        classifier_params=args.classifier_params,
+        components_pca_values=args.components_pca_values,
+        chance_classes=args.chance_classes,
+        random_state=args.random_state,
+        signflip_permutations=args.signflip_permutations,
+        signflip_seed=args.signflip_seed,
+    )
+    artifacts = export_nested_cross_subject_stimulus(
+        data_folder,
+        participants,
+        candidate_configs=candidate_configs,
+        outer_output_path=args.outer_output,
+        group_summary_output_path=args.summary_output,
+        inner_validation_output_path=args.inner_validation_output,
+        selected_output_path=args.selected_output,
+        predictions_output_path=args.predictions_output,
+        confusion_output_path=args.confusion_output,
+        per_stimulus_output_path=args.per_stimulus_output,
+        progress=lambda message: print(message, flush=True),
+    )
+    print(f"Wrote {len(artifacts['outer'])} untouched outer participant rows to {args.outer_output}")
+    print(f"Wrote {len(artifacts['inner_validation'])} inner validation rows to {args.inner_validation_output}")
+    print(f"Wrote {len(artifacts['selected'])} selected hyperparameter rows to {args.selected_output}")
     print(f"Wrote {len(artifacts['group_summary'])} group summary rows to {args.summary_output}")
     print(f"Wrote {len(artifacts['predictions'])} trial prediction rows to {args.predictions_output}")
     print(f"Wrote {len(artifacts['confusion'])} confusion rows to {args.confusion_output}")

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
+from itertools import product
 from pathlib import Path
 
 import numpy as np
 import scipy.io as sio
+from reptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
+from reptrace.decoding.windowed import predict_window_model as predict_reptrace_window_model
+from reptrace.metrics.confusion import confusion_counts, per_class_accuracy
+from sklearn.metrics import accuracy_score, balanced_accuracy_score
+
 from pymegdec.alpha_metrics import write_alpha_metrics_csv
 from pymegdec.alpha_signal import get_data_field
 from pymegdec.classifiers import (
@@ -16,10 +22,6 @@ from pymegdec.classifiers import (
     train_multiclass_classifier,
 )
 from pymegdec.data_config import resolve_data_folder
-from reptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
-from reptrace.decoding.windowed import predict_window_model as predict_reptrace_window_model
-from reptrace.metrics.confusion import confusion_counts, per_class_accuracy
-from sklearn.metrics import accuracy_score, balanced_accuracy_score
 
 DEFAULT_CROSS_SUBJECT_PARTICIPANTS = "1-4,6,8,9,10,13-27"
 DEFAULT_CROSS_SUBJECT_WINDOW_CENTER = 0.175
@@ -30,6 +32,8 @@ DEFAULT_CROSS_SUBJECT_FEATURE_MODE = "sensor_mean"
 DEFAULT_CROSS_SUBJECT_NORMALIZATION = "subject_baseline_z"
 DEFAULT_CROSS_SUBJECT_CLASSIFIER = "multiclass-svm"
 DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA = 64
+DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS = (0.150, 0.175, 0.200)
+DEFAULT_CROSS_SUBJECT_SELECTION_METRIC = "balanced_accuracy"
 FEATURE_MODES = ("sensor_mean", "sensor_flat")
 NORMALIZATION_MODES = ("none", "subject_z", "subject_baseline_z")
 
@@ -115,6 +119,95 @@ def evaluate_cross_subject_stimulus_smoke(data_folder, participants, *, config=N
     }
 
 
+def evaluate_nested_cross_subject_stimulus(data_folder, participants, *, candidate_configs, progress=None):
+    """Run nested LOSO model selection and evaluate each untouched outer participant once."""
+
+    candidate_configs = _normalized_candidate_configs(candidate_configs)
+    data_folder = resolve_data_folder(data_folder)
+    participants = tuple(int(participant) for participant in participants)
+    if len(participants) < 3:
+        raise ValueError("At least three participants are required for nested cross-subject decoding.")
+    if not candidate_configs:
+        raise ValueError("At least one candidate configuration is required.")
+
+    feature_cache = _load_feature_cache(data_folder, participants, candidate_configs, progress=progress)
+    inner_rows = []
+    outer_rows = []
+    selected_rows = []
+    prediction_rows = []
+    for test_participant in participants:
+        outer_row, outer_inner_rows, selected_row, participant_predictions = _evaluate_nested_outer_fold(
+            test_participant,
+            participants,
+            candidate_configs,
+            feature_cache,
+            progress=progress,
+        )
+        inner_rows.extend(outer_inner_rows)
+        outer_rows.append(outer_row)
+        selected_rows.append(selected_row)
+        prediction_rows.extend(participant_predictions)
+
+    group_summary_rows = summarize_nested_cross_subject_stimulus(
+        outer_rows,
+        signflip_permutations=candidate_configs[0].signflip_permutations,
+        signflip_seed=candidate_configs[0].signflip_seed,
+    )
+    confusion_rows, per_stimulus_rows = summarize_cross_subject_predictions(prediction_rows)
+    return {
+        "outer": outer_rows,
+        "inner_validation": inner_rows,
+        "selected": selected_rows,
+        "predictions": prediction_rows,
+        "group_summary": group_summary_rows,
+        "confusion": confusion_rows,
+        "per_stimulus": per_stimulus_rows,
+    }
+
+
+def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
+    *,
+    window_centers=DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS,
+    window_size=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
+    baseline_window=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW,
+    feature_modes=(DEFAULT_CROSS_SUBJECT_FEATURE_MODE,),
+    normalizations=(DEFAULT_CROSS_SUBJECT_NORMALIZATION,),
+    classifiers=(DEFAULT_CROSS_SUBJECT_CLASSIFIER,),
+    classifier_params=(float("nan"),),
+    components_pca_values=(DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA,),
+    chance_classes=DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES,
+    random_state=0,
+    signflip_permutations=10_000,
+    signflip_seed=0,
+):
+    """Build a candidate grid for nested cross-subject model selection."""
+
+    return tuple(
+        CrossSubjectStimulusConfig(
+            window_center=window_center,
+            window_size=window_size,
+            baseline_window=baseline_window,
+            feature_mode=feature_mode,
+            normalization=normalization,
+            classifier=classifier,
+            classifier_param=classifier_param,
+            components_pca=components_pca,
+            chance_classes=chance_classes,
+            random_state=random_state,
+            signflip_permutations=signflip_permutations,
+            signflip_seed=signflip_seed,
+        )
+        for window_center, feature_mode, normalization, classifier, classifier_param, components_pca in product(
+            window_centers,
+            feature_modes,
+            normalizations,
+            classifiers,
+            classifier_params,
+            components_pca_values,
+        )
+    )
+
+
 def load_participant_stimulus_features(data_folder, participant, *, config=None):
     """Load one participant's main ``Part*Data.mat`` file and extract fixed-window features."""
 
@@ -195,6 +288,51 @@ def summarize_cross_subject_stimulus_smoke(outer_rows, *, config=None):
     ]
 
 
+def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations=10_000, signflip_seed=0):
+    """Summarize nested cross-subject held-out scores without assuming one fixed configuration."""
+
+    if not outer_rows:
+        return []
+
+    balanced = np.asarray([float(row["balanced_accuracy"]) for row in outer_rows], dtype=float)
+    raw = np.asarray([float(row["accuracy"]) for row in outer_rows], dtype=float)
+    chance = float(outer_rows[0]["chance_accuracy"])
+    differences = balanced - chance
+    p_value = _one_sided_signflip_p_value(differences, n_permutations=signflip_permutations, seed=signflip_seed)
+    selected_counts = Counter(int(row["selected_candidate_index"]) for row in outer_rows)
+    classifier_counts = Counter(str(row["classifier"]) for row in outer_rows)
+    window_counts = Counter(float(row["window_center_s"]) for row in outer_rows)
+    return [
+        {
+            "n_outer_folds": len(outer_rows),
+            "n_test_participants": len(outer_rows),
+            "selection_mode": "nested_loso",
+            "selection_metric": DEFAULT_CROSS_SUBJECT_SELECTION_METRIC,
+            "n_candidates": int(max(int(row["n_candidates"]) for row in outer_rows)),
+            "selected_candidate_counts": _format_counter(selected_counts),
+            "selected_classifier_counts": _format_counter(classifier_counts),
+            "selected_window_center_counts": _format_counter(window_counts),
+            "chance_accuracy": chance,
+            "chance_percent": 100.0 * chance,
+            "accuracy_mean": float(np.mean(raw)),
+            "accuracy_median": float(np.median(raw)),
+            "accuracy_sem": _sem(raw),
+            "percent_mean": float(100.0 * np.mean(raw)),
+            "balanced_accuracy_mean": float(np.mean(balanced)),
+            "balanced_accuracy_median": float(np.median(balanced)),
+            "balanced_accuracy_sem": _sem(balanced),
+            "balanced_percent_mean": float(100.0 * np.mean(balanced)),
+            "balanced_percent_median": float(100.0 * np.median(balanced)),
+            "balanced_percent_sem": float(100.0 * _sem(balanced)),
+            "mean_above_chance": float(np.mean(differences)),
+            "percent_above_chance": float(100.0 * np.mean(differences)),
+            "participants_above_chance": int(np.sum(balanced > chance)),
+            "participants_at_or_below_chance": int(np.sum(balanced <= chance)),
+            "one_sided_signflip_p_value": p_value,
+        }
+    ]
+
+
 def summarize_cross_subject_predictions(prediction_rows):
     """Return confusion-count and per-stimulus recall summaries for cross-subject predictions."""
 
@@ -254,7 +392,193 @@ def export_cross_subject_stimulus_smoke(
     return artifacts
 
 
-def _evaluate_outer_fold(train_sets, test_set, *, config, classifier_param):
+def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
+    data_folder,
+    participants,
+    *,
+    candidate_configs,
+    outer_output_path,
+    group_summary_output_path=None,
+    inner_validation_output_path=None,
+    selected_output_path=None,
+    predictions_output_path=None,
+    confusion_output_path=None,
+    per_stimulus_output_path=None,
+    progress=None,
+):
+    """Run nested LOSO cross-subject decoding and write compact CSV artifacts."""
+
+    artifacts = evaluate_nested_cross_subject_stimulus(data_folder, participants, candidate_configs=candidate_configs, progress=progress)
+    write_alpha_metrics_csv(artifacts["outer"], outer_output_path)
+    if group_summary_output_path:
+        write_alpha_metrics_csv(artifacts["group_summary"], group_summary_output_path)
+    if inner_validation_output_path:
+        write_alpha_metrics_csv(artifacts["inner_validation"], inner_validation_output_path)
+    if selected_output_path:
+        write_alpha_metrics_csv(artifacts["selected"], selected_output_path)
+    if predictions_output_path:
+        write_alpha_metrics_csv(artifacts["predictions"], predictions_output_path)
+    if confusion_output_path:
+        write_alpha_metrics_csv(artifacts["confusion"], confusion_output_path)
+    if per_stimulus_output_path:
+        write_alpha_metrics_csv(artifacts["per_stimulus"], per_stimulus_output_path)
+    return artifacts
+
+
+def _load_feature_cache(data_folder, participants, candidate_configs, *, progress=None):
+    representative_configs: dict[tuple[float, float, float, float, str, str], CrossSubjectStimulusConfig] = {}
+    for candidate_config in candidate_configs:
+        representative_configs.setdefault(_feature_cache_key(candidate_config), candidate_config)
+
+    feature_cache = {}
+    for key, candidate_config in representative_configs.items():
+        if progress is not None:
+            progress(
+                "LOAD feature_set "
+                f"window_center={candidate_config.window_center} "
+                f"feature_mode={candidate_config.feature_mode} "
+                f"normalization={candidate_config.normalization}"
+            )
+        feature_cache[key] = {participant: load_participant_stimulus_features(data_folder, participant, config=candidate_config) for participant in participants}
+    return feature_cache
+
+
+def _evaluate_nested_outer_fold(test_participant, participants, candidate_configs, feature_cache, *, progress=None):
+    if progress is not None:
+        progress(f"START outer_test_participant={test_participant}")
+    outer_train_participants = tuple(participant for participant in participants if participant != test_participant)
+    outer_inner_rows = _evaluate_nested_inner_rows(test_participant, outer_train_participants, candidate_configs, feature_cache)
+    selected_row = _select_nested_candidate(outer_inner_rows)
+    selected_config = candidate_configs[int(selected_row["selected_candidate_index"]) - 1]
+    selected_feature_sets = feature_cache[_feature_cache_key(selected_config)]
+    train_sets = [selected_feature_sets[participant] for participant in outer_train_participants]
+    test_set = selected_feature_sets[test_participant]
+    outer_row, participant_predictions = _evaluate_outer_fold(
+        train_sets,
+        test_set,
+        config=selected_config,
+        classifier_param=_resolved_classifier_param(selected_config),
+        include_predictions=True,
+    )
+    _add_selected_candidate_fields(outer_row, selected_row)
+    for prediction_row in participant_predictions:
+        _add_selected_candidate_fields(prediction_row, selected_row)
+    if progress is not None:
+        progress(
+            "DONE outer_test_participant="
+            f"{test_participant} selected_candidate={selected_row['selected_candidate_index']} "
+            f"inner_mean={selected_row['selected_inner_balanced_accuracy_mean']:.4f} "
+            f"outer_balanced_accuracy={outer_row['balanced_accuracy']:.4f}"
+        )
+    return outer_row, outer_inner_rows, selected_row, participant_predictions
+
+
+def _evaluate_nested_inner_rows(test_participant, outer_train_participants, candidate_configs, feature_cache):
+    inner_rows = []
+    for candidate_index, candidate_config in enumerate(candidate_configs, start=1):
+        feature_sets = feature_cache[_feature_cache_key(candidate_config)]
+        for validation_participant in outer_train_participants:
+            train_sets = [feature_sets[participant] for participant in outer_train_participants if participant != validation_participant]
+            validation_set = feature_sets[validation_participant]
+            inner_row, _predictions = _evaluate_outer_fold(
+                train_sets,
+                validation_set,
+                config=candidate_config,
+                classifier_param=_resolved_classifier_param(candidate_config),
+                include_predictions=False,
+            )
+            inner_rows.append(_nested_inner_row(inner_row, test_participant, validation_participant, candidate_index))
+    return inner_rows
+
+
+def _feature_cache_key(config):
+    return (
+        float(config.window_center),
+        float(config.window_size),
+        float(config.baseline_window[0]),
+        float(config.baseline_window[1]),
+        str(config.feature_mode),
+        str(config.normalization),
+    )
+
+
+def _resolved_classifier_param(config):
+    classifier_param = config.classifier_param
+    if should_use_default_classifier_param(classifier_param):
+        classifier_param = get_default_classifier_param(config.classifier)
+    return classifier_param
+
+
+def _nested_inner_row(row, outer_test_participant, validation_participant, candidate_index):
+    inner_row = dict(row)
+    inner_row.update(
+        {
+            "selection_mode": "nested_loso",
+            "selection_metric": DEFAULT_CROSS_SUBJECT_SELECTION_METRIC,
+            "outer_test_participant": int(outer_test_participant),
+            "inner_fold": int(validation_participant),
+            "inner_validation_participant": int(validation_participant),
+            "inner_train_participants": row["train_participants"],
+            "n_inner_train_participants": row["n_train_participants"],
+            "candidate_index": int(candidate_index),
+        }
+    )
+    return inner_row
+
+
+def _select_nested_candidate(inner_rows):
+    if not inner_rows:
+        raise ValueError("At least one inner-validation row is required for nested selection.")
+
+    summaries = []
+    candidate_indices = sorted({int(row["candidate_index"]) for row in inner_rows})
+    for candidate_index in candidate_indices:
+        candidate_rows = [row for row in inner_rows if int(row["candidate_index"]) == candidate_index]
+        balanced = np.asarray([float(row["balanced_accuracy"]) for row in candidate_rows], dtype=float)
+        raw = np.asarray([float(row["accuracy"]) for row in candidate_rows], dtype=float)
+        example = candidate_rows[0]
+        summaries.append(
+            {
+                "selection_mode": "nested_loso",
+                "selection_metric": DEFAULT_CROSS_SUBJECT_SELECTION_METRIC,
+                "outer_fold": int(example["outer_test_participant"]),
+                "test_participant": int(example["outer_test_participant"]),
+                "selected_candidate_index": int(candidate_index),
+                "n_candidates": len(candidate_indices),
+                "n_inner_folds": len(candidate_rows),
+                "selected_inner_balanced_accuracy_mean": float(np.mean(balanced)),
+                "selected_inner_balanced_accuracy_median": float(np.median(balanced)),
+                "selected_inner_balanced_accuracy_sem": _sem(balanced),
+                "selected_inner_accuracy_mean": float(np.mean(raw)),
+                "selected_inner_accuracy_median": float(np.median(raw)),
+                "selected_inner_accuracy_sem": _sem(raw),
+                "selected_window_center_s": example["window_center_s"],
+                "selected_window_size_s": example["window_size_s"],
+                "selected_window_start_s": example["window_start_s"],
+                "selected_window_stop_s": example["window_stop_s"],
+                "selected_feature_mode": example["feature_mode"],
+                "selected_normalization": example["normalization"],
+                "selected_classifier": example["classifier"],
+                "selected_classifier_param": example["classifier_param"],
+                "selected_components_pca": example["components_pca"],
+            }
+        )
+    return max(
+        summaries,
+        key=lambda row: (
+            float(row["selected_inner_balanced_accuracy_mean"]),
+            float(row["selected_inner_balanced_accuracy_median"]),
+            -int(row["selected_candidate_index"]),
+        ),
+    )
+
+
+def _add_selected_candidate_fields(row, selected_row):
+    for key, value in selected_row.items():
+        row[key] = value
+
+
+def _evaluate_outer_fold(train_sets, test_set, *, config, classifier_param, include_predictions=True):
     train_features = np.vstack([_normalized_subject_features(feature_set, config) for feature_set in train_sets])
     train_labels_one_based = np.concatenate([feature_set.labels for feature_set in train_sets])
     test_features = _normalized_subject_features(test_set, config)
@@ -320,7 +644,9 @@ def _evaluate_outer_fold(train_sets, test_set, *, config, classifier_param):
         "n_window_samples": test_set.n_window_samples,
         "n_baseline_samples": test_set.n_baseline_samples,
     }
-    prediction_rows = _prediction_rows(test_set, test_labels, predictions, config=config, actual_components_pca=model_bundle.actual_components_pca)
+    prediction_rows = []
+    if include_predictions:
+        prediction_rows = _prediction_rows(test_set, test_labels, predictions, config=config, actual_components_pca=model_bundle.actual_components_pca)
     return outer_row, prediction_rows
 
 
@@ -496,6 +822,10 @@ def _sem(values):
     return float(np.std(values, ddof=1) / np.sqrt(values.size))
 
 
+def _format_counter(counter):
+    return ";".join(f"{key}:{counter[key]}" for key in sorted(counter))
+
+
 def _one_sided_signflip_p_value(differences, *, n_permutations, seed):
     differences = np.asarray(differences, dtype=float)
     differences = differences[np.isfinite(differences)]
@@ -529,6 +859,16 @@ def _normalized_config(config):
         signflip_permutations=config.signflip_permutations,
         signflip_seed=config.signflip_seed,
     )
+
+
+def _normalized_candidate_configs(candidate_configs):
+    normalized_configs = tuple(_normalized_config(config) for config in candidate_configs)
+    if not normalized_configs:
+        raise ValueError("At least one candidate configuration is required.")
+    chance_classes = {config.chance_classes for config in normalized_configs}
+    if len(chance_classes) != 1:
+        raise ValueError("All nested candidate configurations must use the same chance_classes value.")
+    return normalized_configs
 
 
 def _normalize_feature_mode(value):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -3,10 +3,13 @@ import unittest
 from unittest.mock import patch
 
 import numpy as np
+
 from pymegdec.stimulus_cross_subject import (
     CrossSubjectStimulusConfig,
     evaluate_cross_subject_stimulus_smoke,
+    evaluate_nested_cross_subject_stimulus,
     load_participant_stimulus_features,
+    make_cross_subject_candidate_configs,
     summarize_cross_subject_stimulus_smoke,
 )
 from tests.matlab_fixtures import cell_array
@@ -103,6 +106,51 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(artifacts["group_summary"][0]["participants_above_chance"], 3)
         self.assertEqual({row["true_stimulus"] for row in artifacts["predictions"]}, {1, 2})
         self.assertEqual({row["predicted_stimulus"] for row in artifacts["predictions"]}, {1, 2})
+
+    def test_nested_cross_subject_selects_from_inner_loso_only(self):
+        data_by_participant = {
+            1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),
+            2: _mat_data([1, 2, 1, 2], [-1.0, 1.0, -0.9, 0.9]),
+            3: _mat_data([1, 2, 1, 2], [-1.3, 1.3, -1.2, 1.2]),
+            4: _mat_data([1, 2, 1, 2], [-1.1, 1.1, -1.0, 1.0]),
+        }
+        candidate_configs = make_cross_subject_candidate_configs(
+            window_centers=(0.1, 0.2),
+            window_size=0.01,
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multiclass-svm",),
+            classifier_params=(0.5,),
+            components_pca_values=(float("inf"),),
+            chance_classes=2,
+            signflip_permutations=128,
+        )
+        candidate_configs = (
+            candidate_configs[0],
+            CrossSubjectStimulusConfig(
+                window_center=0.2,
+                window_size=0.1,
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                components_pca=float("inf"),
+                chance_classes=2,
+                signflip_permutations=128,
+            ),
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            artifacts = evaluate_nested_cross_subject_stimulus("unused", [1, 2, 3, 4], candidate_configs=candidate_configs)
+
+        self.assertEqual(len(artifacts["outer"]), 4)
+        self.assertEqual(len(artifacts["inner_validation"]), 24)
+        self.assertEqual(len(artifacts["selected"]), 4)
+        self.assertEqual(len(artifacts["predictions"]), 16)
+        self.assertEqual({row["selected_candidate_index"] for row in artifacts["selected"]}, {2})
+        self.assertEqual({row["selected_candidate_index"] for row in artifacts["outer"]}, {2})
+        self.assertEqual({row["balanced_accuracy"] for row in artifacts["outer"]}, {1.0})
+        self.assertEqual(artifacts["group_summary"][0]["selection_mode"], "nested_loso")
+        self.assertEqual(artifacts["group_summary"][0]["n_candidates"], 2)
 
     def test_summarize_cross_subject_stimulus_smoke_signflip(self):
         config = CrossSubjectStimulusConfig(chance_classes=2, signflip_permutations=128)


### PR DESCRIPTION
## Summary
- add nested leave-one-subject-out cross-subject stimulus decoding support
- select candidate windows/classifiers/PCA settings by inner LOSO on the outer-training participants only
- export untouched outer scores, inner-validation rows, selected hyperparameters, predictions, confusion counts, per-stimulus summaries, and a group summary
- add `pymegdec stimulus cross-subject-nested`, a compatibility script, docs, and a manual self-hosted workflow

## Validation
- `$env:MPLBACKEND='Agg'; python -m pytest -q`
- `python -m ruff check`
- `python -m mypy src`
- `python -m pylint src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py src\pymegdec\grouped_cli.py`
- `python -m black --check src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject.py scripts\export_stimulus_cross_subject_nested.py`
- `python -m isort --check-only src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject.py scripts\export_stimulus_cross_subject_nested.py`
- `python scripts\export_stimulus_cross_subject_nested.py --help`
- `$env:PYTHONPATH='src'; python -m pymegdec.grouped_cli stimulus cross-subject-nested --help`