### PR TITLE
Make nested cross-subject outputs resumable

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -172,6 +172,7 @@ jobs:
             --predictions-output outputs/stimulus_cross_subject_nested_predictions.csv
             --confusion-output outputs/stimulus_cross_subject_nested_confusion.csv
             --per-stimulus-output outputs/stimulus_cross_subject_nested_per_stimulus.csv
+            --write-incremental
           )
           if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" ]]; then
             args+=(--max-trials-per-class-per-participant "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}")
@@ -179,6 +180,7 @@ jobs:
           "${args[@]}"
 
       - name: Append workflow summary
+        if: ${{ always() }}
         shell: bash
         run: |
           set -euo pipefail
@@ -186,8 +188,17 @@ jobs:
           import csv
           from pathlib import Path
 
-          summary = next(csv.DictReader(Path("outputs/stimulus_cross_subject_nested_group_summary.csv").open(newline="", encoding="utf-8")))
-          selected_rows = list(csv.DictReader(Path("outputs/stimulus_cross_subject_nested_selected.csv").open(newline="", encoding="utf-8")))
+          summary_path = Path("outputs/stimulus_cross_subject_nested_group_summary.csv")
+          selected_path = Path("outputs/stimulus_cross_subject_nested_selected.csv")
+          if not summary_path.exists() or not selected_path.exists():
+              Path(__import__("os").environ["GITHUB_STEP_SUMMARY"]).write_text(
+                  "# Stimulus cross-subject nested\n\nNo nested benchmark CSV outputs were produced.\n",
+                  encoding="utf-8",
+              )
+              raise SystemExit(0)
+
+          summary = next(csv.DictReader(summary_path.open(newline="", encoding="utf-8")))
+          selected_rows = list(csv.DictReader(selected_path.open(newline="", encoding="utf-8")))
           lines = [
               "# Stimulus cross-subject nested",
               "",
@@ -218,7 +229,9 @@ jobs:
           PY
 
       - name: Upload nested cross-subject outputs
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: stimulus-cross-subject-nested-outputs
           path: outputs/stimulus_cross_subject_nested_*.csv
+          if-no-files-found: warn

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -367,6 +367,8 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
     parser.add_argument("--predictions-output", default="outputs/stimulus_cross_subject_nested_predictions.csv", help="Trial prediction CSV.")
     parser.add_argument("--confusion-output", default="outputs/stimulus_cross_subject_nested_confusion.csv", help="Confusion-count CSV.")
     parser.add_argument("--per-stimulus-output", default="outputs/stimulus_cross_subject_nested_per_stimulus.csv", help="Per-stimulus recall CSV.")
+    parser.add_argument("--resume", action="store_true", help="Skip outer participants already present in the existing nested output CSVs.")
+    parser.add_argument("--write-incremental", action="store_true", help="Rewrite nested output CSVs after each completed outer participant.")
     return parser
 
 
@@ -403,6 +405,8 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         predictions_output_path=args.predictions_output,
         confusion_output_path=args.confusion_output,
         per_stimulus_output_path=args.per_stimulus_output,
+        resume=args.resume,
+        write_incremental=args.write_incremental,
         progress=lambda message: print(message, flush=True),
     )
     print(f"Wrote {len(artifacts['outer'])} untouched outer participant rows to {args.outer_output}")

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 from collections import Counter
 from dataclasses import dataclass
 from itertools import product
@@ -122,7 +123,7 @@ def evaluate_cross_subject_stimulus_smoke(data_folder, participants, *, config=N
     }
 
 
-def evaluate_nested_cross_subject_stimulus(data_folder, participants, *, candidate_configs, progress=None):
+def evaluate_nested_cross_subject_stimulus(data_folder, participants, *, candidate_configs, progress=None, existing_artifacts=None, after_outer_fold=None):
     """Run nested LOSO model selection and evaluate each untouched outer participant once."""
 
     candidate_configs = _normalized_candidate_configs(candidate_configs)
