### PR TITLE
Add exact sign test to cross-subject summaries

### DIFF
--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -30,7 +30,9 @@ The first-pass feature mode averages every sensor within the decoding window,
 then fits a linear multiclass SVM after training-fold PCA. The outputs include
 held-out participant scores, trial predictions, confusion counts, per-stimulus
 recall, and a group summary with a subject-level one-sided sign-flip test
-against 16-way chance.
+against 16-way chance. The group summary also reports an exact one-sided sign
+test over held-out participants, so the direction-only result is visible next
+to the magnitude-sensitive sign-flip p-value.
 
 The manual GitHub Actions smoke workflow has a `benchmark_mode` input. Use
 `poststimulus` for the standard `0.175` s benchmark and

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -6,6 +6,7 @@ import csv
 from collections import Counter
 from dataclasses import dataclass
 from itertools import product
+from math import comb
 from pathlib import Path
 
 import numpy as np
@@ -293,7 +294,14 @@ def summarize_cross_subject_stimulus_smoke(outer_rows, *, config=None):
     mean_ranks = _finite_metric_values(outer_rows, "mean_true_label_rank")
     chance = float(outer_rows[0]["chance_accuracy"])
     differences = balanced - chance
-    p_value = _one_sided_signflip_p_value(differences, n_permutations=config.signflip_permutations, seed=config.signflip_seed)
+    participants_above_chance = _participants_above_chance(differences)
+    participants_total = _participants_total(differences)
+    exact_sign_p_value = _one_sided_exact_sign_p_value(differences)
+    signflip_p_value = _one_sided_signflip_p_value(
+        differences,
+        n_permutations=config.signflip_permutations,
+        seed=config.signflip_seed,
+    )
     return [
         {
             "n_outer_folds": len(outer_rows),
@@ -336,9 +344,11 @@ def summarize_cross_subject_stimulus_smoke(outer_rows, *, config=None):
             "balanced_percent_sem": float(100.0 * _sem(balanced)),
             "mean_above_chance": float(np.mean(differences)),
             "percent_above_chance": float(100.0 * np.mean(differences)),
-            "participants_above_chance": int(np.sum(balanced > chance)),
+            "participants_above_chance": participants_above_chance,
+            "participants_total": participants_total,
             "participants_at_or_below_chance": int(np.sum(balanced <= chance)),
-            "one_sided_signflip_p_value": p_value,
+            "one_sided_exact_sign_p_value": exact_sign_p_value,
+            "one_sided_signflip_p_value": signflip_p_value,
         }
     ]
 
@@ -356,7 +366,10 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
     mean_ranks = _finite_metric_values(outer_rows, "mean_true_label_rank")
     chance = float(outer_rows[0]["chance_accuracy"])
     differences = balanced - chance
-    p_value = _one_sided_signflip_p_value(differences, n_permutations=signflip_permutations, seed=signflip_seed)
+    participants_above_chance = _participants_above_chance(differences)
+    participants_total = _participants_total(differences)
+    exact_sign_p_value = _one_sided_exact_sign_p_value(differences)
+    signflip_p_value = _one_sided_signflip_p_value(differences, n_permutations=signflip_permutations, seed=signflip_seed)
     selected_counts = Counter(int(row["selected_candidate_index"]) for row in outer_rows)
     classifier_counts = Counter(str(row["classifier"]) for row in outer_rows)
     window_counts = Counter(float(row["window_center_s"]) for row in outer_rows)
@@ -399,9 +412,11 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
             "balanced_percent_sem": float(100.0 * _sem(balanced)),
             "mean_above_chance": float(np.mean(differences)),
             "percent_above_chance": float(100.0 * np.mean(differences)),
-            "participants_above_chance": int(np.sum(balanced > chance)),
+            "participants_above_chance": participants_above_chance,
+            "participants_total": participants_total,
             "participants_at_or_below_chance": int(np.sum(balanced <= chance)),
-            "one_sided_signflip_p_value": p_value,
+            "one_sided_exact_sign_p_value": exact_sign_p_value,
+            "one_sided_signflip_p_value": signflip_p_value,
         }
     ]
 
@@ -1608,6 +1623,28 @@ def _percent_sem_or_nan(values):
 
 def _format_counter(counter):
     return ";".join(f"{key}:{counter[key]}" for key in sorted(counter))
