### PR TITLE
Add cue-calibrated shared-space decoding

### DIFF
--- a/.github/workflows/stimulus-cross-subject-alignment-benchmarks.yml
+++ b/.github/workflows/stimulus-cross-subject-alignment-benchmarks.yml
@@ -65,6 +65,12 @@ on:
         required: true
         default: "0.1"
         type: string
+      alignment_data:
+        description: Files used to fit shared-space alignment projections.
+        required: true
+        default: main
+        type: choice
+        options: [main, cue]
       baseline_window:
         description: Baseline normalization window as start,stop in seconds.
         required: true
@@ -98,7 +104,7 @@ on:
         default: "64"
         type: string
       max_trials_per_class_per_participant:
-        description: Optional screening trial cap per stimulus class and participant. Empty means all trials.
+        description: Optional screening trial cap per stimulus class and participant. Use all/none for all trials.
         required: false
         default: "10"
         type: string
@@ -146,6 +152,7 @@ jobs:
       OUTER_PARTICIPANTS: ${{ inputs.outer_participants }}
       WINDOW_CENTER: ${{ inputs.window_center }}
       WINDOW_SIZE: ${{ inputs.window_size }}
+      ALIGNMENT_DATA: ${{ inputs.alignment_data }}
       BASELINE_WINDOW: ${{ inputs.baseline_window }}
       FEATURE_MODE: ${{ inputs.feature_mode }}
       NORMALIZATION: ${{ inputs.normalization }}
@@ -164,22 +171,29 @@ jobs:
         Part15Data.mat,Part16Data.mat,Part17Data.mat,Part18Data.mat,Part19Data.mat,
         Part20Data.mat,Part21Data.mat,Part22Data.mat,Part23Data.mat,Part24Data.mat,
         Part25Data.mat,Part26Data.mat,Part27Data.mat
+      CUE_FILE_NAMES: >-
+        Part1CueData.mat,Part2CueData.mat,Part3CueData.mat,Part4CueData.mat,Part6CueData.mat,
+        Part8CueData.mat,Part9CueData.mat,Part10CueData.mat,Part13CueData.mat,Part14CueData.mat,
+        Part15CueData.mat,Part16CueData.mat,Part17CueData.mat,Part18CueData.mat,Part19CueData.mat,
+        Part20CueData.mat,Part21CueData.mat,Part22CueData.mat,Part23CueData.mat,Part24CueData.mat,
+        Part25CueData.mat,Part26CueData.mat,Part27CueData.mat
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Prepare main MEG data
+      - name: Prepare MEG data
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
         timeout-minutes: 90
         uses: ./.github/actions/prepare-meg-data
         with:
           data-dir: ${{ env.DATA_DIR }}
           cache-version: ${{ env.DATA_CACHE_VERSION }}
-          cache-key: meg-data-main-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-          file-names: ${{ env.MAIN_FILE_NAMES }}
-          require-cue-files: "false"
+          cache-key: ${{ inputs.alignment_data == 'cue' && format('meg-data-main-cue-{0}-{1}', runner.os, env.DATA_CACHE_VERSION) || format('meg-data-main-{0}-{1}', runner.os, env.DATA_CACHE_VERSION) }}
+          file-names: ${{ inputs.alignment_data == 'cue' && format('{0},{1}', env.MAIN_FILE_NAMES, env.CUE_FILE_NAMES) || env.MAIN_FILE_NAMES }}
+          require-cue-files: ${{ inputs.alignment_data == 'cue' && 'true' || 'false' }}
           expected-main-files: "23"
+          expected-cue-files: "23"
           webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
           webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
           webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
@@ -196,13 +210,18 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .
 
-      - name: Validate main data files
+      - name: Validate MEG data files
         shell: bash
         run: |
           set -euo pipefail
           main_count="$(find -L "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+          cue_count="$(find -L "${DATA_DIR}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
           echo "Main files: ${main_count}"
+          echo "Cue files: ${cue_count}"
           test "${main_count}" -ge 23
+          if [[ "${ALIGNMENT_DATA}" == "cue" ]]; then
+            test "${cue_count}" -ge 23
+          fi
 
       - name: Run alignment benchmarks
         shell: bash
@@ -241,6 +260,7 @@ jobs:
             --participants "${PARTICIPANTS}"
             --window-center "${WINDOW_CENTER}"
             --window-size "${WINDOW_SIZE}"
+            --alignment-data "${ALIGNMENT_DATA}"
             "--baseline-window=${BASELINE_WINDOW}"
             --feature-mode "${FEATURE_MODE}"
             --normalization "${NORMALIZATION}"
@@ -254,7 +274,7 @@ jobs:
           if [[ -n "${CLASSIFIER_PARAM}" && "${CLASSIFIER_PARAM}" != "default" ]]; then
             common_args+=(--classifier-param "${CLASSIFIER_PARAM}")
           fi
-          if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" ]]; then
+          if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" && "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" != "all" && "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" != "none" ]]; then
             common_args+=(--max-trials-per-class-per-participant "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}")
           fi
           if [[ "${LABEL_SHUFFLE_CONTROL}" == "true" ]]; then
