### PR TITLE
Add trial cap for nested cross-subject screening

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -74,6 +74,11 @@ on:
         required: true
         default: "64"
         type: string
+      max_trials_per_class_per_participant:
+        description: Optional trial cap per stimulus class and participant. Use an empty value for all trials.
+        required: false
+        default: "10"
+        type: string
 
 permissions:
   contents: read
@@ -96,6 +101,7 @@ jobs:
       CLASSIFIERS: ${{ inputs.classifiers }}
       CLASSIFIER_PARAMS: ${{ inputs.classifier_params }}
       COMPONENTS_PCA_VALUES: ${{ inputs.components_pca_values }}
+      MAX_TRIALS_PER_CLASS_PER_PARTICIPANT: ${{ inputs.max_trials_per_class_per_participant }}
       MAIN_FILE_NAMES: >-
         Part1Data.mat,Part2Data.mat,Part3Data.mat,Part4Data.mat,Part6Data.mat,
         Part8Data.mat,Part9Data.mat,Part10Data.mat,Part13Data.mat,Part14Data.mat,
@@ -144,24 +150,30 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p outputs
-          python scripts/export_stimulus_cross_subject_nested.py \
-            --data-dir "${DATA_DIR}" \
-            --participants "${PARTICIPANTS}" \
-            --window-centers "${WINDOW_CENTERS}" \
-            --window-size "${WINDOW_SIZE}" \
-            --baseline-window "${BASELINE_WINDOW}" \
-            --feature-modes "${FEATURE_MODES}" \
-            --normalizations "${NORMALIZATIONS}" \
-            --classifiers "${CLASSIFIERS}" \
-            --classifier-params "${CLASSIFIER_PARAMS}" \
-            --components-pca-values "${COMPONENTS_PCA_VALUES}" \
-            --outer-output outputs/stimulus_cross_subject_nested_outer.csv \
-            --summary-output outputs/stimulus_cross_subject_nested_group_summary.csv \
-            --inner-validation-output outputs/stimulus_cross_subject_nested_inner_validation.csv \
-            --selected-output outputs/stimulus_cross_subject_nested_selected.csv \
-            --predictions-output outputs/stimulus_cross_subject_nested_predictions.csv \
-            --confusion-output outputs/stimulus_cross_subject_nested_confusion.csv \
+          args=(
+            python scripts/export_stimulus_cross_subject_nested.py
+            --data-dir "${DATA_DIR}"
+            --participants "${PARTICIPANTS}"
+            --window-centers "${WINDOW_CENTERS}"
+            --window-size "${WINDOW_SIZE}"
+            --baseline-window "${BASELINE_WINDOW}"
+            --feature-modes "${FEATURE_MODES}"
+            --normalizations "${NORMALIZATIONS}"
+            --classifiers "${CLASSIFIERS}"
+            --classifier-params "${CLASSIFIER_PARAMS}"
+            --components-pca-values "${COMPONENTS_PCA_VALUES}"
+            --outer-output outputs/stimulus_cross_subject_nested_outer.csv
+            --summary-output outputs/stimulus_cross_subject_nested_group_summary.csv
+            --inner-validation-output outputs/stimulus_cross_subject_nested_inner_validation.csv
+            --selected-output outputs/stimulus_cross_subject_nested_selected.csv
+            --predictions-output outputs/stimulus_cross_subject_nested_predictions.csv
+            --confusion-output outputs/stimulus_cross_subject_nested_confusion.csv
             --per-stimulus-output outputs/stimulus_cross_subject_nested_per_stimulus.csv
+          )
+          if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" ]]; then
+            args+=(--max-trials-per-class-per-participant "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}")
+          fi
+          "${args[@]}"
 
       - name: Append workflow summary
         shell: bash
@@ -182,6 +194,7 @@ jobs:
               "| --- | ---: |",
               f"| outer folds | {summary['n_outer_folds']} |",
               f"| candidates | {summary['n_candidates']} |",
