### PR TITLE
Allow smoke workflow preset window center

### DIFF
--- a/.github/workflows/stimulus-cross-subject-smoke.yml
+++ b/.github/workflows/stimulus-cross-subject-smoke.yml
@@ -44,7 +44,7 @@ on:
           - prestimulus-control
       window_center:
         description: Stimulus decoding window center in seconds. Leave empty to use the benchmark-mode preset.
-        required: true
+        required: false
         default: ""
         type: string
       window_size:


### PR DESCRIPTION
## Summary
- make the smoke workflow `window_center` input optional
- allow benchmark-mode presets to provide the default poststimulus/prestimulus window center when the dispatch field is left empty

## Test
- workflow YAML parse check passed locally