@@ -323,7 +343,8 @@ jobs:
           lines = [
               "# Stimulus cross-subject alignment benchmarks",
               "",
-              "LOSO image-identity decoding using only `Part*Data.mat` with shared-space alignment methods.",
+              "LOSO image-identity decoding on `Part*Data.mat` with shared-space alignment methods.",
+              f"Alignment data: `{os.environ.get('ALIGNMENT_DATA', 'main')}`.",
               "",
               "| method | folds | chance | balanced accuracy | SEM | participants above chance | sign-flip p |",
               "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",

--- a/.github/workflows/stimulus-hyperalignment-grid.yml
+++ b/.github/workflows/stimulus-hyperalignment-grid.yml
@@ -75,6 +75,12 @@ on:
         required: false
         default: ""
         type: string
+      alignment_data:
+        description: Files used to fit hyperalignment projections.
+        required: true
+        default: main
+        type: choice
+        options: [main, cue]
       baseline_window:
         description: Baseline normalization window as start,stop in seconds.
         required: true
@@ -108,7 +114,7 @@ on:
         default: "64"
         type: string
       max_trials_per_class_per_participant:
-        description: Optional screening trial cap per stimulus class and participant. Empty means all trials.
+        description: Optional screening trial cap per stimulus class and participant. Use all/none for all trials.
         required: false
         default: "10"
         type: string
@@ -196,6 +202,7 @@ jobs:
       WINDOW_SIZE: ${{ inputs.window_size }}
       ALIGNMENT_WINDOW_CENTER: ${{ inputs.alignment_window_center }}
       ALIGNMENT_WINDOW_SIZE: ${{ inputs.alignment_window_size }}
+      ALIGNMENT_DATA: ${{ inputs.alignment_data }}
       BASELINE_WINDOW: ${{ inputs.baseline_window }}
       FEATURE_MODE: ${{ inputs.feature_mode }}
       NORMALIZATION: ${{ inputs.normalization }}
@@ -211,22 +218,29 @@ jobs:
         Part15Data.mat,Part16Data.mat,Part17Data.mat,Part18Data.mat,Part19Data.mat,
         Part20Data.mat,Part21Data.mat,Part22Data.mat,Part23Data.mat,Part24Data.mat,
         Part25Data.mat,Part26Data.mat,Part27Data.mat
+      CUE_FILE_NAMES: >-
+        Part1CueData.mat,Part2CueData.mat,Part3CueData.mat,Part4CueData.mat,Part6CueData.mat,
+        Part8CueData.mat,Part9CueData.mat,Part10CueData.mat,Part13CueData.mat,Part14CueData.mat,
+        Part15CueData.mat,Part16CueData.mat,Part17CueData.mat,Part18CueData.mat,Part19CueData.mat,
+        Part20CueData.mat,Part21CueData.mat,Part22CueData.mat,Part23CueData.mat,Part24CueData.mat,
+        Part25CueData.mat,Part26CueData.mat,Part27CueData.mat
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Prepare main MEG data
+      - name: Prepare MEG data
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
         timeout-minutes: 90
         uses: ./.github/actions/prepare-meg-data
         with:
           data-dir: ${{ env.DATA_DIR }}
           cache-version: ${{ env.DATA_CACHE_VERSION }}
-          cache-key: ${{ env.DATA_CACHE_KIND }}-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-          file-names: ${{ env.MAIN_FILE_NAMES }}
-          require-cue-files: "false"
+          cache-key: ${{ inputs.alignment_data == 'cue' && format('{0}-cue-{1}-{2}', env.DATA_CACHE_KIND, runner.os, env.DATA_CACHE_VERSION) || format('{0}-{1}-{2}', env.DATA_CACHE_KIND, runner.os, env.DATA_CACHE_VERSION) }}
+          file-names: ${{ inputs.alignment_data == 'cue' && format('{0},{1}', env.MAIN_FILE_NAMES, env.CUE_FILE_NAMES) || env.MAIN_FILE_NAMES }}
+          require-cue-files: ${{ inputs.alignment_data == 'cue' && 'true' || 'false' }}
           expected-main-files: "23"
+          expected-cue-files: "23"
           webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
           webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
           webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
@@ -243,13 +257,18 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .
 
-      - name: Validate main data files
+      - name: Validate MEG data files
         shell: bash
         run: |
           set -euo pipefail
           main_count="$(find -L "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+          cue_count="$(find -L "${DATA_DIR}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
           echo "Main files: ${main_count}"
+          echo "Cue files: ${cue_count}"
           test "${main_count}" -ge 23
+          if [[ "${ALIGNMENT_DATA}" == "cue" ]]; then
+            test "${cue_count}" -ge 23
+          fi
 
       - name: Run hyperalignment grid variant
         shell: bash
@@ -268,6 +287,7 @@ jobs:
             --participants "${PARTICIPANTS}"
             --window-center "${WINDOW_CENTER}"
             --window-size "${WINDOW_SIZE}"
+            --alignment-data "${ALIGNMENT_DATA}"
             --baseline-window="${BASELINE_WINDOW}"
             --feature-mode "${FEATURE_MODE}"
             --normalization "${NORMALIZATION}"
@@ -292,7 +312,7 @@ jobs:
           if [[ -n "${CLASSIFIER_PARAM}" && "${CLASSIFIER_PARAM}" != "default" ]]; then
             args+=(--classifier-param "${CLASSIFIER_PARAM}")
           fi
-          if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" ]]; then
+          if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" && "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" != "all" && "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" != "none" ]]; then
             args+=(--max-trials-per-class-per-participant "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}")
           fi
           if [[ -n "${ALIGNMENT_WINDOW_CENTER}" ]]; then

--- a/.github/workflows/stimulus-mcca-grid.yml
+++ b/.github/workflows/stimulus-mcca-grid.yml
@@ -75,6 +75,12 @@ on:
         required: false
         default: ""
         type: string
+      alignment_data:
+        description: Files used to fit M-CCA alignment projections.
+        required: true
+        default: main
+        type: choice
+        options: [main, cue]
       baseline_window:
         description: Baseline normalization window as start,stop in seconds.
         required: true
@@ -108,7 +114,7 @@ on:
         default: "64"
         type: string
       max_trials_per_class_per_participant:
-        description: Optional screening trial cap per stimulus class and participant. Empty means all trials.
+        description: Optional screening trial cap per stimulus class and participant. Use all/none for all trials.
         required: false
         default: "10"
         type: string
@@ -196,6 +202,7 @@ jobs:
       WINDOW_SIZE: ${{ inputs.window_size }}
       ALIGNMENT_WINDOW_CENTER: ${{ inputs.alignment_window_center }}
       ALIGNMENT_WINDOW_SIZE: ${{ inputs.alignment_window_size }}
+      ALIGNMENT_DATA: ${{ inputs.alignment_data }}
       BASELINE_WINDOW: ${{ inputs.baseline_window }}
       FEATURE_MODE: ${{ inputs.feature_mode }}
       NORMALIZATION: ${{ inputs.normalization }}
@@ -211,22 +218,29 @@ jobs:
         Part15Data.mat,Part16Data.mat,Part17Data.mat,Part18Data.mat,Part19Data.mat,
         Part20Data.mat,Part21Data.mat,Part22Data.mat,Part23Data.mat,Part24Data.mat,
         Part25Data.mat,Part26Data.mat,Part27Data.mat
+      CUE_FILE_NAMES: >-
+        Part1CueData.mat,Part2CueData.mat,Part3CueData.mat,Part4CueData.mat,Part6CueData.mat,
+        Part8CueData.mat,Part9CueData.mat,Part10CueData.mat,Part13CueData.mat,Part14CueData.mat,
+        Part15CueData.mat,Part16CueData.mat,Part17CueData.mat,Part18CueData.mat,Part19CueData.mat,
+        Part20CueData.mat,Part21CueData.mat,Part22CueData.mat,Part23CueData.mat,Part24CueData.mat,
+        Part25CueData.mat,Part26CueData.mat,Part27CueData.mat
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Prepare main MEG data
+      - name: Prepare MEG data
         if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
         timeout-minutes: 90
         uses: ./.github/actions/prepare-meg-data
         with:
           data-dir: ${{ env.DATA_DIR }}
           cache-version: ${{ env.DATA_CACHE_VERSION }}
-          cache-key: ${{ env.DATA_CACHE_KIND }}-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-          file-names: ${{ env.MAIN_FILE_NAMES }}
-          require-cue-files: "false"
+          cache-key: ${{ inputs.alignment_data == 'cue' && format('{0}-cue-{1}-{2}', env.DATA_CACHE_KIND, runner.os, env.DATA_CACHE_VERSION) || format('{0}-{1}-{2}', env.DATA_CACHE_KIND, runner.os, env.DATA_CACHE_VERSION) }}
+          file-names: ${{ inputs.alignment_data == 'cue' && format('{0},{1}', env.MAIN_FILE_NAMES, env.CUE_FILE_NAMES) || env.MAIN_FILE_NAMES }}
+          require-cue-files: ${{ inputs.alignment_data == 'cue' && 'true' || 'false' }}
           expected-main-files: "23"
+          expected-cue-files: "23"
           webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
           webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
           webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
@@ -243,13 +257,18 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .
 
-      - name: Validate main data files
+      - name: Validate MEG data files
         shell: bash
         run: |
           set -euo pipefail
           main_count="$(find -L "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+          cue_count="$(find -L "${DATA_DIR}" -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
           echo "Main files: ${main_count}"
+          echo "Cue files: ${cue_count}"
           test "${main_count}" -ge 23
+          if [[ "${ALIGNMENT_DATA}" == "cue" ]]; then
+            test "${cue_count}" -ge 23
+          fi
 
       - name: Run M-CCA grid variant
         shell: bash
@@ -268,6 +287,7 @@ jobs:
             --participants "${PARTICIPANTS}"
             --window-center "${WINDOW_CENTER}"
             --window-size "${WINDOW_SIZE}"
+            --alignment-data "${ALIGNMENT_DATA}"
             --baseline-window="${BASELINE_WINDOW}"
             --feature-mode "${FEATURE_MODE}"
             --normalization "${NORMALIZATION}"
@@ -291,7 +311,7 @@ jobs:
           if [[ -n "${CLASSIFIER_PARAM}" && "${CLASSIFIER_PARAM}" != "default" ]]; then
             args+=(--classifier-param "${CLASSIFIER_PARAM}")
           fi
-          if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" ]]; then
+          if [[ -n "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" && "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" != "all" && "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}" != "none" ]]; then
             args+=(--max-trials-per-class-per-participant "${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}")
           fi
           if [[ -n "${ALIGNMENT_WINDOW_CENTER}" ]]; then

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -21,6 +21,7 @@
     "src/pymegdec/stimulus_hyperalignment.py",
     "src/pymegdec/stimulus_mcca.py",
     "src/pymegdec/synthetic_data_cli.py",
+    "tests/test_stimulus_alignment_benchmarks.py",
     "tests/test_stimulus_cross_subject.py",
     "tests/test_stimulus_decoding.py"
   ],

