### PR TITLE
Support fixed shrinkage for LDA

### DIFF
--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -37,6 +37,9 @@ Useful follow-up classifiers for this cross-subject benchmark are
 `correlation-prototype` classifies each held-out trial by correlation to the
 training-set class-average pattern, which is a simple baseline for shared
 stimulus topographies across participants.
+For `multinomial-logistic`, `--classifier-params` controls the inverse
+regularization strength `C`. For `shrinkage-lda`, use `auto` or a numeric
+shrinkage value between `0` and `1`.
 
 Supported cross-subject normalization modes are `none`, `subject_z`,
 `subject_trial_z`, `subject_baseline_z`, and `subject_baseline_whiten`.

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -1,18 +1,12 @@
 """Classifier compatibility wrappers used by PyMEGDec decoding routines."""
 
 import numpy as np
-from reptrace.decoding.classifiers import (
-    CLASSIFIER_REGISTRY as REPTRACE_CLASSIFIER_REGISTRY,
-)
-from reptrace.decoding.classifiers import (
-    DEFAULT_CLASSIFIER_PARAMS as REPTRACE_DEFAULT_CLASSIFIER_PARAMS,
-)
+from reptrace.decoding.classifiers import CLASSIFIER_REGISTRY as REPTRACE_CLASSIFIER_REGISTRY
+from reptrace.decoding.classifiers import DEFAULT_CLASSIFIER_PARAMS as REPTRACE_DEFAULT_CLASSIFIER_PARAMS
 from reptrace.decoding.classifiers import (
     ClassifierSpec,
 )
-from reptrace.decoding.classifiers import (
-    get_default_classifier_param as get_reptrace_default_classifier_param,
-)
+from reptrace.decoding.classifiers import get_default_classifier_param as get_reptrace_default_classifier_param
 from reptrace.decoding.classifiers import (
     should_use_default_classifier_param,
     train_binary_svm,
@@ -126,8 +120,21 @@ def _build_multinomial_logistic(_features, _labels, classifier_param, random_sta
     )
 
 
-def _build_shrinkage_lda(_features, _labels, _classifier_param, _random_state):
-    return LinearDiscriminantAnalysis(solver="lsqr", shrinkage="auto")
+def _build_shrinkage_lda(_features, _labels, classifier_param, _random_state):
+    return LinearDiscriminantAnalysis(solver="lsqr", shrinkage=_normalize_lda_shrinkage(classifier_param))
+
+
+def _normalize_lda_shrinkage(classifier_param):
+    if classifier_param is None:
+        return "auto"
+    if isinstance(classifier_param, str):
+        normalized = classifier_param.strip().lower()
+        if normalized == "auto":
+            return "auto"
+    shrinkage = float(classifier_param)
+    if not 0.0 <= shrinkage <= 1.0:
+        raise ValueError("shrinkage-lda classifier_param must be 'auto' or a numeric shrinkage in [0, 1].")
+    return shrinkage
 
 
 def _build_pytorch_mlp_classifier(features, labels, classifier_param, random_state):

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -59,6 +59,8 @@ def _parse_classifier_param(value: str | None):
     normalized = value.strip()
     if normalized.lower() == "nan":
         return np.nan
+    if normalized.lower() == "auto":
+        return "auto"
 
     for parser in (json.loads, ast.literal_eval):
         try:

--- a/tests/test_classifier_registry.py
+++ b/tests/test_classifier_registry.py
@@ -3,12 +3,13 @@ import unittest
 import warnings
 
 import numpy as np
+from sklearn.exceptions import ConvergenceWarning
+
 from pymegdec.classifiers import (
     CLASSIFIER_REGISTRY,
     should_use_default_classifier_param,
     train_multiclass_classifier,
 )
-from sklearn.exceptions import ConvergenceWarning
 
 
 class TestClassifierRegistry(unittest.TestCase):
@@ -96,6 +97,27 @@ class TestClassifierRegistry(unittest.TestCase):
         predictions = model.predict(np.array([[0.9, 0.1, 0.0], [0.0, 0.2, 1.0]]))
 
         np.testing.assert_array_equal(predictions, np.array([0, 2]))
+
+    def test_shrinkage_lda_accepts_auto_and_numeric_shrinkage(self):
+        for classifier_param in ("auto", 0.1, 0.5):
+            with self.subTest(classifier_param=classifier_param):
+                model = train_multiclass_classifier(
+                    self.features,
+                    self.labels,
+                    "shrinkage-lda",
+                    classifier_param,
+                )
+                predictions = model.predict(self.features)
+                self.assertEqual(len(predictions), len(self.labels))
+
+    def test_shrinkage_lda_rejects_invalid_numeric_shrinkage(self):
+        with self.assertRaisesRegex(ValueError, "shrinkage-lda classifier_param"):
+            train_multiclass_classifier(
+                self.features,
+                self.labels,
+                "shrinkage-lda",
+                1.5,
+            )
 
     def test_random_state_reproduces_stochastic_classifier_predictions(self):
         model_a = train_multiclass_classifier(self.features, self.labels, "random-forest", 5, random_state=7)

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -5,10 +5,12 @@ import unittest
 from pathlib import Path
 
 import numpy as np
+
 from pymegdec.classifiers import (
     get_default_classifier_param,
     train_multiclass_classifier,
 )
+from pymegdec.cli import parse_classifier_param
 
 
 class TestClassifiers(unittest.TestCase):
@@ -39,6 +41,9 @@ class TestClassifiers(unittest.TestCase):
         self.assertIsNone(get_default_classifier_param("correlation-prototype"))
         self.assertEqual(get_default_classifier_param("multinomial-logistic"), 1.0)
         self.assertIsNone(get_default_classifier_param("shrinkage-lda"))
+
+    def test_parse_classifier_param_accepts_auto(self):
+        self.assertEqual(parse_classifier_param("auto"), "auto")
 
     def test_optional_ml_dependencies_are_lazy_imported(self):
         env = os.environ.copy()


### PR DESCRIPTION
## Summary
- allow shrinkage-lda to use classifier_param=auto or a numeric shrinkage value in [0, 1]
- allow the CLI classifier-param parser to accept bare uto
- document logistic C and LDA shrinkage tuning
- add tests for auto/numeric LDA shrinkage and invalid shrinkage values

## Tests
- python -m pytest tests\\test_classifier_registry.py tests\\test_classifiers.py -q
- python -m ruff check src\\pymegdec\\classifiers.py src\\pymegdec\\cli.py tests\\test_classifier_registry.py tests\\test_classifiers.py
- python -m pylint src\\pymegdec\\classifiers.py src\\pymegdec\\cli.py
- python -m black --check src\\pymegdec\\classifiers.py src\\pymegdec\\cli.py tests\\test_classifier_registry.py tests\\test_classifiers.py
- python -m isort --check-only src\\pymegdec\\classifiers.py src\\pymegdec\\cli.py tests\\test_classifier_registry.py tests\\test_classifiers.py
- python -m mypy --no-incremental src\\pymegdec\\classifiers.py
- python -m pytest -q

Note: mypy on src\\pymegdec\\classifiers.py src\\pymegdec\\cli.py hung locally, so I narrowed mypy to the changed classifier module and ran the full pytest suite.