### PR TITLE
Add cross-subject normalization sweep modes

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -62,7 +62,7 @@ on:
       normalizations:
         description: Candidate normalization modes.
         required: true
-        default: subject_baseline_z
+        default: subject_baseline_z,subject_trial_z,subject_baseline_whiten
         type: string
       classifiers:
         description: Candidate classifier names.

--- a/.github/workflows/stimulus-cross-subject-smoke.yml
+++ b/.github/workflows/stimulus-cross-subject-smoke.yml
@@ -64,6 +64,8 @@ on:
         type: choice
         options:
           - subject_baseline_z
+          - subject_trial_z
+          - subject_baseline_whiten
           - subject_z
           - none
       classifier:

--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -38,6 +38,13 @@ Useful follow-up classifiers for this cross-subject benchmark are
 training-set class-average pattern, which is a simple baseline for shared
 stimulus topographies across participants.
 
+Supported cross-subject normalization modes are `none`, `subject_z`,
+`subject_trial_z`, `subject_baseline_z`, and `subject_baseline_whiten`.
+`subject_trial_z` normalizes each trial feature vector independently.
+`subject_baseline_whiten` estimates a shrinkage channel covariance from the
+baseline window and applies the resulting channel whitening transform to each
+stimulus-window feature vector.
+
 ## Nested cross-subject benchmark
 
 Use nested LOSO when choosing among windows, classifiers, or PCA settings. For
@@ -52,7 +59,7 @@ pymegdec stimulus cross-subject-nested \
   --window-centers 0.150,0.175,0.200 \
   --window-size 0.1 \
   --feature-modes sensor_flat \
-  --normalizations subject_baseline_z \
+  --normalizations subject_baseline_z,subject_trial_z,subject_baseline_whiten \
   --classifiers multinomial-logistic,shrinkage-lda,multiclass-svm \
   --classifier-params default \
   --components-pca-values 64 \

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -35,6 +35,7 @@ from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_PARTICIPANTS,
     DEFAULT_CROSS_SUBJECT_WINDOW_CENTER,
     DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
+    NORMALIZATION_MODES,
     CrossSubjectStimulusConfig,
     export_cross_subject_stimulus_smoke,
     export_nested_cross_subject_stimulus,
@@ -240,7 +241,7 @@ def _build_cross_subject_smoke_parser(prog: str | None = None) -> argparse.Argum
         "--normalization",
         type=_normalization_token,
         default=DEFAULT_CROSS_SUBJECT_NORMALIZATION,
-        choices=("none", "subject_z", "subject_baseline_z"),
+        choices=NORMALIZATION_MODES,
         help="Subject-level normalization mode.",
     )
     parser.add_argument("--classifier", default=DEFAULT_CROSS_SUBJECT_CLASSIFIER, help="Classifier name.")

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -37,7 +37,9 @@ DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA = 64
 DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS = (0.150, 0.175, 0.200)
 DEFAULT_CROSS_SUBJECT_SELECTION_METRIC = "balanced_accuracy"
 FEATURE_MODES = ("sensor_mean", "sensor_flat")