--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -205,6 +205,31 @@ own unlabeled feature mean before projecting into the group space; use
 `label_shuffle_control` to check whether the shared-space pipeline returns
 near-chance performance when training labels are shuffled within participants.
 
+Set `--alignment-data cue` to fit the M-CCA or hyperalignment projections from
+the independent `Part*CueData.mat` files instead of the scored main-task files.
+In that mode, source and held-out participants are projected using cue-file
+class anchors, while the classifier is trained on source participants'
+`Part*Data.mat` trials and evaluated on all held-out `Part*Data.mat` trials:
+
+```bash
+pymegdec stimulus cross-subject-mcca \
+  --participants 1-4,6,8,9,10,13-27 \
+  --window-center 0.175 \
+  --window-size 0.1 \
+  --alignment-data cue \
+  --feature-mode sensor_flat \
+  --normalization subject_baseline_z \
+  --classifier multiclass-svm \
+  --components-pca 64 \
+  --mcca-components 64 \
+  --mcca-regularization 1e-6
+```
+
+The manual alignment benchmark and M-CCA/hyperalignment grid workflows expose
+the same `alignment_data` input. When `alignment_data=cue`, the workflows request
+both `Part*Data.mat` and `Part*CueData.mat` from the configured data source and
+require all 23 main/cue subject files before running.
+
 ## Confusion structure
 
 Use the confusion-structure export on trial prediction CSVs to check whether

--- a/poetry.lock
+++ b/poetry.lock
@@ -2285,11 +2285,17 @@ numpy = "*"
 pandas = "*"
 scikit-learn = "*"
 
+[package.extras]
+all = ["pytorch-lightning", "torch", "xgboost"]
+ml = ["pytorch-lightning", "torch", "xgboost"]
+torch = ["pytorch-lightning", "torch"]
+xgboost = ["xgboost"]
+
 [package.source]
 type = "git"
 url = "https://github.com/IPS-Stuttgart/RepTrace.git"
-reference = "500323f2932d51bac9170ed81d5704c035bf12f5"
-resolved_reference = "500323f2932d51bac9170ed81d5704c035bf12f5"
+reference = "main"
+resolved_reference = "e50bc1ea95926ec2e2b9acab344f8a843bb7efe5"
 
 [[package]]
 name = "requests"
@@ -2867,4 +2873,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "d69c2e1487390e55591129707e79a86413477861d85b517b1a1c86a87b241dbe"
+content-hash = "1ac5f76e8e285824cae06ea6c687619f73b721e3da733a879d4a102864a6f0f0"

--- a/scripts/run_alignment_loso_benchmarks.sh
+++ b/scripts/run_alignment_loso_benchmarks.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 DATA_DIR="${1:-${PYMEGDEC_DATA_DIR:-data}}"
 PARTICIPANTS="${PARTICIPANTS:-1-4,6,8,9,10,13-27}"
 OUT_DIR="${OUT_DIR:-outputs/alignment_loso}"
-COMMON=(--data-dir "$DATA_DIR" --participants "$PARTICIPANTS" --window-center 0.175 --window-size 0.1 --feature-mode sensor_flat --normalization subject_baseline_z --classifier multinomial-logistic --classifier-param 1.0 --components-pca 64 --chance-classes 16 --signflip-permutations 10000 --signflip-seed 0)
+ALIGNMENT_DATA="${ALIGNMENT_DATA:-main}"
+COMMON=(--data-dir "$DATA_DIR" --participants "$PARTICIPANTS" --window-center 0.175 --window-size 0.1 --alignment-data "$ALIGNMENT_DATA" --feature-mode sensor_flat --normalization subject_baseline_z --classifier multinomial-logistic --classifier-param 1.0 --components-pca 64 --chance-classes 16 --signflip-permutations 10000 --signflip-seed 0)
 mkdir -p "$OUT_DIR"
 
 pymegdec stimulus cross-subject-mcca \

--- a/src/pymegdec/_stimulus_hyperalignment_legacy.py
+++ b/src/pymegdec/_stimulus_hyperalignment_legacy.py
@@ -29,6 +29,7 @@ from pymegdec.classifiers import get_default_classifier_param, should_use_defaul
 from pymegdec.cli import normalize_argv, parse_classifier_param, parse_int_or_inf
 from pymegdec.data_config import resolve_data_folder
 from pymegdec.reaction_time_analysis import parse_participant_spec
+from pymegdec.stimulus_cue_calibration import load_participant_cue_calibration_features
 from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW,
     DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES,
@@ -50,6 +51,7 @@ HYPERALIGNMENT_TARGET_CENTERING_MODES = ("group_mean", "target_unsupervised")
 DEFAULT_HYPERALIGNMENT_COMPONENTS = 64
 DEFAULT_HYPERALIGNMENT_SAMPLE_MODE = "class_repetition"
 DEFAULT_HYPERALIGNMENT_TARGET_CENTERING = "target_unsupervised"
+ALIGNMENT_DATASETS = ("main", "cue")
 
 
 @dataclass(frozen=True)
@@ -60,6 +62,7 @@ class CrossSubjectHyperalignmentConfig:  # pylint: disable=too-many-instance-att
     window_size: float = DEFAULT_CROSS_SUBJECT_WINDOW_SIZE
     alignment_window_center: float | None = None
     alignment_window_size: float | None = None
+    alignment_data: str = "main"
     baseline_window: tuple[float, float] = DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW
     feature_mode: str = "sensor_flat"
     normalization: str = DEFAULT_CROSS_SUBJECT_NORMALIZATION
