### PR TITLE
Add nested label-shuffle control

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -84,6 +84,16 @@ on:
         required: false
         default: "10"
         type: string
+      label_shuffle_control:
+        description: Shuffle training labels within each participant as a nested null control.
+        required: true
+        default: false
+        type: boolean
+      label_shuffle_seed:
+        description: Seed for the nested label-shuffle control.
+        required: true
+        default: "0"
+        type: string
 
 permissions:
   contents: read
@@ -108,6 +118,8 @@ jobs:
       CLASSIFIER_PARAMS: ${{ inputs.classifier_params }}
       COMPONENTS_PCA_VALUES: ${{ inputs.components_pca_values }}
       MAX_TRIALS_PER_CLASS_PER_PARTICIPANT: ${{ inputs.max_trials_per_class_per_participant }}
+      LABEL_SHUFFLE_CONTROL: ${{ inputs.label_shuffle_control }}
+      LABEL_SHUFFLE_SEED: ${{ inputs.label_shuffle_seed }}
       MAIN_FILE_NAMES: >-
         Part1Data.mat,Part2Data.mat,Part3Data.mat,Part4Data.mat,Part6Data.mat,
         Part8Data.mat,Part9Data.mat,Part10Data.mat,Part13Data.mat,Part14Data.mat,
@@ -159,6 +171,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p outputs
+          output_prefix="outputs/stimulus_cross_subject_nested"
+          if [[ "${LABEL_SHUFFLE_CONTROL}" == "true" ]]; then
+            output_prefix="outputs/stimulus_cross_subject_nested_label_shuffle"
+          fi
           args=(
             python scripts/export_stimulus_cross_subject_nested.py
             --data-dir "${DATA_DIR}"
@@ -171,16 +187,19 @@ jobs:
             --classifiers "${CLASSIFIERS}"
             --classifier-params "${CLASSIFIER_PARAMS}"
             --components-pca-values "${COMPONENTS_PCA_VALUES}"
-            --outer-output outputs/stimulus_cross_subject_nested_outer.csv
-            --summary-output outputs/stimulus_cross_subject_nested_group_summary.csv
-            --inner-validation-output outputs/stimulus_cross_subject_nested_inner_validation.csv
-            --selected-output outputs/stimulus_cross_subject_nested_selected.csv
-            --predictions-output outputs/stimulus_cross_subject_nested_predictions.csv
-            --confusion-output outputs/stimulus_cross_subject_nested_confusion.csv
-            --per-stimulus-output outputs/stimulus_cross_subject_nested_per_stimulus.csv
-            --confusion-pairs-output outputs/stimulus_cross_subject_nested_confusion_pairs.csv
+            --outer-output "${output_prefix}_outer.csv"
+            --summary-output "${output_prefix}_group_summary.csv"
+            --inner-validation-output "${output_prefix}_inner_validation.csv"
+            --selected-output "${output_prefix}_selected.csv"
+            --predictions-output "${output_prefix}_predictions.csv"
+            --confusion-output "${output_prefix}_confusion.csv"
+            --per-stimulus-output "${output_prefix}_per_stimulus.csv"
+            --confusion-pairs-output "${output_prefix}_confusion_pairs.csv"
             --write-incremental
           )
+          if [[ "${LABEL_SHUFFLE_CONTROL}" == "true" ]]; then
+            args+=(--label-shuffle-control --label-shuffle-seed "${LABEL_SHUFFLE_SEED}")
+          fi
           if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" ]]; then
             args+=(--max-trials-per-class-per-participant "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}")
           fi
@@ -197,11 +216,15 @@ jobs:
           python - <<'PY'
           import csv
           import math
+          import os
           from pathlib import Path
 
