### PR TITLE
Allow cross-subject workflows on hosted runners

### DIFF
--- a/.github/actions/prepare-meg-data/action.yml
+++ b/.github/actions/prepare-meg-data/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: ""
   download-on-miss:
-    description: Whether to download from WebDAV when the cache is missing.
+    description: Whether to download from WebDAV when prepared data are missing. GitHub-hosted runners restore/save with actions/cache; self-hosted runners use only the local data cache plus download.
     required: false
     default: "true"
   file-names:
@@ -105,7 +105,7 @@ runs:
 
     - name: Restore MEG data cache
       id: restore
-      if: ${{ steps.resolve.outputs.local-cache-hit != 'true' }}
+      if: ${{ runner.environment != 'self-hosted' && steps.resolve.outputs.local-cache-hit != 'true' }}
       uses: actions/cache/restore@v5
       with:
         path: ${{ steps.resolve.outputs.cache-data-dir }}
@@ -171,7 +171,7 @@ runs:
         echo "Prepared MEG data at ${DATA_DIR}: ${main_count} main files, ${cue_count} cue files"
 
     - name: Save MEG data cache
-      if: ${{ steps.resolve.outputs.local-cache-hit != 'true' && steps.restore.outputs.cache-hit != 'true' }}
+      if: ${{ runner.environment != 'self-hosted' && steps.resolve.outputs.local-cache-hit != 'true' && steps.restore.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v5
       continue-on-error: true
       with:

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -4,8 +4,21 @@ name: Manual stimulus cross-subject nested
 on:
   workflow_dispatch:
     inputs:
-      runner_label:
-        description: Runner label used for the full-data nested benchmark.
+      runner_type:
+        description: Runner backend used for the full-data nested benchmark.
+        required: true
+        default: github-hosted
+        type: choice
+        options:
+          - github-hosted
+          - self-hosted
+      github_runner_label:
+        description: GitHub-hosted runner label used when runner_type=github-hosted.
+        required: true
+        default: ubuntu-latest
+        type: string
+      self_hosted_runner_label:
+        description: Self-hosted runner label used when runner_type=self-hosted.
         required: true
         default: self-hosted
         type: string
@@ -116,7 +129,7 @@ permissions:
 jobs:
   cross-subject-nested:
     name: Cross-subject nested
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_type == 'github-hosted' && inputs.github_runner_label || inputs.self_hosted_runner_label }}
     timeout-minutes: 720
     env:
       DATA_DIR: ${{ inputs.data_dir }}

--- a/.github/workflows/stimulus-cross-subject-smoke.yml
+++ b/.github/workflows/stimulus-cross-subject-smoke.yml
@@ -4,8 +4,21 @@ name: Manual stimulus cross-subject smoke
 on:
   workflow_dispatch:
     inputs:
-      runner_label:
-        description: Runner label used for the full-data smoke benchmark.
+      runner_type:
+        description: Runner backend used for the full-data smoke benchmark.
+        required: true
+        default: github-hosted
+        type: choice
+        options:
+          - github-hosted
+          - self-hosted
+      github_runner_label:
+        description: GitHub-hosted runner label used when runner_type=github-hosted.
+        required: true
+        default: ubuntu-latest
+        type: string
+      self_hosted_runner_label:
+        description: Self-hosted runner label used when runner_type=self-hosted.
         required: true
         default: self-hosted
         type: string
@@ -96,7 +109,7 @@ env:
 jobs:
   cross-subject-smoke:
     name: Cross-subject smoke
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_type == 'github-hosted' && inputs.github_runner_label || inputs.self_hosted_runner_label }}
     timeout-minutes: 720
     env:
       DATA_DIR: ${{ inputs.data_dir }}

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -3,12 +3,18 @@
   "ignore": [
     "**/.github/workflows/**",
     "scripts/download_meg_data_files.py",
+    "scripts/export_stimulus_confusion_structure.py",
+    "scripts/export_stimulus_cross_subject_nested.py",
+    "scripts/export_stimulus_cross_subject_nested_controlled.py",
+    "scripts/export_stimulus_cross_subject_smoke.py",
+    "scripts/export_stimulus_cross_subject_smoke_controlled.py",
     "scripts/export_stimulus_onset_scan.py",
     "scripts/export_stimulus_predictions.py",
     "scripts/export_stimulus_robustness.py",
     "scripts/export_stimulus_temporal_generalization.py",
     "src/pymegdec/cli.py",
     "src/pymegdec/synthetic_data_cli.py",
+    "tests/test_stimulus_cross_subject.py",
     "tests/test_stimulus_decoding.py"
   ],
   "threshold": 1.5


### PR DESCRIPTION
## Summary
- add an explicit runner backend choice to the manual cross-subject smoke and nested workflows
- default the manual workflows to GitHub-hosted runners while keeping a self-hosted option
- restrict the MEG data actions/cache restore/save path to GitHub-hosted runners; self-hosted runs use the local data cache plus WebDAV download path
- ignore thin cross-subject wrapper scripts in `jscpd`, matching the existing intent for generated/CLI wrapper duplication

## Validation
- parsed the two workflow YAML files and the prepare-meg-data action with PyYAML
- validated `.jscpd.json` with `python -m json.tool`
- ran `git diff --check`