@@ -133,13 +134,20 @@ def evaluate_nested_cross_subject_stimulus(data_folder, participants, *, candida
     if not candidate_configs:
         raise ValueError("At least one candidate configuration is required.")
 
-    feature_cache = _load_feature_cache(data_folder, participants, candidate_configs, progress=progress)
-    inner_rows = []
-    outer_rows = []
-    selected_rows = []
-    prediction_rows = []
+    resumed = _existing_nested_artifact_rows(existing_artifacts)
+    inner_rows = resumed["inner_validation"]
+    outer_rows = resumed["outer"]
+    selected_rows = resumed["selected"]
+    prediction_rows = resumed["predictions"]
+    completed_outer_folds = {int(row["test_participant"]) for row in outer_rows}
+    missing_participants = tuple(participant for participant in participants if participant not in completed_outer_folds)
+    feature_cache = _load_feature_cache(data_folder, participants, candidate_configs, progress=progress) if missing_participants else {}
     inner_pair_cache: dict[tuple[int, tuple[int, int]], dict] = {}
     for test_participant in participants:
+        if int(test_participant) in completed_outer_folds:
+            if progress is not None:
+                progress(f"SKIP outer_test_participant={test_participant} resume=complete")
+            continue
         outer_row, outer_inner_rows, selected_row, participant_predictions = _evaluate_nested_outer_fold(
             test_participant,
             participants,
@@ -152,22 +160,10 @@ def evaluate_nested_cross_subject_stimulus(data_folder, participants, *, candida
         outer_rows.append(outer_row)
         selected_rows.append(selected_row)
         prediction_rows.extend(participant_predictions)
+        if after_outer_fold is not None:
+            after_outer_fold(_assemble_nested_artifacts(outer_rows, inner_rows, selected_rows, prediction_rows, candidate_configs))
 
-    group_summary_rows = summarize_nested_cross_subject_stimulus(
-        outer_rows,
-        signflip_permutations=candidate_configs[0].signflip_permutations,
-        signflip_seed=candidate_configs[0].signflip_seed,
-    )
-    confusion_rows, per_stimulus_rows = summarize_cross_subject_predictions(prediction_rows)
-    return {
-        "outer": outer_rows,
-        "inner_validation": inner_rows,
-        "selected": selected_rows,
-        "predictions": prediction_rows,
-        "group_summary": group_summary_rows,
-        "confusion": confusion_rows,
-        "per_stimulus": per_stimulus_rows,
-    }
+    return _assemble_nested_artifacts(outer_rows, inner_rows, selected_rows, prediction_rows, candidate_configs)
 
 
 def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
@@ -382,6 +378,86 @@ def summarize_cross_subject_predictions(prediction_rows):
     return confusion.to_dict(orient="records"), per_stimulus.to_dict(orient="records")
 
 
+def _assemble_nested_artifacts(outer_rows, inner_rows, selected_rows, prediction_rows, candidate_configs):
+    group_summary_rows = summarize_nested_cross_subject_stimulus(
+        outer_rows,
+        signflip_permutations=candidate_configs[0].signflip_permutations,
+        signflip_seed=candidate_configs[0].signflip_seed,
+    )
+    confusion_rows, per_stimulus_rows = summarize_cross_subject_predictions(prediction_rows)
+    return {
+        "outer": outer_rows,
+        "inner_validation": inner_rows,
+        "selected": selected_rows,
+        "predictions": prediction_rows,
+        "group_summary": group_summary_rows,
+        "confusion": confusion_rows,
+        "per_stimulus": per_stimulus_rows,
+    }
+
+
+def _existing_nested_artifact_rows(existing_artifacts):
+    empty_artifacts: dict[str, list] = {
+        "outer": [],
+        "inner_validation": [],
+        "selected": [],
+        "predictions": [],
+    }
+    if existing_artifacts is None:
+        return empty_artifacts
+    return {key: list(existing_artifacts.get(key, [])) for key in empty_artifacts}
+
+
+def _read_csv_rows(path):
+    if not path:
+        return []
+    csv_path = Path(path)
+    if not csv_path.exists():
+        return []
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _read_nested_output_rows(
+    *,
+    outer_output_path,
+    inner_validation_output_path=None,
+    selected_output_path=None,
+    predictions_output_path=None,
+):
+    return {
+        "outer": _read_csv_rows(outer_output_path),
+        "inner_validation": _read_csv_rows(inner_validation_output_path),
+        "selected": _read_csv_rows(selected_output_path),
+        "predictions": _read_csv_rows(predictions_output_path),
+    }
+
+
+def _write_nested_output_rows(
+    artifacts,
+    *,
+    outer_output_path,
+    group_summary_output_path=None,
+    inner_validation_output_path=None,
+    selected_output_path=None,
+    predictions_output_path=None,
+    confusion_output_path=None,
+    per_stimulus_output_path=None,
+):
+    _write_rows_if_present(artifacts["outer"], outer_output_path)
+    _write_rows_if_present(artifacts["group_summary"], group_summary_output_path)
+    _write_rows_if_present(artifacts["inner_validation"], inner_validation_output_path)
+    _write_rows_if_present(artifacts["selected"], selected_output_path)
+    _write_rows_if_present(artifacts["predictions"], predictions_output_path)
+    _write_rows_if_present(artifacts["confusion"], confusion_output_path)
+    _write_rows_if_present(artifacts["per_stimulus"], per_stimulus_output_path)
+
+
+def _write_rows_if_present(rows, path):
+    if path and rows:
+        write_alpha_metrics_csv(rows, path)
+
+
 def export_cross_subject_stimulus_smoke(
     data_folder,
     participants,
@@ -421,24 +497,44 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
     predictions_output_path=None,
     confusion_output_path=None,
     per_stimulus_output_path=None,
+    resume=False,
+    write_incremental=False,
     progress=None,
 ):
     """Run nested LOSO cross-subject decoding and write compact CSV artifacts."""
 
-    artifacts = evaluate_nested_cross_subject_stimulus(data_folder, participants, candidate_configs=candidate_configs, progress=progress)
-    write_alpha_metrics_csv(artifacts["outer"], outer_output_path)
-    if group_summary_output_path:
-        write_alpha_metrics_csv(artifacts["group_summary"], group_summary_output_path)
-    if inner_validation_output_path:
-        write_alpha_metrics_csv(artifacts["inner_validation"], inner_validation_output_path)
-    if selected_output_path:
-        write_alpha_metrics_csv(artifacts["selected"], selected_output_path)
-    if predictions_output_path:
-        write_alpha_metrics_csv(artifacts["predictions"], predictions_output_path)
-    if confusion_output_path:
-        write_alpha_metrics_csv(artifacts["confusion"], confusion_output_path)
-    if per_stimulus_output_path:
-        write_alpha_metrics_csv(artifacts["per_stimulus"], per_stimulus_output_path)
+    existing_artifacts = (
+        _read_nested_output_rows(
+            outer_output_path=outer_output_path,
+            inner_validation_output_path=inner_validation_output_path,
+            selected_output_path=selected_output_path,
+            predictions_output_path=predictions_output_path,
+        )
+        if resume
+        else None
+    )
+
+    def write_outputs(current_artifacts):
+        _write_nested_output_rows(
+            current_artifacts,
+            outer_output_path=outer_output_path,
+            group_summary_output_path=group_summary_output_path,
+            inner_validation_output_path=inner_validation_output_path,
+            selected_output_path=selected_output_path,
+            predictions_output_path=predictions_output_path,
+            confusion_output_path=confusion_output_path,
+            per_stimulus_output_path=per_stimulus_output_path,
+        )
+
+    artifacts = evaluate_nested_cross_subject_stimulus(
+        data_folder,
+        participants,
+        candidate_configs=candidate_configs,
+        progress=progress,
+        existing_artifacts=existing_artifacts,
+        after_outer_fold=write_outputs if write_incremental else None,
+    )
+    write_outputs(artifacts)
     return artifacts
 
 
@@ -464,7 +560,14 @@ def _evaluate_nested_outer_fold(test_participant, participants, candidate_config
     if progress is not None:
         progress(f"START outer_test_participant={test_participant}")
     outer_train_participants = tuple(participant for participant in participants if participant != test_participant)
-    outer_inner_rows = _evaluate_nested_inner_rows(test_participant, outer_train_participants, candidate_configs, feature_cache, inner_pair_cache)
+    outer_inner_rows = _evaluate_nested_inner_rows(
+        test_participant,
+        outer_train_participants,
+        candidate_configs,
+        feature_cache,
+        inner_pair_cache,
+        progress=progress,
+    )
     selected_row = _select_nested_candidate(outer_inner_rows)
     selected_config = candidate_configs[int(selected_row["selected_candidate_index"]) - 1]
     selected_feature_sets = feature_cache[_feature_cache_key(selected_config)]
@@ -490,14 +593,25 @@ def _evaluate_nested_outer_fold(test_participant, participants, candidate_config
     return outer_row, outer_inner_rows, selected_row, participant_predictions
 
 
-def _evaluate_nested_inner_rows(test_participant, outer_train_participants, candidate_configs, feature_cache, inner_pair_cache):
+def _evaluate_nested_inner_rows(test_participant, outer_train_participants, candidate_configs, feature_cache, inner_pair_cache, *, progress=None):
     inner_rows = []
+    completed = 0
+    total = len(candidate_configs) * len(outer_train_participants)
     for candidate_index, candidate_config in enumerate(candidate_configs, start=1):
         feature_sets = feature_cache[_feature_cache_key(candidate_config)]
         for validation_participant in outer_train_participants:
             excluded_pair = tuple(sorted((int(test_participant), int(validation_participant))))
             pair_rows = _cached_nested_pair_rows(candidate_index, candidate_config, excluded_pair, feature_sets, inner_pair_cache)
             inner_rows.append(pair_rows[(int(test_participant), int(validation_participant))])
+            completed += 1
+            if progress is not None:
+                progress(
+                    "DONE inner_validation "
+                    f"outer_test_participant={test_participant} "
+                    f"candidate={candidate_index}/{len(candidate_configs)} "
+                    f"validation_participant={validation_participant} "
+                    f"progress={completed}/{total}"
+                )
     return inner_rows
 
 

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1,5 +1,7 @@
 import re
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -9,6 +11,7 @@ from pymegdec.stimulus_cross_subject import (
     CrossSubjectStimulusConfig,
     evaluate_cross_subject_stimulus_smoke,
     evaluate_nested_cross_subject_stimulus,
+    export_nested_cross_subject_stimulus,
     load_participant_stimulus_features,
     make_cross_subject_candidate_configs,
     summarize_cross_subject_stimulus_smoke,
@@ -174,6 +177,64 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(artifacts["group_summary"][0]["selection_mode"], "nested_loso")
         self.assertEqual(artifacts["group_summary"][0]["n_candidates"], 2)
         self.assertEqual(fit_model.call_count, 16)
+
+    def test_nested_export_resumes_existing_outer_rows(self):
+        data_by_participant = {
+            1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),
+            2: _mat_data([1, 2, 1, 2], [-1.0, 1.0, -0.9, 0.9]),
+            3: _mat_data([1, 2, 1, 2], [-1.3, 1.3, -1.2, 1.2]),
+            4: _mat_data([1, 2, 1, 2], [-1.1, 1.1, -1.0, 1.0]),
+        }
+        candidate_configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            window_size=0.1,
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multiclass-svm",),
+            classifier_params=(0.5,),
+            components_pca_values=(float("inf"),),
+            chance_classes=2,
+            signflip_permutations=128,
+        )
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            full_artifacts = evaluate_nested_cross_subject_stimulus("unused", [1, 2, 3, 4], candidate_configs=candidate_configs)
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_dir = Path(output_dir)
+            paths = {
+                "outer": output_dir / "outer.csv",
+                "summary": output_dir / "summary.csv",
+                "inner": output_dir / "inner.csv",
+                "selected": output_dir / "selected.csv",
+                "predictions": output_dir / "predictions.csv",
+                "confusion": output_dir / "confusion.csv",
+                "per_stimulus": output_dir / "per_stimulus.csv",
+            }
+            cross_subject.write_alpha_metrics_csv([row for row in full_artifacts["outer"] if int(row["test_participant"]) == 1], paths["outer"])
+            cross_subject.write_alpha_metrics_csv([row for row in full_artifacts["inner_validation"] if int(row["outer_test_participant"]) == 1], paths["inner"])
+            cross_subject.write_alpha_metrics_csv([row for row in full_artifacts["selected"] if int(row["test_participant"]) == 1], paths["selected"])
+            cross_subject.write_alpha_metrics_csv([row for row in full_artifacts["predictions"] if int(row["test_participant"]) == 1], paths["predictions"])
+            progress_messages = []
+            with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+                resumed_artifacts = export_nested_cross_subject_stimulus(
+                    "unused",
+                    [1, 2, 3, 4],
+                    candidate_configs=candidate_configs,
+                    outer_output_path=paths["outer"],
+                    group_summary_output_path=paths["summary"],
+                    inner_validation_output_path=paths["inner"],
+                    selected_output_path=paths["selected"],
+                    predictions_output_path=paths["predictions"],
+                    confusion_output_path=paths["confusion"],
+                    per_stimulus_output_path=paths["per_stimulus"],
+                    resume=True,
+                    write_incremental=True,
+                    progress=progress_messages.append,
+                )
+
+        self.assertEqual(len(resumed_artifacts["outer"]), 4)
+        self.assertEqual({int(row["test_participant"]) for row in resumed_artifacts["outer"]}, {1, 2, 3, 4})
+        self.assertIn("SKIP outer_test_participant=1 resume=complete", progress_messages)
 
     def test_summarize_cross_subject_stimulus_smoke_signflip(self):
         config = CrossSubjectStimulusConfig(chance_classes=2, signflip_permutations=128)


### PR DESCRIPTION
## Summary
- add `--resume` and `--write-incremental` for nested cross-subject stimulus decoding
- rewrite nested CSV outputs after each completed outer participant so interrupted runs can still upload partial artifacts
- make the manual nested workflow upload partial outputs and summarize gracefully on failure

## Test Plan
- `python -m pytest tests\test_stimulus_cross_subject.py -q`
- `python -m ruff check src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject.py`
- `python -m black --check src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject.py`
- `python -m isort --check-only src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject.py`
- `python -m mypy src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py`
- `$env:MPLBACKEND='Agg'; python -m pytest -q`