-          summary_path = Path("outputs/stimulus_cross_subject_nested_group_summary.csv")
-          selected_path = Path("outputs/stimulus_cross_subject_nested_selected.csv")
-          pairs_path = Path("outputs/stimulus_cross_subject_nested_confusion_pairs.csv")
+          output_prefix = "stimulus_cross_subject_nested"
+          if os.environ.get("LABEL_SHUFFLE_CONTROL") == "true":
+              output_prefix = "stimulus_cross_subject_nested_label_shuffle"
+          summary_path = Path("outputs") / f"{output_prefix}_group_summary.csv"
+          selected_path = Path("outputs") / f"{output_prefix}_selected.csv"
+          pairs_path = Path("outputs") / f"{output_prefix}_confusion_pairs.csv"
           if not summary_path.exists() or not selected_path.exists():
               Path(__import__("os").environ["GITHUB_STEP_SUMMARY"]).write_text(
                   "# Stimulus cross-subject nested\n\nNo nested benchmark CSV outputs were produced.\n",
@@ -241,6 +264,8 @@ jobs:
               "| --- | ---: |",
               f"| outer folds | {summary['n_outer_folds']} |",
               f"| candidates | {summary['n_candidates']} |",
+              f"| label shuffle control | {summary.get('label_shuffle_control', os.environ.get('LABEL_SHUFFLE_CONTROL', 'false'))} |",
+              f"| label shuffle seed | {summary.get('label_shuffle_seed', os.environ.get('LABEL_SHUFFLE_SEED', ''))} |",
               f"| trial cap counts | {summary.get('max_trials_per_class_per_participant_counts', '')} |",
               f"| selected classifier counts | {summary.get('selected_classifier_counts', '')} |",
               f"| selected window center counts | {summary.get('selected_window_center_counts', '')} |",

--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -92,6 +92,14 @@ inner winner margin, defined per outer fold as the best inner balanced accuracy
 minus the second-best inner balanced accuracy, to make noisy hyperparameter
 selection visible.
 
+Add `--label-shuffle-control` to run a nested null control with the same
+participant splits and candidate grid, but with stimulus labels shuffled within
+each training participant before every model fit. Validation and outer-test
+labels remain untouched, so this control should return group performance near
+16-way chance if the pipeline is not exploiting leakage or a nonstimulus
+confound. In the manual workflow, enable `label_shuffle_control`; artifacts are
+written as `stimulus_cross_subject_nested_label_shuffle_*.csv`.
+
 ## Time-resolved decoding curve
 
 ```powershell

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -367,6 +367,12 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
     )
     parser.add_argument("--chance-classes", type=int, default=DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES, help="Number of stimulus classes used for chance level.")
     parser.add_argument("--random-state", type=int, default=0, help="Random state passed to classifiers.")
+    parser.add_argument(
+        "--label-shuffle-control",
+        action="store_true",
+        help="Shuffle training labels within each participant for a nested null-control benchmark.",
+    )
+    parser.add_argument("--label-shuffle-seed", type=int, default=0, help="Seed for the nested label-shuffle control.")
     parser.add_argument("--signflip-permutations", type=int, default=10000, help="Monte Carlo sign-flip permutations for the group summary.")
     parser.add_argument("--signflip-seed", type=int, default=0, help="Random seed for sign-flip permutations.")
     parser.add_argument("--outer-output", default="outputs/stimulus_cross_subject_nested_outer.csv", help="Untouched outer participant score CSV.")
@@ -421,6 +427,8 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         write_incremental=args.write_incremental,
         outer_participants=outer_participants,
         progress=lambda message: print(message, flush=True),
+        label_shuffle_control=args.label_shuffle_control,
+        label_shuffle_seed=args.label_shuffle_seed,
     )
     print(f"Wrote {len(artifacts['outer'])} untouched outer participant rows to {args.outer_output}")
     print(f"Wrote {len(artifacts['inner_validation'])} inner validation rows to {args.inner_validation_output}")

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -48,6 +48,8 @@ CROSS_SUBJECT_PREDICTION_GROUP_COLUMNS = (
     "classifier",
     "components_pca",
     "max_trials_per_class_per_participant",
+    "label_shuffle_control",
+    "label_shuffle_seed",
 )
 STIMULUS_METADATA_ID_COLUMNS = ("stimulus", "stimulus_id", "true_stimulus", "label", "image_id")
 
@@ -148,6 +150,8 @@ def evaluate_nested_cross_subject_stimulus(
     progress=None,
     existing_artifacts=None,
     after_outer_fold=None,
+    label_shuffle_control=False,
+    label_shuffle_seed=0,
 ):
     """Run nested LOSO model selection and evaluate each untouched outer participant once."""
 
@@ -181,6 +185,8 @@ def evaluate_nested_cross_subject_stimulus(
             feature_cache,
             inner_pair_cache,
             progress=progress,
+            label_shuffle_control=label_shuffle_control,
+            label_shuffle_seed=label_shuffle_seed,
         )
         inner_rows.extend(outer_inner_rows)
         outer_rows.append(outer_row)
@@ -378,12 +384,16 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
     components_pca_counts = _row_value_counts(outer_rows, "selected_components_pca", fallback_key="components_pca")
     trial_cap_counts = Counter(str(row["max_trials_per_class_per_participant"]) for row in outer_rows)
     winner_margins = _finite_metric_values(outer_rows, "selected_inner_winner_margin")
+    label_shuffle_control = _single_row_value(outer_rows, "label_shuffle_control", default=False)
+    label_shuffle_seed = _single_row_value(outer_rows, "label_shuffle_seed", default="")
     return [
         {
             "n_outer_folds": len(outer_rows),
             "n_test_participants": len(outer_rows),
             "selection_mode": "nested_loso",
             "selection_metric": DEFAULT_CROSS_SUBJECT_SELECTION_METRIC,
+            "label_shuffle_control": label_shuffle_control,
+            "label_shuffle_seed": label_shuffle_seed,
             "n_candidates": int(max(int(row["n_candidates"]) for row in outer_rows)),
             "selected_candidate_counts": _format_counter(selected_counts),
             "selected_classifier_counts": _format_counter(classifier_counts),
@@ -847,6 +857,8 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
     write_incremental=False,
     outer_participants=None,
     progress=None,
+    label_shuffle_control=False,
+    label_shuffle_seed=0,
 ):
     """Run nested LOSO cross-subject decoding and write compact CSV artifacts."""
 
@@ -882,6 +894,8 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
         progress=progress,
         existing_artifacts=existing_artifacts,
         after_outer_fold=write_outputs if write_incremental else None,
+        label_shuffle_control=label_shuffle_control,
+        label_shuffle_seed=label_shuffle_seed,
     )
     write_outputs(artifacts)
     return artifacts
@@ -905,7 +919,17 @@ def _load_feature_cache(data_folder, participants, candidate_configs, *, progres
     return feature_cache
 
 
-def _evaluate_nested_outer_fold(test_participant, participants, candidate_configs, feature_cache, inner_pair_cache, *, progress=None):
+def _evaluate_nested_outer_fold(
+    test_participant,
+    participants,
+    candidate_configs,
+    feature_cache,
+    inner_pair_cache,
+    *,
+    progress=None,
+    label_shuffle_control=False,
+    label_shuffle_seed=0,
+):
     if progress is not None:
         progress(f"START outer_test_participant={test_participant}")
     outer_train_participants = tuple(participant for participant in participants if participant != test_participant)
@@ -916,6 +940,8 @@ def _evaluate_nested_outer_fold(test_participant, participants, candidate_config
         feature_cache,
         inner_pair_cache,
         progress=progress,
+        label_shuffle_control=label_shuffle_control,
+        label_shuffle_seed=label_shuffle_seed,
     )
     selected_row = _select_nested_candidate(outer_inner_rows)
     selected_config = candidate_configs[int(selected_row["selected_candidate_index"]) - 1]
@@ -928,6 +954,8 @@ def _evaluate_nested_outer_fold(test_participant, participants, candidate_config
         config=selected_config,
         classifier_param=_resolved_classifier_param(selected_config),
         include_predictions=True,
+        label_shuffle_seed=label_shuffle_seed if label_shuffle_control else None,
+        label_shuffle_context=(int(test_participant), int(selected_row["selected_candidate_index"]), 0),
     )
     _add_selected_candidate_fields(outer_row, selected_row)
     for prediction_row in participant_predictions:
@@ -942,7 +970,17 @@ def _evaluate_nested_outer_fold(test_participant, participants, candidate_config
     return outer_row, outer_inner_rows, selected_row, participant_predictions
 
 
-def _evaluate_nested_inner_rows(test_participant, outer_train_participants, candidate_configs, feature_cache, inner_pair_cache, *, progress=None):
+def _evaluate_nested_inner_rows(
+    test_participant,
+    outer_train_participants,
+    candidate_configs,
+    feature_cache,
+    inner_pair_cache,
+    *,
+    progress=None,
+    label_shuffle_control=False,
+    label_shuffle_seed=0,
+):
     inner_rows = []
     completed = 0
     total = len(candidate_configs) * len(outer_train_participants)
@@ -950,7 +988,15 @@ def _evaluate_nested_inner_rows(test_participant, outer_train_participants, cand
         feature_sets = feature_cache[_feature_cache_key(candidate_config)]
         for validation_participant in outer_train_participants:
             excluded_pair = tuple(sorted((int(test_participant), int(validation_participant))))
-            pair_rows = _cached_nested_pair_rows(candidate_index, candidate_config, excluded_pair, feature_sets, inner_pair_cache)
+            pair_rows = _cached_nested_pair_rows(
+                candidate_index,
+                candidate_config,
+                excluded_pair,
+                feature_sets,
+                inner_pair_cache,
+                label_shuffle_control=label_shuffle_control,
+                label_shuffle_seed=label_shuffle_seed,
+            )
             inner_rows.append(pair_rows[(int(test_participant), int(validation_participant))])
             completed += 1
             if progress is not None:
@@ -964,11 +1010,26 @@ def _evaluate_nested_inner_rows(test_participant, outer_train_participants, cand
     return inner_rows
 
 
-def _cached_nested_pair_rows(candidate_index, candidate_config, excluded_pair, feature_sets, inner_pair_cache):
-    cache_key = (int(candidate_index), tuple(excluded_pair))
+def _cached_nested_pair_rows(
+    candidate_index,
+    candidate_config,
+    excluded_pair,
+    feature_sets,
+    inner_pair_cache,
+    *,
+    label_shuffle_control=False,
+    label_shuffle_seed=0,
+):
+    cache_key = (int(candidate_index), tuple(excluded_pair), bool(label_shuffle_control), int(label_shuffle_seed))
     if cache_key not in inner_pair_cache:
         train_sets = [feature_set for participant, feature_set in feature_sets.items() if int(participant) not in excluded_pair]
-        fitted_model = _fit_outer_fold_model(train_sets, candidate_config, _resolved_classifier_param(candidate_config))
+        fitted_model = _fit_outer_fold_model(
+            train_sets,
+            candidate_config,
+            _resolved_classifier_param(candidate_config),
+            label_shuffle_seed=label_shuffle_seed if label_shuffle_control else None,
+            label_shuffle_context=(int(candidate_index), *tuple(int(participant) for participant in excluded_pair)),
+        )
         first_participant, second_participant = excluded_pair
         pair_rows = {}
         for outer_test_participant, validation_participant in (
@@ -989,6 +1050,15 @@ def _cached_nested_pair_rows(candidate_index, candidate_config, excluded_pair, f
             )
         inner_pair_cache[cache_key] = pair_rows
     return inner_pair_cache[cache_key]
+
+
+def _training_labels(feature_set, *, label_shuffle_seed=None, label_shuffle_context=()):
+    labels = np.asarray(feature_set.labels, dtype=int)
+    if label_shuffle_seed is None:
+        return labels
+    seed_values = [int(label_shuffle_seed), *[int(value) for value in label_shuffle_context], int(feature_set.participant)]
+    rng = np.random.default_rng(np.random.SeedSequence(seed_values))
+    return rng.permutation(labels)
 
 
 def _feature_cache_key(config):
@@ -1063,6 +1133,8 @@ def _select_nested_candidate(inner_rows):
                 "selected_classifier_param": example["classifier_param"],
                 "selected_components_pca": example["components_pca"],
                 "selected_max_trials_per_class_per_participant": example["max_trials_per_class_per_participant"],
+                "label_shuffle_control": example.get("label_shuffle_control", False),
+                "label_shuffle_seed": example.get("label_shuffle_seed", ""),
             }
         )
     ranked = sorted(
@@ -1092,14 +1164,37 @@ def _add_selected_candidate_fields(row, selected_row):
         row[key] = value
 
 
-def _evaluate_outer_fold(train_sets, test_set, *, config, classifier_param, include_predictions=True):
-    fitted_model = _fit_outer_fold_model(train_sets, config, classifier_param)
+def _evaluate_outer_fold(
+    train_sets,
+    test_set,
+    *,
+    config,
+    classifier_param,
+    include_predictions=True,
+    label_shuffle_seed=None,
+    label_shuffle_context=(),
+):
+    fitted_model = _fit_outer_fold_model(
+        train_sets,
+        config,
+        classifier_param,
+        label_shuffle_seed=label_shuffle_seed,
+        label_shuffle_context=label_shuffle_context,
+    )
     return _score_outer_fold_model(fitted_model, test_set, config, include_predictions=include_predictions)
 
 
-def _fit_outer_fold_model(train_sets, config, classifier_param):
+def _fit_outer_fold_model(train_sets, config, classifier_param, *, label_shuffle_seed=None, label_shuffle_context=()):
     train_features = np.vstack([_normalized_subject_features(feature_set, config) for feature_set in train_sets])
-    train_labels_one_based = np.concatenate([feature_set.labels for feature_set in train_sets])
+    train_label_arrays = [
+        _training_labels(
+            feature_set,
+            label_shuffle_seed=label_shuffle_seed,
+            label_shuffle_context=label_shuffle_context,
+        )
+        for feature_set in train_sets
+    ]
+    train_labels_one_based = np.concatenate(train_label_arrays)
     train_labels = train_labels_one_based - 1
 
     train_window = _centered_window(config.window_center, config.window_size)
@@ -1124,6 +1219,8 @@ def _fit_outer_fold_model(train_sets, config, classifier_param):
         "train_labels": train_labels,
         "train_participants": tuple(feature_set.participant for feature_set in train_sets),
         "train_window": train_window,
+        "label_shuffle_control": label_shuffle_seed is not None,
+        "label_shuffle_seed": "" if label_shuffle_seed is None else int(label_shuffle_seed),
     }
 
 
@@ -1191,6 +1288,8 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
         "n_channels": test_set.n_channels,
         "n_window_samples": test_set.n_window_samples,
         "n_baseline_samples": test_set.n_baseline_samples,
+        "label_shuffle_control": bool(fitted_model["label_shuffle_control"]),
+        "label_shuffle_seed": fitted_model["label_shuffle_seed"],
     }
     prediction_rows = []
     if include_predictions:
@@ -1668,6 +1767,21 @@ def _row_value_counts(rows, key, *, fallback_key=None, transform=str):
         except (TypeError, ValueError):
             continue
     return Counter(values)
+
+
+def _single_row_value(rows, key, *, default=""):
+    values = []
+    for row in rows:
+        value = row.get(key, default)
+        if value in (None, ""):
+            continue
+        if value not in values:
+            values.append(value)
+    if not values:
+        return default
+    if len(values) == 1:
+        return values[0]
+    return ";".join(str(value) for value in values)
 
 
 def _participants_total(differences):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -355,6 +355,41 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(len(artifacts["predictions"]), 8)
         self.assertEqual(artifacts["group_summary"][0]["n_outer_folds"], 2)
 
+    def test_nested_cross_subject_label_shuffle_control_marks_outputs(self):
+        data_by_participant = {
+            1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),
+            2: _mat_data([1, 2, 1, 2], [-1.0, 1.0, -0.9, 0.9]),
+            3: _mat_data([1, 2, 1, 2], [-1.3, 1.3, -1.2, 1.2]),
+        }
+        candidate_configs = make_cross_subject_candidate_configs(
+            window_centers=(0.1, 0.2),
+            window_size=0.1,
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multiclass-svm",),
+            classifier_params=(0.5,),
+            components_pca_values=(float("inf"),),
+            chance_classes=2,
+            signflip_permutations=128,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            artifacts = evaluate_nested_cross_subject_stimulus(
+                "unused",
+                [1, 2, 3],
+                candidate_configs=candidate_configs,
+                label_shuffle_control=True,
+                label_shuffle_seed=11,
+            )
+
+        self.assertEqual({row["label_shuffle_control"] for row in artifacts["outer"]}, {True})
+        self.assertEqual({row["label_shuffle_seed"] for row in artifacts["outer"]}, {11})
+        self.assertEqual({row["label_shuffle_control"] for row in artifacts["inner_validation"]}, {True})
+        self.assertEqual({row["label_shuffle_seed"] for row in artifacts["inner_validation"]}, {11})
+        self.assertEqual(artifacts["group_summary"][0]["label_shuffle_control"], True)
+        self.assertEqual(artifacts["group_summary"][0]["label_shuffle_seed"], 11)
+        self.assertEqual({row["true_stimulus"] for row in artifacts["predictions"]}, {1, 2})
+
     def test_nested_export_resumes_existing_outer_rows(self):
         data_by_participant = {
             1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),


### PR DESCRIPTION
## Summary
- add a nested label-shuffle control that permutes training labels within each participant before every model fit
- keep validation and outer-test labels untouched so the control tests leakage/confounds in the full nested pipeline
- expose `--label-shuffle-control` / `--label-shuffle-seed` in the CLI and manual nested workflow
- write label-shuffle workflow outputs as `stimulus_cross_subject_nested_label_shuffle_*.csv`
- carry label-shuffle metadata through inner, selected, outer, prediction, and group-summary rows

## Test
- `python -m pytest tests\test_stimulus_cross_subject.py`
- `python -m ruff check src\pymegdec\stimulus_cross_subject.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject.py`
- workflow YAML parse check for `.github/workflows/stimulus-cross-subject-nested.yml`
