### PR TITLE
Fix main CI checks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2288,8 +2288,8 @@ scikit-learn = "*"
 [package.source]
 type = "git"
 url = "https://github.com/IPS-Stuttgart/RepTrace.git"
-reference = "1c7044442bd059658ffe98e4944235afd86c79e0"
-resolved_reference = "1c7044442bd059658ffe98e4944235afd86c79e0"
+reference = "500323f2932d51bac9170ed81d5704c035bf12f5"
+resolved_reference = "500323f2932d51bac9170ed81d5704c035bf12f5"
 
 [[package]]
 name = "requests"
@@ -2867,4 +2867,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "d98e520072feea8afe40f9668277c551f48144e1917a4358cd318c88ac356961"
+content-hash = "d69c2e1487390e55591129707e79a86413477861d85b517b1a1c86a87b241dbe"

--- a/src/pymegdec/_stimulus_trial_sampling.py
+++ b/src/pymegdec/_stimulus_trial_sampling.py
@@ -48,12 +48,12 @@ def _normalize_trial_selection_seed(value):
 def _install_reptrace_sampling_bridge():
     _impl = _core._impl
     for module in (_core, _impl):
-        module.DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION = DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION
-        module.DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED = DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED
-        module.TRIAL_SELECTION_MODES = TRIAL_SELECTION_MODES
-        module._selected_trial_indices = _selected_trial_indices
-        module._normalize_trial_selection = _normalize_trial_selection
-        module._normalize_trial_selection_seed = _normalize_trial_selection_seed
+        setattr(module, "DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION", DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION)
+        setattr(module, "DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED", DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED)
+        setattr(module, "TRIAL_SELECTION_MODES", TRIAL_SELECTION_MODES)
+        setattr(module, "_selected_trial_indices", _selected_trial_indices)
+        setattr(module, "_normalize_trial_selection", _normalize_trial_selection)
+        setattr(module, "_normalize_trial_selection_seed", _normalize_trial_selection_seed)
 
 
 _install_reptrace_sampling_bridge()

--- a/src/pymegdec/stimulus_decoding.py
+++ b/src/pymegdec/stimulus_decoding.py
@@ -449,52 +449,43 @@ def summarize_stimulus_onset_events(rows):
 
 
 def _group_rows_for_onset_scan_summary(rows):
-    grouped = {}
-    for row in rows:
-        grouped.setdefault(_onset_scan_summary_key(row), []).append(row)
-    return grouped
+    return _group_rows_by_summary_key(rows, _onset_scan_summary_key)
 
 
 def _group_rows_for_onset_event_summary(rows):
-    grouped = {}
+    return _group_rows_by_summary_key(rows, _onset_event_summary_key)
+
+
+def _group_rows_by_summary_key(rows, key_factory):
+    grouped: dict[tuple[object, ...], list[dict[str, _typing.Any]]] = {}
     for row in rows:
-        grouped.setdefault(_onset_event_summary_key(row), []).append(row)
+        grouped.setdefault(key_factory(row), []).append(row)
     return grouped
 
 
+_ONSET_BASE_KEY_FIELDS = (
+    "participant",
+    "variant",
+    "transfer_direction",
+    "train_window_center_s",
+    "threshold_method",
+    "min_consecutive",
+    "min_duration_s",
+    "require_stable_prediction",
+)
+_ONSET_MODEL_KEY_FIELDS = ("classifier", "components_pca", "frequency_low_hz", "frequency_high_hz")
+
+
+def _summary_key_from_fields(row, fields):
+    return tuple(row.get(field) for field in fields)
+
+
 def _onset_scan_summary_key(row):
-    return (
-        row.get("participant"),
-        row.get("variant"),
-        row.get("transfer_direction"),
-        row.get("train_window_center_s"),
-        row.get("threshold_method"),
-        row.get("min_consecutive"),
-        row.get("min_duration_s"),
-        row.get("require_stable_prediction"),
-        row.get("scan_window_center_s"),
-        row.get("classifier"),
-        row.get("components_pca"),
-        row.get("frequency_low_hz"),
-        row.get("frequency_high_hz"),
-    )
+    return _summary_key_from_fields(row, (*_ONSET_BASE_KEY_FIELDS, "scan_window_center_s", *_ONSET_MODEL_KEY_FIELDS))
 
 
 def _onset_event_summary_key(row):
-    return (
-        row.get("participant"),
-        row.get("variant"),
-        row.get("transfer_direction"),
-        row.get("train_window_center_s"),
-        row.get("threshold_method"),
-        row.get("min_consecutive"),
-        row.get("min_duration_s"),
-        row.get("require_stable_prediction"),
-        row.get("classifier"),
-        row.get("components_pca"),
-        row.get("frequency_low_hz"),
-        row.get("frequency_high_hz"),
-    )
+    return _summary_key_from_fields(row, (*_ONSET_BASE_KEY_FIELDS, *_ONSET_MODEL_KEY_FIELDS))
 
 
 def _finite_values(values):

--- a/tests/test_stimulus_alignment_benchmarks.py
+++ b/tests/test_stimulus_alignment_benchmarks.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import numpy as np
-import pytest
 
 from pymegdec.stimulus_hyperalignment import CrossSubjectHyperalignmentConfig, evaluate_cross_subject_hyperalignment
 from pymegdec.stimulus_mcca import CrossSubjectMCCAConfig, evaluate_cross_subject_mcca
@@ -178,8 +177,12 @@ def test_cross_subject_hyperalignment_mean_initialization_uses_mean_path():
 
 def test_cross_subject_hyperalignment_rejects_unknown_initialization():
     config = CrossSubjectHyperalignmentConfig(hyperalignment_initialization="unsupported")
-    with pytest.raises(ValueError, match="Unsupported hyperalignment initialization"):
+    try:
         evaluate_cross_subject_hyperalignment("unused", [1, 2, 3], config=config)
+    except ValueError as exc:
+        assert "Unsupported hyperalignment initialization" in str(exc)
+    else:
+        raise AssertionError("Expected unsupported hyperalignment initialization to raise ValueError.")
 
 
 def test_cross_subject_hyperalignment_can_use_separate_alignment_window():


### PR DESCRIPTION
## Summary
- refresh the Poetry lockfile so it matches the pinned RepTrace commit with decoding sampling helpers
- use dynamic bridge assignments to satisfy mypy for patched sampling helpers
- share onset-summary grouping and key-field construction to reduce duplicated Python code for jscpd without changing the copy-paste threshold
- remove pytest-only syntax from an imported unittest-discovered benchmark test module

## Verification
- `poetry check --lock`
- `python -m ruff check .`
- `python -m mypy src`
- `python -c "import tests.test_stimulus_alignment_benchmarks"`
- `python -m unittest discover -v`