### PR TITLE
Cache normalized cross-subject features

### DIFF
--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -63,6 +63,7 @@ class ParticipantFeatureSet:
     participant: int
     labels: np.ndarray
     features: np.ndarray
+    normalization: str
     baseline_features: np.ndarray | None
     baseline_feature_mean: np.ndarray | None
     baseline_feature_std: np.ndarray | None
@@ -228,12 +229,14 @@ def load_participant_stimulus_features(data_folder, participant, *, config=None)
     n_baseline_samples = 0
     if config.normalization == "subject_baseline_z":
         baseline_feature_mean, baseline_feature_std, n_baseline_samples = _baseline_feature_statistics(data, config, n_window_samples)
+    normalized_features = _normalize_features(features, config, baseline_feature_mean, baseline_feature_std)
     if labels.shape[0] != features.shape[0]:
         raise ValueError(f"Participant {participant} has {labels.shape[0]} labels but {features.shape[0]} feature rows.")
     return ParticipantFeatureSet(
         participant=int(participant),
         labels=labels,
-        features=features,
+        features=normalized_features,
+        normalization=config.normalization,
         baseline_features=baseline_features,
         baseline_feature_mean=baseline_feature_mean,
         baseline_feature_std=baseline_feature_std,
@@ -832,6 +835,8 @@ def _time_mask(time_vector, time_window):
 
 
 def _normalized_subject_features(feature_set, config):
+    if feature_set.normalization == config.normalization:
+        return feature_set.features
     if config.normalization == "none":
         return feature_set.features
     if config.normalization == "subject_z":
@@ -846,6 +851,25 @@ def _normalized_subject_features(feature_set, config):
     else:
         raise ValueError(f"Unsupported normalization: {config.normalization}")
     return (feature_set.features - mean) / std
+
+
+def _normalize_features(features, config, baseline_feature_mean, baseline_feature_std):
+    features = np.asarray(features, dtype=float)
+    if config.normalization == "none":
+        return features
+    if config.normalization == "subject_z":
+        mean = np.mean(features, axis=0, keepdims=True)
+        std = _nonzero_std(np.std(features, axis=0, keepdims=True))
+        features -= mean
+        features /= std
+        return features
+    if config.normalization == "subject_baseline_z":
+        if baseline_feature_mean is None or baseline_feature_std is None:
+            raise ValueError("subject_baseline_z requires baseline feature statistics.")
+        features -= baseline_feature_mean
+        features /= baseline_feature_std
+        return features
+    raise ValueError(f"Unsupported normalization: {config.normalization}")
 
 
 def _nonzero_std(std):


### PR DESCRIPTION
## Summary
- store participant feature matrices in the requested normalization when loading them
- avoid re-normalizing the same held-out and training participant matrices for every nested LOSO fit
- keep the nested split and exported result schema unchanged

## Tests
- python -m pytest tests\\test_stimulus_cross_subject.py -q
- python -m ruff check src\\pymegdec\\stimulus_cross_subject.py tests\\test_stimulus_cross_subject.py
- python -m mypy src
- python -m isort src\\pymegdec\\stimulus_cross_subject.py tests\\test_stimulus_cross_subject.py
- python -m black src\\pymegdec\\stimulus_cross_subject.py tests\\test_stimulus_cross_subject.py
- python -m black --check src\\pymegdec\\stimulus_cross_subject.py tests\\test_stimulus_cross_subject.py
- python -m isort --check-only src\\pymegdec\\stimulus_cross_subject.py tests\\test_stimulus_cross_subject.py
- $env:MPLBACKEND='Agg'; python -m pytest -q
- python -m pylint src\\pymegdec\\stimulus_cross_subject.py src\\pymegdec\\stimulus_cli.py src\\pymegdec\\grouped_cli.py
- python -m ruff check
- python -m mypy src