### PR TITLE
Harden main MEG data cache preparation

### DIFF
--- a/.github/actions/prepare-meg-data/action.yml
+++ b/.github/actions/prepare-meg-data/action.yml
@@ -37,6 +37,14 @@ inputs:
     description: Whether prepared data must include Part*CueData.mat files.
     required: false
     default: "true"
+  expected-main-files:
+    description: Minimum number of Part*Data.mat files required before treating data as complete.
+    required: false
+    default: "1"
+  expected-cue-files:
+    description: Minimum number of Part*CueData.mat files required when require-cue-files=true.
+    required: false
+    default: "1"
 
 outputs:
   data-dir:
@@ -73,12 +81,14 @@ runs:
         mkdir -p "$(dirname "${data_dir}")" "${cache_data_dir}"
         main_count="$(find "${cache_data_dir}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
         cue_count="$(find "${cache_data_dir}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
-        if [ "${main_count}" -gt 0 ] && { [ "${{ inputs.require-cue-files }}" != "true" ] || [ "${cue_count}" -gt 0 ]; }; then
+        expected_main_files="${{ inputs.expected-main-files }}"
+        expected_cue_files="${{ inputs.expected-cue-files }}"
+        if [ "${main_count}" -ge "${expected_main_files}" ] && { [ "${{ inputs.require-cue-files }}" != "true" ] || [ "${cue_count}" -ge "${expected_cue_files}" ]; }; then
           echo "local-cache-hit=true" >> "$GITHUB_OUTPUT"
           echo "MEG data cache hit at ${cache_data_dir}: ${main_count} main files, ${cue_count} cue files"
         else
           echo "local-cache-hit=false" >> "$GITHUB_OUTPUT"
-          echo "MEG data cache miss at ${cache_data_dir}"
+          echo "MEG data cache miss at ${cache_data_dir}: ${main_count}/${expected_main_files} main files, ${cue_count}/${expected_cue_files} cue files"
         fi
         echo "data-dir=${data_dir}" >> "$GITHUB_OUTPUT"
         echo "cache-data-dir=${cache_data_dir}" >> "$GITHUB_OUTPUT"
@@ -136,8 +146,10 @@ runs:
         fi
         main_count="$(find -L "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
         cue_count="$(find -L "${DATA_DIR}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
-        if [ "${main_count}" -eq 0 ] || { [ "${{ inputs.require-cue-files }}" = "true" ] && [ "${cue_count}" -eq 0 ]; }; then
-          echo "Prepared MEG data is incomplete at ${DATA_DIR}: ${main_count} main files, ${cue_count} cue files" >&2
+        expected_main_files="${{ inputs.expected-main-files }}"
+        expected_cue_files="${{ inputs.expected-cue-files }}"
+        if [ "${main_count}" -lt "${expected_main_files}" ] || { [ "${{ inputs.require-cue-files }}" = "true" ] && [ "${cue_count}" -lt "${expected_cue_files}" ]; }; then
+          echo "Prepared MEG data is incomplete at ${DATA_DIR}: ${main_count}/${expected_main_files} main files, ${cue_count}/${expected_cue_files} cue files" >&2
           exit 1
         fi
         echo "Prepared MEG data at ${DATA_DIR}: ${main_count} main files, ${cue_count} cue files"

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -115,12 +115,15 @@ jobs:
 
       - name: Prepare main MEG data
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
+        timeout-minutes: 90
         uses: ./.github/actions/prepare-meg-data
         with:
           data-dir: ${{ env.DATA_DIR }}
           cache-version: ${{ env.DATA_CACHE_VERSION }}
+          cache-key: meg-data-main-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
           file-names: ${{ env.MAIN_FILE_NAMES }}
           require-cue-files: "false"
+          expected-main-files: "23"
           webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
           webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
           webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}

--- a/.github/workflows/stimulus-cross-subject-smoke.yml
+++ b/.github/workflows/stimulus-cross-subject-smoke.yml
@@ -113,12 +113,15 @@ jobs:
 
       - name: Prepare main MEG data
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
+        timeout-minutes: 90
         uses: ./.github/actions/prepare-meg-data
         with:
           data-dir: ${{ env.DATA_DIR }}
           cache-version: ${{ env.DATA_CACHE_VERSION }}
+          cache-key: meg-data-main-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
           file-names: ${{ env.MAIN_FILE_NAMES }}
           require-cue-files: "false"
+          expected-main-files: "23"
           webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
           webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
           webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}


### PR DESCRIPTION
## Summary
- require a configurable minimum number of main/cue files before accepting a prepared MEG cache
- use a main-only cache key for cross-subject smoke/nested workflows instead of the broad `meg-data-all` key
- add a 90-minute timeout to the main-data preparation step in those workflows

## Rationale
The capped nested screening run spent hours in `Prepare main MEG data` before reaching the benchmark. These changes make main-only data staging smaller and less ambiguous, and prevent silent multi-hour stalls.

## Tests
- python -m ruff check
- python -m mypy src
- $env:MPLBACKEND='Agg'; python -m pytest -q