### PR TITLE
Use upstream RepTrace class score helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas>=3.0.3,<4.0.0",
-    "reptrace @ git+https://github.com/IPS-Stuttgart/RepTrace.git@7a0b3d3da271339c98c74c823b2f1a7eaccec324",
+    "reptrace @ git+https://github.com/IPS-Stuttgart/RepTrace.git@1c95381ed8a67cdd603c72d947056dfe71b29bcc",
     "scikit-learn",
     "scipy",
 ]

--- a/src/pymegdec/_reptrace_score_overrides.py
+++ b/src/pymegdec/_reptrace_score_overrides.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import numpy as np
-from reptrace.decoding.class_scores import predict_window_class_scores
+from reptrace.decoding.class_scores import class_score_matrix, predict_window_class_scores
 from reptrace.metrics import rank_class_scores
 
 
 def mcca_score_matrix(bundle, features):
     """Return upstream RepTrace per-class scores for a fitted M-CCA window bundle."""
 
-    return predict_window_class_scores(bundle, features)
+    if hasattr(bundle, "pca_coeff") and hasattr(bundle, "train_features_mean"):
+        return predict_window_class_scores(bundle, features)
+    return class_score_matrix(bundle.model, features, fallback_labels=getattr(bundle, "train_labels", None))
 
 
 def mcca_rank_metrics(scores, classes, y_true):

--- a/src/pymegdec/_reptrace_score_overrides.py
+++ b/src/pymegdec/_reptrace_score_overrides.py
@@ -1,0 +1,92 @@
+"""Thin PyMEGDec adapters for upstream RepTrace class-score helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+from reptrace.decoding.class_scores import predict_window_class_scores
+from reptrace.metrics import rank_class_scores
+
+
+def mcca_score_matrix(bundle, features):
+    """Return upstream RepTrace per-class scores for a fitted M-CCA window bundle."""
+
+    return predict_window_class_scores(bundle, features)
+
+
+def mcca_rank_metrics(scores, classes, y_true):
+    """Return the legacy PyMEGDec tuple shape from RepTrace rank summaries."""
+
+    summary = rank_class_scores(scores, classes, y_true, top_k=(2, 3), row_top_k=3, class_column="stimulus")
+    top_k_accuracy = summary["top_k_accuracy"]
+    return top_k_accuracy[2], top_k_accuracy[3], summary["mean_true_label_rank"], summary["rows"]
+
+
+def hyperalignment_class_score_matrix(model_bundle, features):
+    """Return class scores for hyperalignment, including predict-only models."""
+
+    return predict_window_class_scores(model_bundle, features, predict_fallback=True)
+
+
+def true_label_ranks(true_labels, class_scores, score_classes):
+    """Return only true-label ranks using RepTrace's ranking semantics."""
+
+    summary = rank_class_scores(class_scores, score_classes, true_labels, top_k=(), row_top_k=0)
+    return summary["true_label_ranks"]
+
+
+def topk_and_rank_metrics(true_labels, class_scores, score_classes):
+    """Return PyMEGDec's top-k metric dict using upstream RepTrace ranking."""
+
+    summary = rank_class_scores(class_scores, score_classes, true_labels, top_k=(2, 3), row_top_k=0)
+    top_k_accuracy = summary["top_k_accuracy"]
+    return {
+        "top2_accuracy": top_k_accuracy[2],
+        "top3_accuracy": top_k_accuracy[3],
+        "mean_true_label_rank": summary["mean_true_label_rank"],
+    }
+
+
+def cross_subject_model_class_scores(model_bundle, features):
+    """Return class scores in the legacy cross-subject empty-matrix shape."""
+
+    scores, classes = predict_window_class_scores(model_bundle, features)
+    if scores is None or classes is None:
+        return np.full((np.asarray(features).shape[0], 0), np.nan, dtype=float), np.asarray([], dtype=int)
+    return scores, classes
+
+
+def cross_subject_ranked_label_metrics(true_labels, class_scores, score_classes):
+    """Return PyMEGDec cross-subject rank metrics using RepTrace summaries."""
+
+    summary = rank_class_scores(class_scores, score_classes, true_labels, top_k=(2, 3), row_top_k=0)
+    top_k_accuracy = summary["top_k_accuracy"]
+    return {
+        "true_label_ranks": summary["true_label_ranks"],
+        "top2_accuracy": top_k_accuracy[2],
+        "top3_accuracy": top_k_accuracy[3],
+        "mean_true_label_rank": summary["mean_true_label_rank"],
+        "median_true_label_rank": summary["median_true_label_rank"],
+    }
+
+
+def install_mcca(impl):
+    """Install upstream-backed M-CCA scoring helpers into the legacy module."""
+
+    impl._score_matrix = mcca_score_matrix
+    impl._rank_metrics = mcca_rank_metrics
+
+
+def install_hyperalignment(impl):
+    """Install upstream-backed hyperalignment scoring helpers."""
+
+    impl._class_score_matrix = hyperalignment_class_score_matrix
+    impl._topk_and_rank_metrics = topk_and_rank_metrics
+    impl._true_label_ranks = true_label_ranks
+
+
+def install_cross_subject(impl):
+    """Install upstream-backed cross-subject scoring helpers."""
+
+    impl._model_class_scores = cross_subject_model_class_scores
+    impl._ranked_label_metrics = cross_subject_ranked_label_metrics
+    impl._true_label_ranks = true_label_ranks

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -7,7 +7,9 @@ import sys
 from pymegdec import _stimulus_cross_subject_core as _core
 from pymegdec import _stimulus_cross_subject_timefix as _timefix  # noqa: F401
 from pymegdec import _stimulus_cross_subject_chance as _chance  # noqa: F401