+              f"| trial cap counts | {summary.get('max_trials_per_class_per_participant_counts', '')} |",
               f"| chance | {float(summary['chance_percent']):.2f}% |",
               f"| mean balanced accuracy | {float(summary['balanced_percent_mean']):.2f}% |",
               f"| balanced accuracy SEM | {float(summary['balanced_percent_sem']):.2f}% |",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,7 +25,7 @@ pymegdec alpha-movement-results --movement-summary outputs/part2_alpha_movement_
 ```bash
 pymegdec stimulus decoding --participants 2 --output outputs/part2_stimulus_decoding.csv
 pymegdec stimulus cross-subject-smoke --participants 1-4,6,8,9,10,13-27 --outer-output outputs/stimulus_cross_subject_outer.csv
-pymegdec stimulus cross-subject-nested --participants 1-4,6,8,9,10,13-27 --window-centers 0.150,0.175,0.200 --classifiers multinomial-logistic,shrinkage-lda,multiclass-svm
+pymegdec stimulus cross-subject-nested --participants 1-4,6,8,9,10,13-27 --window-centers 0.150,0.175,0.200 --classifiers multinomial-logistic,shrinkage-lda,multiclass-svm --max-trials-per-class-per-participant 10
 pymegdec stimulus predictions --participants 2 --output outputs/stimulus_predictions.csv
 pymegdec stimulus robustness --participants 2 --predictions-output outputs/stimulus_robustness_predictions.csv
 pymegdec stimulus temporal-generalization --participants 2 --output outputs/stimulus_temporal_generalization.csv

--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -55,8 +55,14 @@ pymegdec stimulus cross-subject-nested \
   --normalizations subject_baseline_z \
   --classifiers multinomial-logistic,shrinkage-lda,multiclass-svm \
   --classifier-params default \
-  --components-pca-values 64
+  --components-pca-values 64 \
+  --max-trials-per-class-per-participant 10
 ```
+
+The trial cap is a deterministic screening option: it keeps the first `N`
+trials of each stimulus class for each participant, preserving nested LOSO
+while making candidate selection fast enough to iterate. Omit
+`--max-trials-per-class-per-participant` for the final all-trial benchmark.
 
 The nested outputs include untouched outer-fold scores, one row per inner
 validation fold and candidate, selected hyperparameters per outer fold, trial

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -246,6 +246,12 @@ def _build_cross_subject_smoke_parser(prog: str | None = None) -> argparse.Argum
     parser.add_argument("--classifier", default=DEFAULT_CROSS_SUBJECT_CLASSIFIER, help="Classifier name.")
     parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
     parser.add_argument("--components-pca", type=parse_int_or_inf, default=DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA, help="Number of PCA components, or inf.")
+    parser.add_argument(
+        "--max-trials-per-class-per-participant",
+        type=int,
+        default=None,
+        help="Optional deterministic cap on trials per stimulus class and participant for quick screening.",
+    )
     parser.add_argument("--chance-classes", type=int, default=DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES, help="Number of stimulus classes used for chance level.")
     parser.add_argument("--random-state", type=int, default=0, help="Random state passed to the classifier.")
     parser.add_argument("--signflip-permutations", type=int, default=10000, help="Monte Carlo sign-flip permutations for the group summary.")
@@ -274,6 +280,7 @@ def stimulus_cross_subject_smoke(argv: Sequence[str] | None = None, prog: str | 
         classifier=args.classifier,
         classifier_param=parse_classifier_param(args.classifier_param),
         components_pca=args.components_pca,
+        max_trials_per_class_per_participant=args.max_trials_per_class_per_participant,
         chance_classes=args.chance_classes,
         random_state=args.random_state,
         signflip_permutations=args.signflip_permutations,
@@ -343,6 +350,12 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
         default=(DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA,),
         help="Comma-separated PCA component counts, or inf.",
     )
+    parser.add_argument(
+        "--max-trials-per-class-per-participant",
+        type=int,
+        default=None,
+        help="Optional deterministic cap on trials per stimulus class and participant for quick nested screening.",
+    )
     parser.add_argument("--chance-classes", type=int, default=DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES, help="Number of stimulus classes used for chance level.")
     parser.add_argument("--random-state", type=int, default=0, help="Random state passed to classifiers.")
     parser.add_argument("--signflip-permutations", type=int, default=10000, help="Monte Carlo sign-flip permutations for the group summary.")
@@ -373,6 +386,7 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         classifiers=args.classifiers,
         classifier_params=args.classifier_params,
         components_pca_values=args.components_pca_values,
+        max_trials_per_class_per_participant=args.max_trials_per_class_per_participant,
         chance_classes=args.chance_classes,
         random_state=args.random_state,
         signflip_permutations=args.signflip_permutations,

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -39,7 +39,7 @@ NORMALIZATION_MODES = ("none", "subject_z", "subject_baseline_z")
 
 
 @dataclass(frozen=True)