+
+
+def _participants_total(differences):
+    differences = np.asarray(differences, dtype=float)
+    return int(np.sum(np.isfinite(differences)))
+
+
+def _participants_above_chance(differences):
+    differences = np.asarray(differences, dtype=float)
+    finite = differences[np.isfinite(differences)]
+    return int(np.sum(finite > 0.0))
+
+
+def _one_sided_exact_sign_p_value(differences):
+    differences = np.asarray(differences, dtype=float)
+    finite = differences[np.isfinite(differences)]
+    if finite.size == 0:
+        return np.nan
+    participants_above = int(np.sum(finite > 0.0))
+    participants_total = int(finite.size)
+    tail_count = sum(comb(participants_total, k) for k in range(participants_above, participants_total + 1))
+    return float(tail_count / (2**participants_total))
 
 
 def _one_sided_signflip_p_value(differences, *, n_permutations, seed):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -211,6 +211,8 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(artifacts["group_summary"][0]["top3_accuracy_mean"], 1.0)
         self.assertEqual(artifacts["group_summary"][0]["mean_true_label_rank_mean"], 1.0)
         self.assertEqual(artifacts["group_summary"][0]["participants_above_chance"], 3)
+        self.assertEqual(artifacts["group_summary"][0]["participants_total"], 3)
+        self.assertAlmostEqual(artifacts["group_summary"][0]["one_sided_exact_sign_p_value"], 1 / 8)
         self.assertEqual({row["true_stimulus"] for row in artifacts["predictions"]}, {1, 2})
         self.assertEqual({row["predicted_stimulus"] for row in artifacts["predictions"]}, {1, 2})
         self.assertEqual({row["true_label_rank"] for row in artifacts["predictions"]}, {1.0})
@@ -307,6 +309,9 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(artifacts["group_summary"][0]["n_candidates"], 2)
         self.assertEqual(artifacts["group_summary"][0]["top2_accuracy_mean"], 1.0)
         self.assertEqual(artifacts["group_summary"][0]["top3_accuracy_mean"], 1.0)
+        self.assertEqual(artifacts["group_summary"][0]["participants_above_chance"], 4)
+        self.assertEqual(artifacts["group_summary"][0]["participants_total"], 4)
+        self.assertAlmostEqual(artifacts["group_summary"][0]["one_sided_exact_sign_p_value"], 1 / 16)
         self.assertEqual(fit_model.call_count, 16)
 
     def test_nested_cross_subject_can_evaluate_outer_subset(self):
@@ -410,7 +415,23 @@ class TestStimulusCrossSubject(unittest.TestCase):
 
         self.assertEqual(summary[0]["n_outer_folds"], 2)
         self.assertAlmostEqual(summary[0]["balanced_accuracy_mean"], 0.875)
+        self.assertEqual(summary[0]["participants_above_chance"], 2)
+        self.assertEqual(summary[0]["participants_total"], 2)
+        self.assertAlmostEqual(summary[0]["one_sided_exact_sign_p_value"], 0.25)
         self.assertLessEqual(summary[0]["one_sided_signflip_p_value"], 1.0)
+
+    def test_summarize_cross_subject_stimulus_smoke_exact_sign_all_23(self):
+        config = CrossSubjectStimulusConfig(chance_classes=16, signflip_permutations=128)
+        rows = [
+            {"balanced_accuracy": 0.10, "accuracy": 0.10, "chance_accuracy": 1 / 16}
+            for _ in range(23)
+        ]
+
+        summary = summarize_cross_subject_stimulus_smoke(rows, config=config)
+
+        self.assertEqual(summary[0]["participants_above_chance"], 23)
+        self.assertEqual(summary[0]["participants_total"], 23)
+        self.assertAlmostEqual(summary[0]["one_sided_exact_sign_p_value"], 1 / (2**23))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `participants_total` and `one_sided_exact_sign_p_value` to fixed and nested cross-subject group summaries
- keep `one_sided_signflip_p_value` as the magnitude-sensitive permutation result
- document the exact sign-test interpretation next to the sign-flip summary

## Test
- `python -m pytest tests\test_stimulus_cross_subject.py`
- `python -m ruff check src\pymegdec\stimulus_cross_subject.py tests\test_stimulus_cross_subject.py`