+from pymegdec._reptrace_score_overrides import install_cross_subject
 
 _impl = _core._impl
+install_cross_subject(_impl)
 sys.modules[__name__] = _impl
 globals().update(_impl.__dict__)

--- a/src/pymegdec/stimulus_hyperalignment.py
+++ b/src/pymegdec/stimulus_hyperalignment.py
@@ -10,25 +10,12 @@ import numpy as np
 from reptrace.decoding.hyperalignment import HyperalignmentModel, SubjectHyperalignmentProjection, class_alignment_matrices
 
 from pymegdec import _stimulus_hyperalignment_legacy as _impl
+from pymegdec._reptrace_score_overrides import install_hyperalignment
 
 HYPERALIGNMENT_INITIALIZATION_MODES = ("pca", "mean")
 
 _ORIGINAL_EVALUATE_HYPERALIGNMENT_OUTER_FOLD = _impl._evaluate_hyperalignment_outer_fold
 _ORIGINAL_NORMALIZED_HYPERALIGNMENT_CONFIG = _impl._normalized_hyperalignment_config
-
-
-def _topk_and_rank_metrics(true_labels, class_scores, score_classes):
-    if class_scores.size == 0:
-        return {"top2_accuracy": np.nan, "top3_accuracy": np.nan, "mean_true_label_rank": np.nan}
-    ranks = np.asarray(_impl._true_label_ranks(true_labels, class_scores, score_classes), dtype=float)
-    finite_ranks = ranks[np.isfinite(ranks)]
-    if ranks.size == 0:
-        return {"top2_accuracy": np.nan, "top3_accuracy": np.nan, "mean_true_label_rank": np.nan}
-    return {
-        "top2_accuracy": float(np.mean(ranks <= 2)),
-        "top3_accuracy": float(np.mean(ranks <= 3)),
-        "mean_true_label_rank": float(np.mean(finite_ranks)) if finite_ranks.size else np.nan,
-    }
 
 
 def _normalize_hyperalignment_initialization(initialization):