-class CrossSubjectStimulusConfig:
+class CrossSubjectStimulusConfig:  # pylint: disable=too-many-instance-attributes
     """Parameters for the fixed-pipeline cross-subject stimulus smoke test."""
 
     window_center: float = DEFAULT_CROSS_SUBJECT_WINDOW_CENTER
@@ -50,6 +50,7 @@ class CrossSubjectStimulusConfig:
     classifier: str = DEFAULT_CROSS_SUBJECT_CLASSIFIER
     classifier_param: object = float("nan")
     components_pca: int | float = DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA
+    max_trials_per_class_per_participant: int | None = None
     chance_classes: int = DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES
     random_state: int | None = 0
     signflip_permutations: int = 10_000
@@ -70,6 +71,7 @@ class ParticipantFeatureSet:
     n_channels: int
     n_window_samples: int
     n_baseline_samples: int
+    max_trials_per_class_per_participant: int | None
 
 
 def evaluate_cross_subject_stimulus_smoke(data_folder, participants, *, config=None, progress=None):
@@ -178,6 +180,7 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
     classifiers=(DEFAULT_CROSS_SUBJECT_CLASSIFIER,),
     classifier_params=(float("nan"),),
     components_pca_values=(DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA,),
+    max_trials_per_class_per_participant=None,
     chance_classes=DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES,
     random_state=0,
     signflip_permutations=10_000,
@@ -195,6 +198,7 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
             classifier=classifier,
             classifier_param=classifier_param,
             components_pca=components_pca,
+            max_trials_per_class_per_participant=max_trials_per_class_per_participant,
             chance_classes=chance_classes,
             random_state=random_state,
             signflip_permutations=signflip_permutations,
@@ -217,18 +221,21 @@ def load_participant_stimulus_features(data_folder, participant, *, config=None)
     config = _normalized_config(config or CrossSubjectStimulusConfig())
     data_path = Path(resolve_data_folder(data_folder)) / f"Part{int(participant)}Data.mat"
     data = sio.loadmat(data_path)["data"][0]
-    labels = _trialinfo_labels(data)
+    all_labels = _trialinfo_labels(data)
+    trial_indices = _selected_trial_indices(all_labels, config.max_trials_per_class_per_participant)
+    labels = all_labels[trial_indices]
     features, n_window_samples = _extract_window_features(
         data,
         _centered_window(config.window_center, config.window_size),
         feature_mode=config.feature_mode,
+        trial_indices=trial_indices,
     )
     baseline_features = None
     baseline_feature_mean = None
     baseline_feature_std = None
     n_baseline_samples = 0
     if config.normalization == "subject_baseline_z":
-        baseline_feature_mean, baseline_feature_std, n_baseline_samples = _baseline_feature_statistics(data, config, n_window_samples)
+        baseline_feature_mean, baseline_feature_std, n_baseline_samples = _baseline_feature_statistics(data, config, n_window_samples, trial_indices)
     normalized_features = _normalize_features(features, config, baseline_feature_mean, baseline_feature_std)
     if labels.shape[0] != features.shape[0]:
         raise ValueError(f"Participant {participant} has {labels.shape[0]} labels but {features.shape[0]} feature rows.")
@@ -243,6 +250,7 @@ def load_participant_stimulus_features(data_folder, participant, *, config=None)
         n_channels=int(_trial_signal(data, 0).shape[0]),
         n_window_samples=int(n_window_samples),
         n_baseline_samples=int(n_baseline_samples),
+        max_trials_per_class_per_participant=config.max_trials_per_class_per_participant,
     )
 
 
@@ -272,6 +280,7 @@ def summarize_cross_subject_stimulus_smoke(outer_rows, *, config=None):
             "normalization": config.normalization,
             "classifier": config.classifier,
             "components_pca": config.components_pca,
+            "max_trials_per_class_per_participant": config.max_trials_per_class_per_participant,
             "chance_accuracy": chance,
             "chance_percent": 100.0 * chance,
             "accuracy_mean": float(np.mean(raw)),
@@ -307,6 +316,7 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
     selected_counts = Counter(int(row["selected_candidate_index"]) for row in outer_rows)
     classifier_counts = Counter(str(row["classifier"]) for row in outer_rows)
     window_counts = Counter(float(row["window_center_s"]) for row in outer_rows)
