### PR TITLE
Allow nested cross-subject outer fold subsets

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -34,6 +34,11 @@ on:
         required: true
         default: "1-4,6,8,9,10,13-27"
         type: string
+      outer_participants:
+        description: Optional held-out participant ids to evaluate in this run. Empty means all participants.
+        required: false
+        default: ""
+        type: string
       window_centers:
         description: Candidate window centers in seconds.
         required: true
@@ -93,6 +98,7 @@ jobs:
       USE_NEXTCLOUD_DATA: ${{ inputs.use_nextcloud_data }}
       DATA_CACHE_VERSION: ${{ inputs.data_cache_version }}
       PARTICIPANTS: ${{ inputs.participants }}
+      OUTER_PARTICIPANTS: ${{ inputs.outer_participants }}
       WINDOW_CENTERS: ${{ inputs.window_centers }}
       WINDOW_SIZE: ${{ inputs.window_size }}
       BASELINE_WINDOW: ${{ inputs.baseline_window }}
@@ -176,6 +182,9 @@ jobs:
           )
           if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" ]]; then
             args+=(--max-trials-per-class-per-participant "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}")
+          fi
+          if [[ -n "${OUTER_PARTICIPANTS}" ]]; then
+            args+=(--outer-participants "${OUTER_PARTICIPANTS}")
           fi
           "${args[@]}"
 

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -313,6 +313,11 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
     parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat files.")
     parser.add_argument("--participants", default=DEFAULT_CROSS_SUBJECT_PARTICIPANTS, help="Participant ids such as 1-4,6,8.")
     parser.add_argument(
+        "--outer-participants",
+        default=None,
+        help="Optional held-out participant ids to evaluate in this run. Defaults to all participants.",
+    )
+    parser.add_argument(
         "--window-centers",
         type=parse_float_list,
         default=DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS,
@@ -379,6 +384,7 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
     participants = parse_participant_spec(args.participants)
     if not participants:
         parser.error("At least one participant is required.")
+    outer_participants = parse_participant_spec(args.outer_participants) if args.outer_participants else None
     candidate_configs = make_cross_subject_candidate_configs(
         window_centers=args.window_centers,
         window_size=args.window_size,
@@ -407,6 +413,7 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         per_stimulus_output_path=args.per_stimulus_output,
         resume=args.resume,
         write_incremental=args.write_incremental,
+        outer_participants=outer_participants,
         progress=lambda message: print(message, flush=True),
     )
     print(f"Wrote {len(artifacts['outer'])} untouched outer participant rows to {args.outer_output}")

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -123,7 +123,16 @@ def evaluate_cross_subject_stimulus_smoke(data_folder, participants, *, config=N
     }
 
 
-def evaluate_nested_cross_subject_stimulus(data_folder, participants, *, candidate_configs, progress=None, existing_artifacts=None, after_outer_fold=None):
+def evaluate_nested_cross_subject_stimulus(
+    data_folder,
+    participants,
+    *,
+    candidate_configs,
+    outer_participants=None,
+    progress=None,
+    existing_artifacts=None,
+    after_outer_fold=None,
+):
     """Run nested LOSO model selection and evaluate each untouched outer participant once."""
 
     candidate_configs = _normalized_candidate_configs(candidate_configs)
@@ -133,6 +142,7 @@ def evaluate_nested_cross_subject_stimulus(data_folder, participants, *, candida
         raise ValueError("At least three participants are required for nested cross-subject decoding.")
     if not candidate_configs:
         raise ValueError("At least one candidate configuration is required.")
+    outer_participants = _normalize_outer_participants(participants, outer_participants)
 
     resumed = _existing_nested_artifact_rows(existing_artifacts)
     inner_rows = resumed["inner_validation"]
@@ -140,10 +150,10 @@ def evaluate_nested_cross_subject_stimulus(data_folder, participants, *, candida
     selected_rows = resumed["selected"]
     prediction_rows = resumed["predictions"]
     completed_outer_folds = {int(row["test_participant"]) for row in outer_rows}
-    missing_participants = tuple(participant for participant in participants if participant not in completed_outer_folds)
+    missing_participants = tuple(participant for participant in outer_participants if participant not in completed_outer_folds)
     feature_cache = _load_feature_cache(data_folder, participants, candidate_configs, progress=progress) if missing_participants else {}
     inner_pair_cache: dict[tuple[int, tuple[int, int]], dict] = {}
-    for test_participant in participants:
+    for test_participant in outer_participants:
         if int(test_participant) in completed_outer_folds:
             if progress is not None:
                 progress(f"SKIP outer_test_participant={test_participant} resume=complete")
@@ -408,6 +418,18 @@ def _existing_nested_artifact_rows(existing_artifacts):
     return {key: list(existing_artifacts.get(key, [])) for key in empty_artifacts}
 
 
+def _normalize_outer_participants(participants, outer_participants):
+    if outer_participants is None:
+        return tuple(participants)
+    outer_participants = tuple(int(participant) for participant in outer_participants)
+    if not outer_participants:
+        raise ValueError("At least one outer participant is required.")
+    unknown = sorted(set(outer_participants) - set(participants))
+    if unknown:
+        raise ValueError(f"Outer participants must be part of participants: {unknown}")
+    return outer_participants
+
+
 def _read_csv_rows(path):
     if not path:
         return []
@@ -499,6 +521,7 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
     per_stimulus_output_path=None,
     resume=False,
     write_incremental=False,
+    outer_participants=None,
     progress=None,
 ):
     """Run nested LOSO cross-subject decoding and write compact CSV artifacts."""
@@ -530,6 +553,7 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
         data_folder,
         participants,
         candidate_configs=candidate_configs,
+        outer_participants=outer_participants,
         progress=progress,
         existing_artifacts=existing_artifacts,
         after_outer_fold=write_outputs if write_incremental else None,

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -178,6 +178,38 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(artifacts["group_summary"][0]["n_candidates"], 2)
         self.assertEqual(fit_model.call_count, 16)
 
+    def test_nested_cross_subject_can_evaluate_outer_subset(self):
+        data_by_participant = {
+            1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),
+            2: _mat_data([1, 2, 1, 2], [-1.0, 1.0, -0.9, 0.9]),
+            3: _mat_data([1, 2, 1, 2], [-1.3, 1.3, -1.2, 1.2]),
+            4: _mat_data([1, 2, 1, 2], [-1.1, 1.1, -1.0, 1.0]),
+        }
+        candidate_configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            window_size=0.1,
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multiclass-svm",),
+            classifier_params=(0.5,),
+            components_pca_values=(float("inf"),),
+            chance_classes=2,
+            signflip_permutations=128,
+        )
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            artifacts = evaluate_nested_cross_subject_stimulus(
+                "unused",
+                [1, 2, 3, 4],
+                candidate_configs=candidate_configs,
+                outer_participants=[2, 4],
+            )
+
+        self.assertEqual({row["test_participant"] for row in artifacts["outer"]}, {2, 4})
+        self.assertEqual({row["outer_test_participant"] for row in artifacts["inner_validation"]}, {2, 4})
+        self.assertEqual({row["test_participant"] for row in artifacts["selected"]}, {2, 4})
+        self.assertEqual(len(artifacts["predictions"]), 8)
+        self.assertEqual(artifacts["group_summary"][0]["n_outer_folds"], 2)
+
     def test_nested_export_resumes_existing_outer_rows(self):
         data_by_participant = {
             1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),


### PR DESCRIPTION
## Summary
- add `--outer-participants` to the nested cross-subject stimulus command
- keep the full participant set as the training/inner-validation pool while restricting which held-out outer folds are evaluated in one run
- expose the same option in the manual nested GitHub Actions workflow for fold-level recovery or sharding

## Test Plan
- `python -m pytest tests\test_stimulus_cross_subject.py -q`
- `python -m ruff check src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject.py`
- `python -m black --check src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject.py`
- `python -m isort --check-only src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject.py`
- `python -m mypy src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py`
- `$env:MPLBACKEND='Agg'; python -m pytest -q`