@@ -214,12 +201,12 @@ def _hyperalignment_average_projection(projections: Mapping[object, SubjectHyper
 
 
 _impl.HYPERALIGNMENT_INITIALIZATION_MODES = HYPERALIGNMENT_INITIALIZATION_MODES
-_impl._topk_and_rank_metrics = _topk_and_rank_metrics
 _impl._normalize_hyperalignment_initialization = _normalize_hyperalignment_initialization
 _impl._normalized_hyperalignment_config = _normalized_hyperalignment_config
 _impl._fit_mean_initialized_class_hyperalignment = _fit_mean_initialized_class_hyperalignment
 _impl._fit_mean_initialized_hyperalignment = _fit_mean_initialized_hyperalignment
 _impl._evaluate_hyperalignment_outer_fold = _evaluate_hyperalignment_outer_fold
+install_hyperalignment(_impl)
 
 sys.modules[__name__] = _impl
 globals().update(_impl.__dict__)

--- a/src/pymegdec/stimulus_mcca.py
+++ b/src/pymegdec/stimulus_mcca.py
@@ -4,66 +4,10 @@ from __future__ import annotations
 
 import sys
 
-import numpy as np
-
 from pymegdec import _stimulus_mcca_legacy as _impl
+from pymegdec._reptrace_score_overrides import install_mcca
 
-
-def _score_classes(model, bundle):
-    classes = getattr(model, "classes_", None)
-    if classes is None and hasattr(model, "named_steps"):
-        for step in reversed(list(model.named_steps.values())):
-            classes = getattr(step, "classes_", None)
-            if classes is not None:
-                break
-    if classes is None:
-        train_labels = getattr(bundle, "train_labels", None)
-        if train_labels is not None:
-            classes = np.unique(np.asarray(train_labels))
-    if classes is None:
-        return None
-    return np.asarray(classes).ravel()
-
-
-def _as_class_score_matrix(raw_scores, classes, *, n_samples):
-    scores = np.asarray(raw_scores, dtype=float)
-    if scores.ndim == 1:
-        if scores.shape[0] != n_samples or classes.size != 2:
-            return None
-        return np.column_stack((-scores, scores))
-    if scores.ndim != 2 or scores.shape[0] != n_samples:
-        return None
-    if scores.shape[1] == classes.size:
-        return scores
-    if scores.shape[1] == 1 and classes.size == 2:
-        column = scores[:, 0]
-        return np.column_stack((-column, column))
-    return None
-
-
-def _score_matrix(bundle, features):
-    transformed = _impl.transform_window_features(bundle, features)
-    model = bundle.model
-    classes = _score_classes(model, bundle)
-    if classes is None or classes.size == 0:
-        return None, None
-
-    for method_name in ("decision_function", "predict_proba"):
-        if not hasattr(model, method_name):
-            continue
-        scores = _as_class_score_matrix(
-            getattr(model, method_name)(transformed),
-            classes,
-            n_samples=int(np.shape(transformed)[0]),
-        )
-        if scores is not None:
-            return scores, classes
-    return None, None
-
-
-_impl._score_matrix = _score_matrix
-_impl._score_classes = _score_classes
-_impl._as_class_score_matrix = _as_class_score_matrix
+install_mcca(_impl)
 
 sys.modules[__name__] = _impl
 globals().update(_impl.__dict__)


### PR DESCRIPTION
Moves PyMEGDec's active class-score/rank logic to upstream RepTrace helpers.

Changes:
- add a thin `_reptrace_score_overrides` adapter that delegates MCCA, hyperalignment, and cross-subject class-score/rank behavior to RepTrace
- simplify `stimulus_mcca.py` by removing local score-matrix helpers and installing the upstream-backed adapter
- make `stimulus_hyperalignment.py` use the upstream-backed adapter for class score and top-k/rank metrics while keeping mean-initialized hyperalignment logic local
- make `stimulus_cross_subject.py` install upstream-backed cross-subject score/rank helpers
- pin RepTrace to commit `1c95381ed8a67cdd603c72d947056dfe71b29bcc`, from RepTrace PR #43

Depends on IPS-Stuttgart/RepTrace#43.

Note: I could not run the test suite from this environment. Also, `main` advanced while these commits were being written, so the branch may need updating before merge.