+    trial_cap_counts = Counter(str(row["max_trials_per_class_per_participant"]) for row in outer_rows)
     return [
         {
             "n_outer_folds": len(outer_rows),
@@ -317,6 +327,7 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
             "selected_candidate_counts": _format_counter(selected_counts),
             "selected_classifier_counts": _format_counter(classifier_counts),
             "selected_window_center_counts": _format_counter(window_counts),
+            "max_trials_per_class_per_participant_counts": _format_counter(trial_cap_counts),
             "chance_accuracy": chance,
             "chance_percent": 100.0 * chance,
             "accuracy_mean": float(np.mean(raw)),
@@ -353,6 +364,7 @@ def summarize_cross_subject_predictions(prediction_rows):
         "normalization",
         "classifier",
         "components_pca",
+        "max_trials_per_class_per_participant",
     )
     confusion = confusion_counts(
         frame,
@@ -524,6 +536,7 @@ def _feature_cache_key(config):
         float(config.baseline_window[1]),
         str(config.feature_mode),
         str(config.normalization),
+        config.max_trials_per_class_per_participant,
     )
 
 
@@ -586,6 +599,7 @@ def _select_nested_candidate(inner_rows):
                 "selected_classifier": example["classifier"],
                 "selected_classifier_param": example["classifier_param"],
                 "selected_components_pca": example["components_pca"],
+                "selected_max_trials_per_class_per_participant": example["max_trials_per_class_per_participant"],
             }
         )
     return max(
@@ -683,6 +697,7 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
         "classifier": config.classifier,
         "classifier_param": fitted_model["classifier_param"],
         "components_pca": config.components_pca,
+        "max_trials_per_class_per_participant": config.max_trials_per_class_per_participant,
         "actual_components_pca": model_bundle.actual_components_pca,
         "pca_explained_variance_percent": model_bundle.explained_variance_percent,
         "n_channels": test_set.n_channels,
@@ -712,6 +727,7 @@ def _prediction_rows(test_set, test_labels, predictions, *, config, actual_compo
                 "normalization": config.normalization,
                 "classifier": config.classifier,
                 "components_pca": config.components_pca,
+                "max_trials_per_class_per_participant": config.max_trials_per_class_per_participant,
                 "actual_components_pca": actual_components_pca,
                 "trial": int(trial_idx),
                 "test_trial_index": int(trial_idx),
@@ -726,12 +742,12 @@ def _prediction_rows(test_set, test_labels, predictions, *, config, actual_compo
     return rows
 
 
-def _extract_window_features(data, time_window, *, feature_mode):
+def _extract_window_features(data, time_window, *, feature_mode, trial_indices=None):
     feature_mode = _normalize_feature_mode(feature_mode)
     time_vector = _time_vector(data, 0)
     mask = _time_mask(time_vector, time_window)
     features = []
-    for trial_idx in range(_count_trials(data)):
+    for trial_idx in _iter_trial_indices(data, trial_indices):
         signal = _trial_signal(data, trial_idx)
         window_signal = signal[:, mask]
         if feature_mode == "sensor_mean":
@@ -744,15 +760,15 @@ def _extract_window_features(data, time_window, *, feature_mode):
     return np.vstack(features), int(np.sum(mask))
 
 
-def _baseline_feature_statistics(data, config, n_window_samples):
+def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
     if config.feature_mode == "sensor_mean":
-        baseline_features, n_baseline_samples = _extract_window_features(data, config.baseline_window, feature_mode="sensor_mean")
+        baseline_features, n_baseline_samples = _extract_window_features(data, config.baseline_window, feature_mode="sensor_mean", trial_indices=trial_indices)
         mean = np.mean(baseline_features, axis=0, keepdims=True)
         std = np.std(baseline_features, axis=0, keepdims=True)
         return mean, _nonzero_std(std), n_baseline_samples
 
     if config.feature_mode == "sensor_flat":
-        channel_mean, channel_std, n_baseline_samples = _baseline_channel_statistics(data, config.baseline_window)
+        channel_mean, channel_std, n_baseline_samples = _baseline_channel_statistics(data, config.baseline_window, trial_indices)
         mean = np.tile(channel_mean, int(n_window_samples))[None, :]
         std = np.tile(channel_std, int(n_window_samples))[None, :]
         return mean, _nonzero_std(std), n_baseline_samples
@@ -760,14 +776,14 @@ def _baseline_feature_statistics(data, config, n_window_samples):
     raise ValueError(f"Unsupported feature_mode: {config.feature_mode}")
 
 
-def _baseline_channel_statistics(data, baseline_window):
+def _baseline_channel_statistics(data, baseline_window, trial_indices):
     time_vector = _time_vector(data, 0)
     mask = _time_mask(time_vector, baseline_window)
     n_channels = int(_trial_signal(data, 0).shape[0])
     sum_values = np.zeros(n_channels, dtype=float)
     sum_squares = np.zeros(n_channels, dtype=float)
     n_values = 0
-    for trial_idx in range(_count_trials(data)):
+    for trial_idx in _iter_trial_indices(data, trial_indices):
         baseline_signal = _trial_signal(data, trial_idx)[:, mask]
         sum_values += np.sum(baseline_signal, axis=1)
         sum_squares += np.sum(np.square(baseline_signal), axis=1)
@@ -775,6 +791,29 @@ def _baseline_channel_statistics(data, baseline_window):
     mean = sum_values / n_values
     variance = np.maximum(sum_squares / n_values - np.square(mean), 0.0)
     return mean, np.sqrt(variance), int(np.sum(mask))
+
+
+def _selected_trial_indices(labels, max_trials_per_class):
+    labels = np.asarray(labels).ravel()
+    if max_trials_per_class is None:
+        return np.arange(labels.shape[0], dtype=int)
+    max_trials_per_class = int(max_trials_per_class)
+    if max_trials_per_class <= 0:
+        raise ValueError("max_trials_per_class_per_participant must be positive.")
+
+    selected = []
+    counts: Counter[int] = Counter()
+    for index, label in enumerate(labels):
+        if counts[int(label)] < max_trials_per_class:
+            selected.append(index)
+            counts[int(label)] += 1
+    return np.asarray(selected, dtype=int)
+
+
+def _iter_trial_indices(data, trial_indices):
+    if trial_indices is None:
+        return range(_count_trials(data))
+    return (int(index) for index in np.asarray(trial_indices, dtype=int).ravel())
 
 
 def _trialinfo_labels(data):
@@ -920,6 +959,7 @@ def _normalized_config(config):
         classifier=config.classifier,
         classifier_param=config.classifier_param,
         components_pca=config.components_pca,
+        max_trials_per_class_per_participant=_normalize_trial_cap(config.max_trials_per_class_per_participant),
         chance_classes=config.chance_classes,
         random_state=config.random_state,
         signflip_permutations=config.signflip_permutations,
@@ -935,6 +975,15 @@ def _normalized_candidate_configs(candidate_configs):
     if len(chance_classes) != 1:
         raise ValueError("All nested candidate configurations must use the same chance_classes value.")
     return normalized_configs
+
+
+def _normalize_trial_cap(value):
+    if value is None:
+        return None
+    value = int(value)
+    if value <= 0:
+        raise ValueError("max_trials_per_class_per_participant must be positive.")
+    return value
 
 
 def _normalize_feature_mode(value):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -80,6 +80,24 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertTrue(np.allclose(feature_set.baseline_feature_mean[0, :2], feature_set.baseline_feature_mean[0, 2:]))
         self.assertTrue(np.allclose(feature_set.baseline_feature_std[0, :2], feature_set.baseline_feature_std[0, 2:]))
 
+    def test_load_participant_stimulus_features_can_cap_trials_per_class(self):
+        data_by_participant = {1: _mat_data([1, 2, 1, 2, 1, 2], [-1.0, 1.0, -0.9, 0.9, -0.8, 0.8])}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.1,
+            normalization="none",
+            components_pca=float("inf"),
+            max_trials_per_class_per_participant=2,
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.labels.tolist(), [1, 2, 1, 2])
+        self.assertEqual(feature_set.features.shape[0], 4)
+        self.assertEqual(feature_set.max_trials_per_class_per_participant, 2)
+
     def test_evaluate_cross_subject_stimulus_smoke(self):
         data_by_participant = {
             1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),


### PR DESCRIPTION
## Summary
- add an optional deterministic per-class trial cap to the cross-subject smoke and nested benchmark config
- carry the cap into output CSVs, summaries, selected candidate rows, and grouping columns
- default the manual nested workflow to a capped screening run (`10` trials per class/participant), while allowing an empty value for the final all-trial run
- document the capped run as screening and the uncapped run as the final benchmark

## Rationale
The uncapped nested `sensor_flat` logistic run remained in the benchmark step for many hours. This change keeps the nested LOSO design intact but gives us a practical first pass before scheduling the full all-trial benchmark.

## Tests
- python -m pytest tests\\test_stimulus_cross_subject.py -q
- $env:MPLBACKEND='Agg'; python -m pytest -q
- python -m ruff check
- python -m mypy src
- python -m pylint src\\pymegdec\\stimulus_cross_subject.py src\\pymegdec\\stimulus_cli.py src\\pymegdec\\grouped_cli.py