@@ -111,7 +114,11 @@ def evaluate_cross_subject_hyperalignment(data_folder, participants, *, config=N
         if progress is not None:
             progress(f"LOAD participant={participant}")
         feature_set = load_participant_stimulus_features(data_folder, participant, config=feature_config)
-        if uses_separate_alignment_window(config):
+        if _alignment_data(config) == "cue":
+            if progress is not None:
+                progress(f"LOAD cue_alignment participant={participant}")
+            alignment_feature_set = load_participant_cue_calibration_features(data_folder, participant, config=alignment_feature_config)
+        elif uses_separate_alignment_window(config):
             alignment_feature_set = load_participant_stimulus_features(data_folder, participant, config=alignment_feature_config)
             validate_paired_feature_sets(feature_set, alignment_feature_set, participant=participant)
         else:
@@ -229,6 +236,7 @@ def summarize_cross_subject_hyperalignment(outer_rows, *, config=None):
             "alignment_window_size_s": resolved_alignment_window(config).size,
             "alignment_window_start_s": resolved_alignment_window(config).start,
             "alignment_window_stop_s": resolved_alignment_window(config).stop,
+            "alignment_data": _alignment_data(config),
             "baseline_window_start_s": config.baseline_window[0],
             "baseline_window_stop_s": config.baseline_window[1],
             "feature_mode": config.feature_mode,
@@ -293,9 +301,20 @@ def _evaluate_hyperalignment_outer_fold(  # pylint: disable=too-many-locals
         feature_set.participant: alignment_feature_set.features
         for feature_set, alignment_feature_set in zip(train_sets, train_alignment_sets, strict=True)
     }
-    train_labels_by_subject = {
+    train_decode_labels_by_subject = {
         feature_set.participant: _training_labels(feature_set, label_shuffle_seed=label_shuffle_seed, context=(test_set.participant,)) for feature_set in train_sets
     }
+    train_alignment_labels_by_subject = {
+        feature_set.participant: train_decode_labels_by_subject[feature_set.participant] if _alignment_data(config) == "main" else np.asarray(alignment_feature_set.labels, dtype=int)
+        for feature_set, alignment_feature_set in zip(train_sets, train_alignment_sets, strict=True)
+    }
+    if _alignment_data(config) == "cue":
+        alignment_classes = _common_alignment_classes([*train_alignment_labels_by_subject.values(), np.asarray(test_alignment_set.labels, dtype=int)])
+        train_features_by_subject, train_alignment_labels_by_subject = _restrict_alignment_to_classes(
+            train_features_by_subject,
+            train_alignment_labels_by_subject,
+            alignment_classes,
+        )
     score_mask = np.ones(test_set.labels.shape[0], dtype=bool)
     calibration_mask = np.zeros(test_set.labels.shape[0], dtype=bool)
     if config.target_calibration_trials_per_class > 0:
@@ -307,7 +326,7 @@ def _evaluate_hyperalignment_outer_fold(  # pylint: disable=too-many-locals
         alignment_repetitions = config.target_calibration_trials_per_class
     hyperalignment_model, class_alignment = fit_class_hyperalignment(
         train_features_by_subject,
-        train_labels_by_subject,
+        train_alignment_labels_by_subject,
         sample_mode=config.hyperalignment_sample_mode,
         n_repetitions_per_class=alignment_repetitions,
         n_components=config.hyperalignment_components,
@@ -318,11 +337,32 @@ def _evaluate_hyperalignment_outer_fold(  # pylint: disable=too-many-locals
     transformed_labels = []
     for feature_set, alignment_feature_set in zip(train_sets, train_alignment_sets, strict=True):
         transformed_train.append(_transform_fitted_subject(hyperalignment_model, feature_set, alignment_feature_set))
-        transformed_labels.append(train_labels_by_subject[feature_set.participant])
+        transformed_labels.append(train_decode_labels_by_subject[feature_set.participant])
     train_matrix = np.vstack(transformed_train)
     train_labels = np.concatenate(transformed_labels)
     test_labels = np.asarray(test_set.labels, dtype=int)[score_mask]
-    if config.target_calibration_trials_per_class > 0:
+    if _alignment_data(config) == "cue":
+        target_aligned = _target_alignment_matrix(
+            test_alignment_set.features,
+            np.asarray(test_alignment_set.labels, dtype=int),
+            classes=class_alignment.classes,
+            sample_mode=config.hyperalignment_sample_mode,
+            n_repetitions_per_class=class_alignment.n_repetitions_per_class,
+        )
+        target_projection = fit_projection_to_hyperalignment(
+            target_aligned,
+            template=hyperalignment_model.template,
+        )
+        test_matrix = transform_with_alignment_projection(
+            test_set.features[score_mask],
+            decode_feature_set=test_set,
+            projection=target_projection.projection,
+            projection_feature_mean=target_projection.feature_mean,
+            projection_feature_set=test_alignment_set,
+        )
+        target_transform = "cue_target_calibrated"
+        n_target_calibration_trials = _count_labels_in_classes(test_alignment_set.labels, class_alignment.classes)
+    elif config.target_calibration_trials_per_class > 0:
         target_alignment = class_alignment_matrices(
             {test_set.participant: test_alignment_set.features[calibration_mask]},
             {test_set.participant: np.asarray(test_set.labels, dtype=int)[calibration_mask]},
@@ -341,6 +381,7 @@ def _evaluate_hyperalignment_outer_fold(  # pylint: disable=too-many-locals
             projection_feature_set=test_alignment_set,
         )
         target_transform = "target_calibrated"
+        n_target_calibration_trials = int(np.sum(calibration_mask))
     else:
         test_matrix = _transform_group_subject(
             hyperalignment_model,
@@ -350,6 +391,7 @@ def _evaluate_hyperalignment_outer_fold(  # pylint: disable=too-many-locals
             score_mask=score_mask,
         )
         target_transform = "group_average"
+        n_target_calibration_trials = 0
 
     model_bundle = fit_window_model(
         train_matrix,
@@ -378,7 +420,7 @@ def _evaluate_hyperalignment_outer_fold(  # pylint: disable=too-many-locals
         test_labels,
         predictions,
         target_transform=target_transform,
-        n_calibration_trials=int(np.sum(calibration_mask)),
+        n_calibration_trials=n_target_calibration_trials,
         n_scored_trials=int(np.sum(score_mask)),
         top_metrics=top_metrics,
     )
@@ -426,6 +468,7 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "n_train_trials": int(sum(feature_set.features.shape[0] for feature_set in train_sets)),
         "n_test_trials": int(n_scored_trials),
         "n_target_calibration_trials": int(n_calibration_trials),
+        "n_scored_trials": int(n_scored_trials),
         "window_center_s": config.window_center,
         "window_size_s": config.window_size,
         "window_start_s": window[0],
@@ -434,6 +477,7 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "alignment_window_size_s": alignment_window.size,
         "alignment_window_start_s": alignment_window.start,
         "alignment_window_stop_s": alignment_window.stop,
+        "alignment_data": _alignment_data(config),
         "baseline_window_start_s": config.baseline_window[0],
         "baseline_window_stop_s": config.baseline_window[1],
         "feature_mode": config.feature_mode,
@@ -506,6 +550,7 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
             "alignment_window_size_s": alignment_window.size,
             "alignment_window_start_s": alignment_window.start,
             "alignment_window_stop_s": alignment_window.stop,
+            "alignment_data": _alignment_data(config),
             "feature_mode": config.feature_mode,
             "normalization": config.normalization,
             "alignment": _alignment_label(config),
@@ -586,6 +631,53 @@ def _target_calibration_mask(labels, trials_per_class):
     return mask
 
 
+def _common_alignment_classes(label_arrays):
+    label_sets = [set(np.asarray(labels, dtype=int).ravel().tolist()) for labels in label_arrays]
+    common = sorted(set.intersection(*label_sets)) if label_sets else []
+    if len(common) < 2:
+        raise ValueError("Cue alignment requires at least two stimulus classes shared by source and target participants.")
+    return np.asarray(common, dtype=int)
+
+
+def _restrict_alignment_to_classes(features_by_subject, labels_by_subject, classes):
+    classes = np.asarray(classes, dtype=int)
+    filtered_features = {}
+    filtered_labels = {}
+    for subject_id, labels in labels_by_subject.items():
+        label_array = np.asarray(labels, dtype=int).ravel()
+        mask = np.isin(label_array, classes)
+        filtered_features[subject_id] = np.asarray(features_by_subject[subject_id], dtype=float)[mask]
+        filtered_labels[subject_id] = label_array[mask]
+    return filtered_features, filtered_labels
+
+
+def _count_labels_in_classes(labels, classes):
+    return int(np.sum(np.isin(np.asarray(labels, dtype=int), np.asarray(classes, dtype=int))))
+
+
+def _target_alignment_matrix(features, labels, *, classes, sample_mode, n_repetitions_per_class):
+    features = np.asarray(features, dtype=float)
+    labels = np.asarray(labels, dtype=int).ravel()
+    classes = np.asarray(classes, dtype=int).ravel()
+    if features.ndim != 2:
+        raise ValueError("target calibration features must be a two-dimensional matrix.")
+    if features.shape[0] != labels.shape[0]:
+        raise ValueError("target calibration feature and label counts must match.")
+    if sample_mode == "class_mean":
+        return np.vstack([np.mean(features[labels == label], axis=0) for label in classes])
+    if sample_mode == "class_repetition":
+        if n_repetitions_per_class is None:
+            raise ValueError("class_repetition target calibration requires n_repetitions_per_class.")
+        rows = []
+        for label in classes:
+            class_features = features[labels == label]
+            if class_features.shape[0] < n_repetitions_per_class:
+                raise ValueError(f"Target class {label} has {class_features.shape[0]} calibration trials, need {n_repetitions_per_class}.")
+            rows.extend(class_features[:n_repetitions_per_class])
+        return np.vstack(rows)
+    raise ValueError(f"Unsupported hyperalignment sample mode: {sample_mode}.")
+
+
 def _training_labels(feature_set, *, label_shuffle_seed=None, context=()):
     labels = np.asarray(feature_set.labels, dtype=int)
     if label_shuffle_seed is None:
@@ -652,6 +744,7 @@ def _normalized_hyperalignment_config(config):
     normalization = str(config.normalization).strip().lower().replace("-", "_")
     sample_mode = str(config.hyperalignment_sample_mode).strip().lower().replace("-", "_")
     target_centering = str(config.target_centering).strip().lower().replace("-", "_")
+    alignment_data = _alignment_data(config)
     if feature_mode not in FEATURE_MODES:
         raise ValueError(f"Unsupported feature mode: {config.feature_mode}. Supported modes: {', '.join(FEATURE_MODES)}.")
     if normalization not in NORMALIZATION_MODES:
@@ -660,8 +753,12 @@ def _normalized_hyperalignment_config(config):
         raise ValueError(f"Unsupported hyperalignment sample mode: {config.hyperalignment_sample_mode}. Supported modes: {', '.join(CLASS_ALIGNMENT_SAMPLE_MODES)}.")
     if target_centering not in HYPERALIGNMENT_TARGET_CENTERING_MODES:
         raise ValueError(f"Unsupported target centering: {config.target_centering}. Supported modes: {', '.join(HYPERALIGNMENT_TARGET_CENTERING_MODES)}.")
+    if alignment_data not in ALIGNMENT_DATASETS:
+        raise ValueError(f"Unsupported alignment data: {config.alignment_data}. Supported modes: {', '.join(ALIGNMENT_DATASETS)}.")
     if config.target_calibration_trials_per_class < 0:
         raise ValueError("target_calibration_trials_per_class must be non-negative.")
+    if alignment_data == "cue" and config.target_calibration_trials_per_class > 0:
+        raise ValueError("alignment_data='cue' uses independent cue target calibration; target_calibration_trials_per_class must be 0.")
     if config.hyperalignment_iterations < 0:
         raise ValueError("hyperalignment_iterations must be non-negative.")
     if float(config.window_size) <= 0:
@@ -676,6 +773,7 @@ def _normalized_hyperalignment_config(config):
         window_size=float(config.window_size),
         alignment_window_center=None if config.alignment_window_center is None else float(config.alignment_window_center),
         alignment_window_size=None if config.alignment_window_size is None else float(config.alignment_window_size),
+        alignment_data=alignment_data,
         baseline_window=(baseline_window[0], baseline_window[1]),
         feature_mode=feature_mode,
         normalization=normalization,
@@ -698,9 +796,15 @@ def _normalized_hyperalignment_config(config):
 
 
 def _alignment_label(config):
+    if _alignment_data(config) == "cue":
+        return "class_hyperalignment_cue_calibrated"
     if config.target_calibration_trials_per_class > 0:
         return "class_hyperalignment_target_calibrated"
     return "class_hyperalignment_group_average"
+
+
+def _alignment_data(config):
+    return str(config.alignment_data).strip().lower().replace("-", "_")
 
 
 def _centered_window(center, size):
@@ -788,6 +892,7 @@ def _build_cross_subject_hyperalignment_parser(prog: str | None = None) -> argpa
     parser.add_argument("--window-size", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE, help="Stimulus decoding window size in seconds.")
     parser.add_argument("--alignment-window-center", type=float, default=None, help="Optional alignment/calibration window center in seconds. Defaults to --window-center.")
     parser.add_argument("--alignment-window-size", type=float, default=None, help="Optional alignment/calibration window size in seconds. Defaults to --window-size.")
+    parser.add_argument("--alignment-data", choices=ALIGNMENT_DATASETS, default="main", help="Use main or cue files to fit hyperalignment projections.")
     parser.add_argument("--baseline-window", type=_parse_time_window, default=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW, help="Baseline window as start,stop in seconds.")
     parser.add_argument("--feature-mode", choices=FEATURE_MODES, default="sensor_flat", help="Feature extraction mode.")
     parser.add_argument("--normalization", choices=NORMALIZATION_MODES, default=DEFAULT_CROSS_SUBJECT_NORMALIZATION, help="Subject-level normalization mode.")
@@ -849,6 +954,7 @@ def stimulus_cross_subject_hyperalignment(argv: Sequence[str] | None = None, pro
         window_size=args.window_size,
         alignment_window_center=args.alignment_window_center,
         alignment_window_size=args.alignment_window_size,
+        alignment_data=args.alignment_data,
         baseline_window=args.baseline_window,
         feature_mode=args.feature_mode,
         normalization=args.normalization,

--- a/src/pymegdec/_stimulus_mcca_legacy.py
+++ b/src/pymegdec/_stimulus_mcca_legacy.py
@@ -24,6 +24,7 @@ from pymegdec.classifiers import get_default_classifier_param, should_use_defaul
 from pymegdec.cli import normalize_argv, parse_classifier_param, parse_int_or_inf
 from pymegdec.data_config import resolve_data_folder
 from pymegdec.reaction_time_analysis import parse_participant_spec
+from pymegdec.stimulus_cue_calibration import load_participant_cue_calibration_features
 from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW,
     DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES,
@@ -42,6 +43,7 @@ from pymegdec.stimulus_cross_subject import (
 )
 
 TARGET_CENTERING_MODES = ("group_mean", "target_unsupervised")
+ALIGNMENT_DATASETS = ("main", "cue")
 
 
 @dataclass(frozen=True)
@@ -50,6 +52,7 @@ class CrossSubjectMCCAConfig:  # pylint: disable=too-many-instance-attributes
     window_size: float = DEFAULT_CROSS_SUBJECT_WINDOW_SIZE
     alignment_window_center: float | None = None
     alignment_window_size: float | None = None
+    alignment_data: str = "main"
     baseline_window: tuple[float, float] = DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW
     feature_mode: str = "sensor_flat"
     normalization: str = DEFAULT_CROSS_SUBJECT_NORMALIZATION
@@ -91,7 +94,11 @@ def evaluate_cross_subject_mcca(data_folder, participants, *, config=None, outer
         if progress:
             progress(f"LOAD participant={participant}")
         feature_set = load_participant_stimulus_features(data_folder, participant, config=feature_config)
-        if uses_separate_alignment_window(config):
+        if _alignment_data(config) == "cue":
+            if progress:
+                progress(f"LOAD cue_alignment participant={participant}")
+            alignment_set = load_participant_cue_calibration_features(data_folder, participant, config=alignment_config)
+        elif uses_separate_alignment_window(config):
             alignment_set = load_participant_stimulus_features(data_folder, participant, config=alignment_config)
             validate_paired_feature_sets(feature_set, alignment_set, participant=participant)
         else:
@@ -176,8 +183,19 @@ def export_cross_subject_mcca(  # pylint: disable=too-many-arguments
 
 
 def _fold(train_sets, test_set, train_alignment_sets, test_alignment_set, config, classifier_param, label_shuffle_seed):
-    labels_by_subject = {item.participant: _labels(item.labels, label_shuffle_seed, test_set.participant, item.participant) for item in train_sets}
+    decode_labels_by_subject = {item.participant: _labels(item.labels, label_shuffle_seed, test_set.participant, item.participant) for item in train_sets}
+    alignment_labels_by_subject = {
+        item.participant: decode_labels_by_subject[item.participant] if _alignment_data(config) == "main" else np.asarray(alignment_set.labels, dtype=int)
+        for item, alignment_set in zip(train_sets, train_alignment_sets, strict=True)
+    }
     alignment_features_by_subject = {item.participant: alignment_set.features for item, alignment_set in zip(train_sets, train_alignment_sets, strict=True)}
+    if _alignment_data(config) == "cue":
+        alignment_classes = _common_alignment_classes([*alignment_labels_by_subject.values(), np.asarray(test_alignment_set.labels, dtype=int)])
+        alignment_features_by_subject, alignment_labels_by_subject = _restrict_alignment_to_classes(
+            alignment_features_by_subject,
+            alignment_labels_by_subject,
+            alignment_classes,
+        )
     calibration_mask = np.zeros(test_set.labels.shape[0], dtype=bool)
     score_mask = np.ones(test_set.labels.shape[0], dtype=bool)
     if config.target_calibration_trials_per_class > 0:
@@ -188,7 +206,7 @@ def _fold(train_sets, test_set, train_alignment_sets, test_alignment_set, config
         alignment_repetitions = config.target_calibration_trials_per_class
     model, alignment = fit_class_mcca(
         alignment_features_by_subject,
-        labels_by_subject,
+        alignment_labels_by_subject,
         sample_mode=config.mcca_sample_mode,
         n_repetitions_per_class=alignment_repetitions,
         n_components=config.mcca_components,
@@ -201,9 +219,32 @@ def _fold(train_sets, test_set, train_alignment_sets, test_alignment_set, config
             for item, alignment_set in zip(train_sets, train_alignment_sets, strict=True)
         ]
     )
-    train_y = np.concatenate([labels_by_subject[item.participant] for item in train_sets])
+    train_y = np.concatenate([decode_labels_by_subject[item.participant] for item in train_sets])
     test_labels = np.asarray(test_set.labels, dtype=int)[score_mask]
-    if config.target_calibration_trials_per_class > 0:
+    if _alignment_data(config) == "cue":
+        target_aligned = class_alignment_matrix(
+            test_alignment_set.features,
+            np.asarray(test_alignment_set.labels, dtype=int),
+            classes=alignment.classes,
+            sample_mode=alignment.sample_mode,
+            n_repetitions_per_class=alignment.n_repetitions_per_class,
+        )
+        target_projection = fit_target_mcca_projection(
+            target_aligned,
+            model,
+            regularization=_target_projection_regularization(config),
+        )
+        target_transformed = transform_with_alignment_projection(
+            test_set.features[score_mask],
+            decode_feature_set=test_set,
+            projection=target_projection.projection,
+            projection_feature_mean=target_projection.feature_mean,
+            projection_feature_set=test_alignment_set,
+        )
+        test_x = target_projection.add_template_mean(target_transformed)
+        target_transform = "cue_target_calibrated"
+        n_target_calibration_trials = _count_labels_in_classes(test_alignment_set.labels, alignment.classes)
+    elif config.target_calibration_trials_per_class > 0:
         target_aligned = class_alignment_matrix(
             test_alignment_set.features[calibration_mask],
             np.asarray(test_set.labels, dtype=int)[calibration_mask],
@@ -225,9 +266,11 @@ def _fold(train_sets, test_set, train_alignment_sets, test_alignment_set, config
         )
         test_x = target_projection.add_template_mean(target_transformed)
         target_transform = "target_calibrated"
+        n_target_calibration_trials = int(np.sum(calibration_mask))
     else:
         test_x = _transform_group_subject(model, test_set, test_alignment_set, config, score_mask=score_mask)
         target_transform = "group_projection"
+        n_target_calibration_trials = 0
     bundle = fit_window_model(
         train_x,
         train_y,
@@ -248,7 +291,7 @@ def _fold(train_sets, test_set, train_alignment_sets, test_alignment_set, config
         "n_train_participants": len(train_sets),
         "n_train_trials": int(train_x.shape[0]),
         "n_test_trials": int(test_labels.shape[0]),
-        "n_target_calibration_trials": int(np.sum(calibration_mask)),
+        "n_target_calibration_trials": n_target_calibration_trials,
         "n_scored_trials": int(np.sum(score_mask)),
         "n_classes": int(np.unique(test_labels).size),
         "chance_accuracy": 1.0 / config.chance_classes,
@@ -336,6 +379,7 @@ def _meta(config):
         "alignment_window_size_s": alignment_window.size,
         "alignment_window_start_s": alignment_window.start,
         "alignment_window_stop_s": alignment_window.stop,
+        "alignment_data": _alignment_data(config),
         "baseline_window_start_s": config.baseline_window[0],
         "baseline_window_stop_s": config.baseline_window[1],
         "feature_mode": config.feature_mode,
@@ -439,6 +483,30 @@ def _rank_metrics(scores, classes, y_true):
     return float(np.mean(top2)), float(np.mean(top3)), _nanmean(ranks), rows
 
 
+def _common_alignment_classes(label_arrays):
+    label_sets = [set(np.asarray(labels, dtype=int).ravel().tolist()) for labels in label_arrays]
+    common = sorted(set.intersection(*label_sets)) if label_sets else []
+    if len(common) < 2:
+        raise ValueError("Cue alignment requires at least two stimulus classes shared by source and target participants.")
+    return np.asarray(common, dtype=int)
+
+
+def _restrict_alignment_to_classes(features_by_subject, labels_by_subject, classes):
+    classes = np.asarray(classes, dtype=int)
+    filtered_features = {}
+    filtered_labels = {}
+    for subject_id, labels in labels_by_subject.items():
+        label_array = np.asarray(labels, dtype=int).ravel()
+        mask = np.isin(label_array, classes)
+        filtered_features[subject_id] = np.asarray(features_by_subject[subject_id], dtype=float)[mask]
+        filtered_labels[subject_id] = label_array[mask]
+    return filtered_features, filtered_labels
+
+
+def _count_labels_in_classes(labels, classes):
+    return int(np.sum(np.isin(np.asarray(labels, dtype=int), np.asarray(classes, dtype=int))))
+
+
 def _labels(labels, seed, test_participant, train_participant):
     labels = np.asarray(labels).copy()
     if seed is None:
@@ -449,9 +517,15 @@ def _labels(labels, seed, test_participant, train_participant):
 
 
 def _alignment_label(config):
+    if _alignment_data(config) == "cue":
+        return "mcca_cue_calibrated"
     if config.target_calibration_trials_per_class > 0:
         return "mcca_target_calibrated"
     return "mcca_group_projection"
+
+
+def _alignment_data(config):
+    return str(config.alignment_data).strip().lower().replace("-", "_")
 
 
 def _target_projection_regularization(config):
@@ -486,8 +560,12 @@ def _checked(config):
         raise ValueError("Unsupported feature mode or normalization.")
     if config.mcca_sample_mode not in CLASS_ALIGNMENT_SAMPLE_MODES or config.target_centering not in TARGET_CENTERING_MODES:
         raise ValueError("Unsupported M-CCA mode.")
+    if _alignment_data(config) not in ALIGNMENT_DATASETS:
+        raise ValueError(f"alignment_data must be one of {ALIGNMENT_DATASETS}.")
     if config.target_calibration_trials_per_class < 0:
         raise ValueError("target_calibration_trials_per_class must be non-negative.")
+    if _alignment_data(config) == "cue" and config.target_calibration_trials_per_class > 0:
+        raise ValueError("alignment_data='cue' uses independent cue target calibration; target_calibration_trials_per_class must be 0.")
     if config.mcca_regularization < 0:
         raise ValueError("mcca_regularization must be non-negative.")
     _target_projection_regularization(config)
@@ -547,6 +625,7 @@ def _parser(prog=None):
     parser.add_argument("--window-size", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE)
     parser.add_argument("--alignment-window-center", type=float, default=None)
     parser.add_argument("--alignment-window-size", type=float, default=None)
+    parser.add_argument("--alignment-data", choices=ALIGNMENT_DATASETS, default="main", help="Use main or cue files to fit M-CCA alignment projections.")
     parser.add_argument("--baseline-window", type=_parse_window, default=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW)
     parser.add_argument("--feature-mode", choices=FEATURE_MODES, default="sensor_flat")
     parser.add_argument("--normalization", choices=NORMALIZATION_MODES, default=DEFAULT_CROSS_SUBJECT_NORMALIZATION)
@@ -596,6 +675,7 @@ def stimulus_cross_subject_mcca(argv: Sequence[str] | None = None, prog: str | N
         window_size=args.window_size,
         alignment_window_center=args.alignment_window_center,
         alignment_window_size=args.alignment_window_size,
+        alignment_data=args.alignment_data,
         baseline_window=args.baseline_window,
         feature_mode=args.feature_mode,
         normalization=args.normalization,

--- a/tests/test_stimulus_alignment_benchmarks.py
+++ b/tests/test_stimulus_alignment_benchmarks.py
@@ -29,6 +29,20 @@ def _loadmat_side_effect(data_by_participant):
     return loadmat
 
 
+def _loadmat_main_and_cue_side_effect(main_by_participant, cue_by_participant, seen_stems=None):
+    def loadmat(path):
+        stem = path.name if hasattr(path, "name") else str(path).rsplit("/", maxsplit=1)[-1]
+        if seen_stems is not None:
+            seen_stems.append(stem)
+        is_cue = stem.endswith("CueData.mat")
+        suffix = "CueData.mat" if is_cue else "Data.mat"
+        participant = int(stem.removeprefix("Part").removesuffix(suffix))
+        data = cue_by_participant[participant] if is_cue else main_by_participant[participant]
+        return {"data": np.array([data], dtype=object)}
+
+    return loadmat
+
+
 def _toy_data_by_participant():
     return {
         1: _mat_data([1, 2, 1, 2], [-1.20, 1.20, -1.10, 1.10]),
@@ -36,6 +50,21 @@ def _toy_data_by_participant():
         3: _mat_data([1, 2, 1, 2], [-1.30, 1.30, -1.20, 1.20]),
         4: _mat_data([1, 2, 1, 2], [-1.10, 1.10, -1.00, 1.00]),
     }
+
+
+def _toy_three_class_data_by_participant():
+    return {
+        1: _mat_data([1, 2, 3, 1, 2, 3], [-1.20, 0.0, 1.20, -1.10, 0.1, 1.10]),
+        2: _mat_data([1, 2, 3, 1, 2, 3], [-1.00, 0.0, 1.00, -0.90, 0.1, 0.90]),
+        3: _mat_data([1, 2, 3, 1, 2, 3], [-1.30, 0.0, 1.30, -1.20, 0.1, 1.20]),
+        4: _mat_data([1, 2, 3, 1, 2, 3], [-1.10, 0.0, 1.10, -1.00, 0.1, 1.00]),
+    }
+
+
+def _toy_cue_data_missing_third_class():
+    data = _toy_three_class_data_by_participant()
+    data[3] = _mat_data([1, 2, 1, 2], [-1.30, 0.0, -1.20, 0.1])
+    return data
 
 
 def test_cross_subject_mcca_exports_full_loso_artifacts():
@@ -117,6 +146,67 @@ def test_cross_subject_mcca_can_use_separate_alignment_window():
     assert first_outer["window_size_s"] == 0.1
     assert first_outer["alignment_window_size_s"] == 0.3
     assert all(row["alignment_window_center_s"] == 0.05 for row in artifacts["predictions"])
+
+
+def test_cross_subject_mcca_can_fit_alignment_from_cue_data():
+    config = CrossSubjectMCCAConfig(
+        window_center=0.2,
+        window_size=0.1,
+        alignment_data="cue",
+        feature_mode="sensor_mean",
+        normalization="none",
+        classifier="correlation-prototype",
+        components_pca=float("inf"),
+        mcca_components=2,
+        mcca_sample_mode="class_repetition",
+        chance_classes=2,
+        signflip_permutations=32,
+    )
+    seen_stems = []
+    loadmat = _loadmat_main_and_cue_side_effect(_toy_data_by_participant(), _toy_data_by_participant(), seen_stems)
+    with (
+        patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat),
+        patch("pymegdec.stimulus_cue_calibration.sio.loadmat", side_effect=loadmat),
+    ):
+        artifacts = evaluate_cross_subject_mcca("unused", [1, 2, 3, 4], config=config)
+
+    assert any(stem.endswith("CueData.mat") for stem in seen_stems)
+    assert len(artifacts["outer"]) == 4
+    assert len(artifacts["predictions"]) == 16
+    assert all(row["alignment"] == "mcca_cue_calibrated" for row in artifacts["outer"])
+    assert all(row["alignment_data"] == "cue" for row in artifacts["outer"])
+    assert all(row["target_transform"] == "cue_target_calibrated" for row in artifacts["outer"])
+    assert all(row["n_target_calibration_trials"] == 4 for row in artifacts["outer"])
+    assert all(row["n_scored_trials"] == 4 for row in artifacts["outer"])
+    assert artifacts["group_summary"][0]["alignment_data"] == "cue"
+
+
+def test_cross_subject_mcca_cue_alignment_uses_common_cue_classes():
+    config = CrossSubjectMCCAConfig(
+        window_center=0.2,
+        window_size=0.1,
+        alignment_data="cue",
+        feature_mode="sensor_mean",
+        normalization="none",
+        classifier="correlation-prototype",
+        components_pca=float("inf"),
+        mcca_components=2,
+        mcca_sample_mode="class_repetition",
+        chance_classes=3,
+        signflip_permutations=32,
+    )
+    loadmat = _loadmat_main_and_cue_side_effect(_toy_three_class_data_by_participant(), _toy_cue_data_missing_third_class())
+    with (
+        patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat),
+        patch("pymegdec.stimulus_cue_calibration.sio.loadmat", side_effect=loadmat),
+    ):
+        artifacts = evaluate_cross_subject_mcca("unused", [1, 2, 3, 4], config=config, outer_participants=[1])
+
+    assert artifacts["outer"][0]["alignment"] == "mcca_cue_calibrated"
+    assert artifacts["outer"][0]["mcca_alignment_rows"] == 4
+    assert artifacts["outer"][0]["mcca_repetitions_per_class"] == 2
+    assert artifacts["outer"][0]["n_target_calibration_trials"] == 4
+    assert len(artifacts["predictions"]) == 6
 
 
 def test_cross_subject_hyperalignment_exports_full_loso_artifacts():
@@ -209,6 +299,68 @@ def test_cross_subject_hyperalignment_can_use_separate_alignment_window():
     assert first_outer["window_size_s"] == 0.1
     assert first_outer["alignment_window_size_s"] == 0.3
     assert all(row["alignment_window_center_s"] == 0.05 for row in artifacts["predictions"])
+
+
+def test_cross_subject_hyperalignment_can_fit_alignment_from_cue_data():
+    config = CrossSubjectHyperalignmentConfig(
+        window_center=0.2,
+        window_size=0.1,
+        alignment_data="cue",
+        feature_mode="sensor_mean",
+        normalization="none",
+        classifier="correlation-prototype",
+        components_pca=float("inf"),
+        hyperalignment_components=2,
+        hyperalignment_sample_mode="class_repetition",
+        chance_classes=2,
+        signflip_permutations=32,
+    )
+    seen_stems = []
+    loadmat = _loadmat_main_and_cue_side_effect(_toy_data_by_participant(), _toy_data_by_participant(), seen_stems)
+    with (
+        patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat),
+        patch("pymegdec.stimulus_cue_calibration.sio.loadmat", side_effect=loadmat),
+    ):
+        artifacts = evaluate_cross_subject_hyperalignment("unused", [1, 2, 3, 4], config=config)
+
+    assert any(stem.endswith("CueData.mat") for stem in seen_stems)
+    assert len(artifacts["outer"]) == 4
+    assert len(artifacts["predictions"]) == 16
+    assert all(row["alignment"] == "class_hyperalignment_cue_calibrated" for row in artifacts["outer"])
+    assert all(row["alignment_data"] == "cue" for row in artifacts["outer"])
+    assert all(row["target_transform"] == "cue_target_calibrated" for row in artifacts["outer"])
+    assert all(row["n_target_calibration_trials"] == 4 for row in artifacts["outer"])
+    assert all(row["n_scored_trials"] == 4 for row in artifacts["outer"])
+    assert artifacts["group_summary"][0]["alignment_data"] == "cue"
+
+
+def test_cross_subject_hyperalignment_cue_alignment_uses_common_cue_classes():
+    config = CrossSubjectHyperalignmentConfig(
+        window_center=0.2,
+        window_size=0.1,
+        alignment_data="cue",
+        feature_mode="sensor_mean",
+        normalization="none",
+        classifier="correlation-prototype",
+        components_pca=float("inf"),
+        hyperalignment_components=2,
+        hyperalignment_sample_mode="class_repetition",
+        chance_classes=3,
+        signflip_permutations=32,
+    )
+    loadmat = _loadmat_main_and_cue_side_effect(_toy_three_class_data_by_participant(), _toy_cue_data_missing_third_class())
+    with (
+        patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat),
+        patch("pymegdec.stimulus_cue_calibration.sio.loadmat", side_effect=loadmat),
+    ):
+        artifacts = evaluate_cross_subject_hyperalignment("unused", [1, 2, 3, 4], config=config, outer_participants=[1])
+
+    assert artifacts["outer"][0]["alignment"] == "class_hyperalignment_cue_calibrated"
+    assert artifacts["outer"][0]["hyperalignment_alignment_classes"] == "1,2"
+    assert artifacts["outer"][0]["hyperalignment_repetitions_per_class"] == 2
+    assert artifacts["outer"][0]["n_target_calibration_trials"] == 4
+    assert artifacts["outer"][0]["n_scored_trials"] == 6
+    assert len(artifacts["predictions"]) == 6
 
 
 def test_cross_subject_hyperalignment_label_shuffle_is_reproducible():


### PR DESCRIPTION
## Summary
- add `--alignment-data cue` support for cross-subject M-CCA and hyperalignment so cue trials calibrate the shared space while image-task trials train and score the classifier
- propagate cue alignment through the manual alignment workflows and grid workflows, including participant-specific `Part*Data.mat`/`Part*CueData.mat` resolution
- add tests and docs for cue-calibrated alignment and missing cue-class handling
- allow workflow dispatch with `max_trials_per_class_per_participant=all`/`none` for uncapped runs

## Validation
- `python -m pytest tests/test_stimulus_alignment_benchmarks.py tests/test_stimulus_cue_calibration.py tests/test_stimulus_mcca_scores.py tests/test_conservative_topk.py tests/test_model_transfer.py` -> 26 passed, 3 skipped
- full local pytest suite -> 130 passed, 6 skipped
- YAML parsing for modified workflows
- self-hosted smoke run: https://github.com/IPS-Stuttgart/PyMEGDec/actions/runs/25965084548
- 23-subject capped run (`max_trials_per_class_per_participant=10`): https://github.com/IPS-Stuttgart/PyMEGDec/actions/runs/25965160702
  - hyperalignment balanced accuracy: 0.0804 vs 0.0625 chance, 18/23 above chance
  - M-CCA balanced accuracy: 0.0813 vs 0.0625 chance, 17/23 above chance
- 23-subject uncapped all-trials run: https://github.com/IPS-Stuttgart/PyMEGDec/actions/runs/25965716732
  - hyperalignment balanced accuracy: 0.0708 vs 0.0625 chance, 14/23 above chance
  - M-CCA balanced accuracy: 0.0746 vs 0.0625 chance, 17/23 above chance