### PR TITLE
Fix workflow arguments for negative time windows

### DIFF
--- a/.github/workflows/stimulus-cross-subject-alignment-benchmarks.yml
+++ b/.github/workflows/stimulus-cross-subject-alignment-benchmarks.yml
@@ -241,7 +241,7 @@ jobs:
             --participants "${PARTICIPANTS}"
             --window-center "${WINDOW_CENTER}"
             --window-size "${WINDOW_SIZE}"
-            --baseline-window "${BASELINE_WINDOW}"
+            "--baseline-window=${BASELINE_WINDOW}"
             --feature-mode "${FEATURE_MODE}"
             --normalization "${NORMALIZATION}"
             --classifier "${CLASSIFIER}"

--- a/.github/workflows/stimulus-cross-subject-time-resolved.yml
+++ b/.github/workflows/stimulus-cross-subject-time-resolved.yml
@@ -209,9 +209,9 @@ jobs:
             python scripts/export_stimulus_cross_subject_time_resolved.py
             --data-dir "${DATA_DIR}"
             --participants "${PARTICIPANTS}"
-            --window-centers "${WINDOW_CENTERS}"
+            "--window-centers=${WINDOW_CENTERS}"
             --window-size "${WINDOW_SIZE}"
-            --baseline-window "${BASELINE_WINDOW}"
+            "--baseline-window=${BASELINE_WINDOW}"
             --feature-mode "${FEATURE_MODE}"
             --normalization "${NORMALIZATION}"
             --alignment "${ALIGNMENT}"


### PR DESCRIPTION
Fixes manual workflow invocations that passed comma-separated negative time-window values as separate arguments. Argparse can treat values such as -0.5,0.0 as options, causing the Procrustes time-resolved workflow to fail before decoding starts. This passes the affected values using --flag=value form in the time-resolved and combined alignment workflows.