-NORMALIZATION_MODES = ("none", "subject_z", "subject_baseline_z")
+NORMALIZATION_MODES = ("none", "subject_z", "subject_trial_z", "subject_baseline_z", "subject_baseline_whiten")
+BASELINE_WHITENING_SHRINKAGE = 0.1
+BASELINE_WHITENING_EIGENVALUE_FLOOR = 1e-6
 CROSS_SUBJECT_PREDICTION_GROUP_COLUMNS = (
     "window_center_s",
     "feature_mode",
@@ -79,6 +81,7 @@ class ParticipantFeatureSet:
     baseline_features: np.ndarray | None
     baseline_feature_mean: np.ndarray | None
     baseline_feature_std: np.ndarray | None
+    baseline_whitening_matrix: np.ndarray | None
     n_channels: int
     n_window_samples: int
     n_baseline_samples: int
@@ -251,10 +254,13 @@ def load_participant_stimulus_features(data_folder, participant, *, config=None)
     baseline_features = None
     baseline_feature_mean = None
     baseline_feature_std = None
+    baseline_whitening_matrix = None
     n_baseline_samples = 0
-    if config.normalization == "subject_baseline_z":
+    if config.normalization in ("subject_baseline_z", "subject_baseline_whiten"):
         baseline_feature_mean, baseline_feature_std, n_baseline_samples = _baseline_feature_statistics(data, config, n_window_samples, trial_indices)
-    normalized_features = _normalize_features(features, config, baseline_feature_mean, baseline_feature_std)
+    if config.normalization == "subject_baseline_whiten":
+        baseline_whitening_matrix, n_baseline_samples = _baseline_channel_whitening_matrix(data, config.baseline_window, trial_indices)
+    normalized_features = _normalize_features(features, config, baseline_feature_mean, baseline_feature_std, baseline_whitening_matrix)
     if labels.shape[0] != features.shape[0]:
         raise ValueError(f"Participant {participant} has {labels.shape[0]} labels but {features.shape[0]} feature rows.")
     return ParticipantFeatureSet(
@@ -265,6 +271,7 @@ def load_participant_stimulus_features(data_folder, participant, *, config=None)
         baseline_features=baseline_features,
         baseline_feature_mean=baseline_feature_mean,
         baseline_feature_std=baseline_feature_std,
+        baseline_whitening_matrix=baseline_whitening_matrix,
         n_channels=int(_trial_signal(data, 0).shape[0]),
         n_window_samples=int(n_window_samples),
         n_baseline_samples=int(n_baseline_samples),
@@ -1305,6 +1312,39 @@ def _baseline_channel_statistics(data, baseline_window, trial_indices):
     return mean, np.sqrt(variance), int(np.sum(mask))
 
 
+def _baseline_channel_whitening_matrix(data, baseline_window, trial_indices):
+    baseline_features, n_baseline_samples = _extract_window_features(data, baseline_window, feature_mode="sensor_mean", trial_indices=trial_indices)
+    covariance = _covariance_matrix(baseline_features)
+    covariance = _shrink_covariance(covariance, shrinkage=BASELINE_WHITENING_SHRINKAGE)
+    return _whitening_matrix(covariance), n_baseline_samples
+
+
+def _covariance_matrix(features):
+    features = np.asarray(features, dtype=float)
+    n_features = int(features.shape[1])
+    if features.shape[0] < 2:
+        return np.eye(n_features, dtype=float)
+    covariance = np.cov(features, rowvar=False)
+    covariance = np.asarray(covariance, dtype=float)
+    if covariance.ndim == 0:
+        covariance = covariance.reshape(1, 1)
+    return 0.5 * (covariance + covariance.T)
+
+
+def _shrink_covariance(covariance, *, shrinkage):
+    covariance = np.asarray(covariance, dtype=float)
+    diagonal = np.diag(np.diag(covariance))
+    return (1.0 - float(shrinkage)) * covariance + float(shrinkage) * diagonal
+
+
+def _whitening_matrix(covariance):
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    eigen_floor = max(float(np.max(eigenvalues)) * BASELINE_WHITENING_EIGENVALUE_FLOOR, 1e-12)
+    inverse_sqrt = 1.0 / np.sqrt(np.maximum(eigenvalues, eigen_floor))
+    whitening = (eigenvectors * inverse_sqrt) @ eigenvectors.T
+    return 0.5 * (whitening + whitening.T)
+
+
 def _selected_trial_indices(labels, max_trials_per_class):
     labels = np.asarray(labels).ravel()
     if max_trials_per_class is None:
@@ -1394,17 +1434,23 @@ def _normalized_subject_features(feature_set, config):
         reference = feature_set.features
         mean = np.mean(reference, axis=0, keepdims=True)
         std = np.std(reference, axis=0, keepdims=True)
-    elif config.normalization == "subject_baseline_z":
+        return (feature_set.features - mean) / _nonzero_std(std)
+    if config.normalization == "subject_trial_z":
+        return _trial_zscore_features(feature_set.features)
+    if config.normalization == "subject_baseline_z":
         if feature_set.baseline_feature_mean is None or feature_set.baseline_feature_std is None:
             raise ValueError("subject_baseline_z requires baseline feature statistics.")
         mean = feature_set.baseline_feature_mean
         std = feature_set.baseline_feature_std
-    else:
-        raise ValueError(f"Unsupported normalization: {config.normalization}")
-    return (feature_set.features - mean) / std
+        return (feature_set.features - mean) / std
+    if config.normalization == "subject_baseline_whiten":
+        if feature_set.baseline_feature_mean is None or feature_set.baseline_whitening_matrix is None:
+            raise ValueError("subject_baseline_whiten requires baseline feature statistics and a whitening matrix.")
+        return _baseline_whiten_features(feature_set.features, config, feature_set.baseline_feature_mean, feature_set.baseline_whitening_matrix)
+    raise ValueError(f"Unsupported normalization: {config.normalization}")
 
 
-def _normalize_features(features, config, baseline_feature_mean, baseline_feature_std):
+def _normalize_features(features, config, baseline_feature_mean, baseline_feature_std, baseline_whitening_matrix):
     features = np.asarray(features, dtype=float)
     if config.normalization == "none":
         return features
@@ -1414,13 +1460,46 @@ def _normalize_features(features, config, baseline_feature_mean, baseline_featur
         features -= mean
         features /= std
         return features
+    if config.normalization == "subject_trial_z":
+        return _trial_zscore_features(features)
     if config.normalization == "subject_baseline_z":
         if baseline_feature_mean is None or baseline_feature_std is None:
             raise ValueError("subject_baseline_z requires baseline feature statistics.")
         features -= baseline_feature_mean
         features /= baseline_feature_std
         return features
+    if config.normalization == "subject_baseline_whiten":
+        if baseline_feature_mean is None or baseline_whitening_matrix is None:
+            raise ValueError("subject_baseline_whiten requires baseline feature statistics and a whitening matrix.")
+        return _baseline_whiten_features(features, config, baseline_feature_mean, baseline_whitening_matrix)
     raise ValueError(f"Unsupported normalization: {config.normalization}")
+
+
+def _trial_zscore_features(features):
+    features = np.asarray(features, dtype=float)
+    mean = np.mean(features, axis=1, keepdims=True)
+    std = _nonzero_std(np.std(features, axis=1, keepdims=True))
+    return (features - mean) / std
+
+
+def _baseline_whiten_features(features, config, baseline_feature_mean, baseline_whitening_matrix):
+    centered = np.asarray(features, dtype=float) - baseline_feature_mean
+    whitening_matrix = np.asarray(baseline_whitening_matrix, dtype=float)
+    if config.feature_mode == "sensor_mean":
+        return centered @ whitening_matrix.T
+    if config.feature_mode == "sensor_flat":
+        return _baseline_whiten_sensor_flat_features(centered, whitening_matrix)
+    raise ValueError(f"Unsupported feature_mode: {config.feature_mode}")
+
+
+def _baseline_whiten_sensor_flat_features(features, whitening_matrix):
+    n_channels = int(whitening_matrix.shape[0])
+    if features.shape[1] % n_channels:
+        raise ValueError("sensor_flat feature width must be a multiple of the number of whitening channels.")
+    n_window_samples = int(features.shape[1] // n_channels)
+    matrices = features.reshape(features.shape[0], n_window_samples, n_channels)
+    whitened = matrices @ whitening_matrix.T
+    return whitened.reshape(features.shape[0], -1)
 
 
 def _nonzero_std(std):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -36,6 +36,14 @@ def _mat_data(labels, values):
     }
 
 
+def _mat_data_from_trials(labels, trials, time):
+    return {
+        "trial": cell_array([np.asarray(trial, dtype=float) for trial in trials]),
+        "time": cell_array([np.asarray(time, dtype=float) for _ in trials]),
+        "trialinfo": np.array([[np.asarray(labels, dtype=int)]], dtype=object),
+    }
+
+
 def _loadmat_side_effect(data_by_participant):
     def loadmat(path):
         match = re.search(r"Part(\d+)Data\.mat$", str(path))
@@ -102,6 +110,57 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(feature_set.baseline_feature_std.shape, (1, 4))
         self.assertTrue(np.allclose(feature_set.baseline_feature_mean[0, :2], feature_set.baseline_feature_mean[0, 2:]))
         self.assertTrue(np.allclose(feature_set.baseline_feature_std[0, :2], feature_set.baseline_feature_std[0, 2:]))
+
+    def test_sensor_flat_subject_trial_z_normalizes_each_trial(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 2.0], [0.0, 0.0, 3.0, 5.0]],
+            [[0.0, 0.0, 2.0, 4.0], [0.0, 0.0, 6.0, 10.0]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_flat",
+            normalization="subject_trial_z",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 4))
+        self.assertTrue(np.allclose(np.mean(feature_set.features, axis=1), 0.0))
+        self.assertTrue(np.allclose(np.std(feature_set.features, axis=1), 1.0))
+
+    def test_sensor_flat_subject_baseline_whiten_uses_channel_covariance(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
+        trials = [
+            [[-1.0, -0.8, 1.0, 1.2], [0.5, 0.7, 3.0, 3.2]],
+            [[-0.4, -0.2, 2.0, 2.2], [1.1, 1.3, 4.0, 4.2]],
+            [[0.2, 0.4, 3.0, 3.2], [1.7, 1.9, 5.0, 5.2]],
+            [[0.8, 1.0, 4.0, 4.2], [2.3, 2.5, 6.0, 6.2]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2, 1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_flat",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (4, 4))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 4))
+        self.assertEqual(feature_set.baseline_whitening_matrix.shape, (2, 2))
+        self.assertEqual(feature_set.n_baseline_samples, 2)
+        self.assertTrue(np.allclose(feature_set.baseline_whitening_matrix, feature_set.baseline_whitening_matrix.T))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
     def test_load_participant_stimulus_features_can_cap_trials_per_class(self):
         data_by_participant = {1: _mat_data([1, 2, 1, 2, 1, 2], [-1.0, 1.0, -0.9, 0.9, -0.8, 0.8])}


### PR DESCRIPTION
## Summary
- add subject_trial_z for per-trial feature-vector z-scoring
- add subject_baseline_whiten using shrinkage baseline channel covariance whitening
- include the new modes in CLI/workflow options and make the nested workflow sweep baseline z, trial z, and baseline whitening by default
- document the normalization modes and add synthetic tests for the new paths

## Notes
- Procrustes/shared-response alignment is left for a later, explicit alignment layer because it needs train-fold templates and must avoid held-out-subject leakage.

## Tests
- python -m pytest tests\\test_stimulus_cross_subject.py -q
- python -m ruff check src\\pymegdec\\stimulus_cross_subject.py src\\pymegdec\\stimulus_cli.py tests\\test_stimulus_cross_subject.py
- python -m pylint src\\pymegdec\\stimulus_cross_subject.py src\\pymegdec\\stimulus_cli.py
- python -m black --check src\\pymegdec\\stimulus_cross_subject.py src\\pymegdec\\stimulus_cli.py tests\\test_stimulus_cross_subject.py
- python -m isort --check-only src\\pymegdec\\stimulus_cross_subject.py src\\pymegdec\\stimulus_cli.py tests\\test_stimulus_cross_subject.py
- python -m mypy src\\pymegdec\\stimulus_cross_subject.py src\\pymegdec\\stimulus_cli.py
- python -m pytest -q