### PR TITLE
Add nested score ensemble selection

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -89,7 +89,7 @@ on:
       classifiers:
         description: Candidate classifier names.
         required: true
-        default: multinomial-logistic,shrinkage-lda,multiclass-svm
+        default: multinomial-logistic,multinomial-logistic-weighted,shrinkage-lda,multiclass-svm
         type: string
       classifier_params:
         description: Candidate classifier parameters; use default for classifier defaults.

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -89,7 +89,7 @@ on:
       classifiers:
         description: Candidate classifier names.
         required: true
-        default: multinomial-logistic,multinomial-logistic-weighted,shrinkage-lda,shrinkage-prototype,multiclass-svm
+        default: multinomial-logistic,multinomial-logistic-weighted,shrinkage-lda,shrinkage-prototype,gaussian-naive-bayes,multiclass-svm
         type: string
       classifier_params:
         description: Candidate classifier parameters; use default for classifier defaults.

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -106,6 +106,17 @@ on:
         required: true
         default: "1"
         type: string
+      selection_ensemble_weighting:
+        description: Weighting for top-K ensemble candidates.
+        required: true
+        default: uniform
+        type: choice
+        options: [uniform, inner_softmax]
+      selection_ensemble_temperature:
+        description: Softmax temperature for inner_softmax ensemble weighting.
+        required: true
+        default: "0.02"
+        type: string
       max_trials_per_class_per_participant:
         description: Optional screening trial cap per stimulus class and participant. Ignored when benchmark_preset=final-all-trials.
         required: false
@@ -157,6 +168,8 @@ jobs:
       CLASSIFIER_PARAMS: ${{ inputs.classifier_params }}
       COMPONENTS_PCA_VALUES: ${{ inputs.components_pca_values }}
       SELECTION_ENSEMBLE_SIZE: ${{ inputs.selection_ensemble_size }}
+      SELECTION_ENSEMBLE_WEIGHTING: ${{ inputs.selection_ensemble_weighting }}
+      SELECTION_ENSEMBLE_TEMPERATURE: ${{ inputs.selection_ensemble_temperature }}
       MAX_TRIALS_PER_CLASS_PER_PARTICIPANT: ${{ inputs.max_trials_per_class_per_participant }}
       LABEL_SHUFFLE_CONTROL: ${{ inputs.label_shuffle_control }}
       LABEL_SHUFFLE_SEED: ${{ inputs.label_shuffle_seed }}
@@ -242,6 +255,8 @@ jobs:
             --classifier-params "${CLASSIFIER_PARAMS}"
             --components-pca-values "${COMPONENTS_PCA_VALUES}"
             --selection-ensemble-size "${SELECTION_ENSEMBLE_SIZE}"
+            --selection-ensemble-weighting "${SELECTION_ENSEMBLE_WEIGHTING}"
+            --selection-ensemble-temperature "${SELECTION_ENSEMBLE_TEMPERATURE}"
             --outer-output "${output_prefix}_outer.csv"
             --summary-output "${output_prefix}_group_summary.csv"
             --inner-validation-output "${output_prefix}_inner_validation.csv"
@@ -351,6 +366,8 @@ jobs:
               f"| candidates | {summary['n_candidates']} |",
               f"| outer evaluation mode | {summary.get('outer_evaluation_mode', 'single_best')} |",
               f"| selection ensemble size | {summary.get('selection_ensemble_size', os.environ.get('SELECTION_ENSEMBLE_SIZE', '1'))} |",
+              f"| selection ensemble weighting | {summary.get('selection_ensemble_weighting', os.environ.get('SELECTION_ENSEMBLE_WEIGHTING', 'uniform'))} |",
+              f"| selection ensemble temperature | {summary.get('selection_ensemble_temperature', os.environ.get('SELECTION_ENSEMBLE_TEMPERATURE', '0.02'))} |",
               f"| selected ensemble candidate counts | {summary.get('selected_ensemble_candidate_counts', '')} |",
               f"| label shuffle control | {summary.get('label_shuffle_control', os.environ.get('LABEL_SHUFFLE_CONTROL', 'false'))} |",
               f"| label shuffle seed | {summary.get('label_shuffle_seed', os.environ.get('LABEL_SHUFFLE_SEED', ''))} |",

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -74,7 +74,7 @@ on:
       feature_modes:
         description: Candidate feature modes.
         required: true
-        default: sensor_flat
+        default: sensor_flat,sensor_mean_slope
         type: string
       normalizations:
         description: Candidate normalization modes.

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -74,7 +74,7 @@ on:
       feature_modes:
         description: Candidate feature modes.
         required: true
-        default: sensor_flat,sensor_mean_slope
+        default: sensor_flat,sensor_mean_slope,sensor_mean_slope_std
         type: string
       normalizations:
         description: Candidate normalization modes.

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -106,6 +106,12 @@ on:
         required: true
         default: "1"
         type: string
+      selection_ensemble_diversity:
+        description: Prefer diverse candidates before filling the top-K ensemble.
+        required: true
+        default: none
+        type: choice
+        options: [none, window, classifier, window_classifier, full_config]
       selection_ensemble_score_normalization:
         description: Per-candidate score normalization before top-K ensemble averaging.
         required: true
@@ -174,6 +180,7 @@ jobs:
       CLASSIFIER_PARAMS: ${{ inputs.classifier_params }}
       COMPONENTS_PCA_VALUES: ${{ inputs.components_pca_values }}
       SELECTION_ENSEMBLE_SIZE: ${{ inputs.selection_ensemble_size }}
+      SELECTION_ENSEMBLE_DIVERSITY: ${{ inputs.selection_ensemble_diversity }}
       SELECTION_ENSEMBLE_SCORE_NORMALIZATION: ${{ inputs.selection_ensemble_score_normalization }}
       SELECTION_ENSEMBLE_WEIGHTING: ${{ inputs.selection_ensemble_weighting }}
       SELECTION_ENSEMBLE_TEMPERATURE: ${{ inputs.selection_ensemble_temperature }}
@@ -262,6 +269,7 @@ jobs:
             --classifier-params "${CLASSIFIER_PARAMS}"
             --components-pca-values "${COMPONENTS_PCA_VALUES}"
             --selection-ensemble-size "${SELECTION_ENSEMBLE_SIZE}"
+            --selection-ensemble-diversity "${SELECTION_ENSEMBLE_DIVERSITY}"
             --selection-ensemble-score-normalization "${SELECTION_ENSEMBLE_SCORE_NORMALIZATION}"
             --selection-ensemble-weighting "${SELECTION_ENSEMBLE_WEIGHTING}"
             --selection-ensemble-temperature "${SELECTION_ENSEMBLE_TEMPERATURE}"
@@ -374,6 +382,7 @@ jobs:
               f"| candidates | {summary['n_candidates']} |",
               f"| outer evaluation mode | {summary.get('outer_evaluation_mode', 'single_best')} |",
               f"| selection ensemble size | {summary.get('selection_ensemble_size', os.environ.get('SELECTION_ENSEMBLE_SIZE', '1'))} |",
+              f"| selection ensemble diversity | {summary.get('selection_ensemble_diversity', os.environ.get('SELECTION_ENSEMBLE_DIVERSITY', 'none'))} |",
               f"| ensemble score normalization | {summary.get('selection_ensemble_score_normalization', os.environ.get('SELECTION_ENSEMBLE_SCORE_NORMALIZATION', 'row_z_softmax'))} |",
               f"| selection ensemble weighting | {summary.get('selection_ensemble_weighting', os.environ.get('SELECTION_ENSEMBLE_WEIGHTING', 'uniform'))} |",
               f"| selection ensemble temperature | {summary.get('selection_ensemble_temperature', os.environ.get('SELECTION_ENSEMBLE_TEMPERATURE', '0.02'))} |",

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -89,7 +89,7 @@ on:
       classifiers:
         description: Candidate classifier names.
         required: true
-        default: multinomial-logistic,multinomial-logistic-weighted,shrinkage-lda,shrinkage-prototype,gaussian-naive-bayes,multiclass-svm
+        default: multinomial-logistic,multinomial-logistic-weighted,shrinkage-lda,shrinkage-prototype,regularized-qda,gaussian-naive-bayes,multiclass-svm
         type: string
       classifier_params:
         description: Candidate classifier parameters; use default for classifier defaults.

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -92,9 +92,9 @@ on:
         default: multinomial-logistic,multinomial-logistic-weighted,shrinkage-lda,shrinkage-prototype,regularized-qda,gaussian-naive-bayes,multiclass-svm
         type: string
       classifier_params:
-        description: Candidate classifier parameters; use default for classifier defaults.
+        description: Candidate classifier parameters; use default for classifier defaults or auto-grid for classifier-specific tuning grids.
         required: true
-        default: default
+        default: auto-grid
         type: string
       components_pca_values:
         description: Candidate PCA component counts, or inf.

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -97,9 +97,9 @@ on:
         default: auto-grid
         type: string
       components_pca_values:
-        description: Candidate PCA component counts, or inf.
+        description: Candidate PCA component counts, inf, or auto-grid for 32,64,128.
         required: true
-        default: "64"
+        default: auto-grid
         type: string
       selection_ensemble_size:
         description: Top-K inner-LOSO candidates to ensemble by row-normalized class scores. Use 1 for single-winner nested selection.

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -89,7 +89,7 @@ on:
       classifiers:
         description: Candidate classifier names.
         required: true
-        default: multinomial-logistic,multinomial-logistic-weighted,shrinkage-lda,multiclass-svm
+        default: multinomial-logistic,multinomial-logistic-weighted,shrinkage-lda,shrinkage-prototype,multiclass-svm
         type: string
       classifier_params:
         description: Candidate classifier parameters; use default for classifier defaults.

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -101,6 +101,11 @@ on:
         required: true
         default: "64"
         type: string
+      selection_ensemble_size:
+        description: Top-K inner-LOSO candidates to ensemble by row-normalized class scores. Use 1 for single-winner nested selection.
+        required: true
+        default: "1"
+        type: string
       max_trials_per_class_per_participant:
         description: Optional screening trial cap per stimulus class and participant. Ignored when benchmark_preset=final-all-trials.
         required: false
@@ -151,6 +156,7 @@ jobs:
       CLASSIFIERS: ${{ inputs.classifiers }}
       CLASSIFIER_PARAMS: ${{ inputs.classifier_params }}
       COMPONENTS_PCA_VALUES: ${{ inputs.components_pca_values }}
+      SELECTION_ENSEMBLE_SIZE: ${{ inputs.selection_ensemble_size }}
       MAX_TRIALS_PER_CLASS_PER_PARTICIPANT: ${{ inputs.max_trials_per_class_per_participant }}
       LABEL_SHUFFLE_CONTROL: ${{ inputs.label_shuffle_control }}
       LABEL_SHUFFLE_SEED: ${{ inputs.label_shuffle_seed }}
@@ -235,6 +241,7 @@ jobs:
             --classifiers "${CLASSIFIERS}"
             --classifier-params "${CLASSIFIER_PARAMS}"
             --components-pca-values "${COMPONENTS_PCA_VALUES}"
+            --selection-ensemble-size "${SELECTION_ENSEMBLE_SIZE}"
             --outer-output "${output_prefix}_outer.csv"
             --summary-output "${output_prefix}_group_summary.csv"
             --inner-validation-output "${output_prefix}_inner_validation.csv"
@@ -342,6 +349,9 @@ jobs:
               f"| output prefix | `{output_prefix}` |",
               f"| outer folds | {summary['n_outer_folds']} |",
               f"| candidates | {summary['n_candidates']} |",
+              f"| outer evaluation mode | {summary.get('outer_evaluation_mode', 'single_best')} |",
+              f"| selection ensemble size | {summary.get('selection_ensemble_size', os.environ.get('SELECTION_ENSEMBLE_SIZE', '1'))} |",
+              f"| selected ensemble candidate counts | {summary.get('selected_ensemble_candidate_counts', '')} |",
               f"| label shuffle control | {summary.get('label_shuffle_control', os.environ.get('LABEL_SHUFFLE_CONTROL', 'false'))} |",
               f"| label shuffle seed | {summary.get('label_shuffle_seed', os.environ.get('LABEL_SHUFFLE_SEED', ''))} |",
               f"| trial cap counts | {summary.get('max_trials_per_class_per_participant_counts', '')} |",
@@ -365,12 +375,12 @@ jobs:
               "",
               "## Selected candidates",
               "",
-              "| participant | candidate | classifier | alignment | window center | inner balanced accuracy | winner margin |",
-              "| ---: | ---: | --- | --- | ---: | ---: | ---: |",
+              "| participant | candidate(s) | classifier | alignment | window center | inner balanced accuracy | winner margin |",
+              "| ---: | --- | --- | --- | ---: | ---: | ---: |",
           ]
           for row in selected_rows:
               lines.append(
-                  f"| {row['test_participant']} | {row['selected_candidate_index']} | {row['selected_classifier']} | "
+                  f"| {row['test_participant']} | {row.get('selected_candidate_indices', row['selected_candidate_index'])} | {row['selected_classifier']} | "
                   f"{row.get('selected_alignment', 'none')} | {float(row['selected_window_center_s']):.3f} | "
                   f"{100.0 * float(row['selected_inner_balanced_accuracy_mean']):.2f}% | "
                   f"{percent_row(row, 'selected_inner_winner_margin')} |"

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -106,6 +106,12 @@ on:
         required: true
         default: "1"
         type: string
+      selection_ensemble_score_normalization:
+        description: Per-candidate score normalization before top-K ensemble averaging.
+        required: true
+        default: row_z_softmax
+        type: choice
+        options: [row_z_softmax, rank_softmax]
       selection_ensemble_weighting:
         description: Weighting for top-K ensemble candidates.
         required: true
@@ -168,6 +174,7 @@ jobs:
       CLASSIFIER_PARAMS: ${{ inputs.classifier_params }}
       COMPONENTS_PCA_VALUES: ${{ inputs.components_pca_values }}
       SELECTION_ENSEMBLE_SIZE: ${{ inputs.selection_ensemble_size }}
+      SELECTION_ENSEMBLE_SCORE_NORMALIZATION: ${{ inputs.selection_ensemble_score_normalization }}
       SELECTION_ENSEMBLE_WEIGHTING: ${{ inputs.selection_ensemble_weighting }}
       SELECTION_ENSEMBLE_TEMPERATURE: ${{ inputs.selection_ensemble_temperature }}
       MAX_TRIALS_PER_CLASS_PER_PARTICIPANT: ${{ inputs.max_trials_per_class_per_participant }}
@@ -255,6 +262,7 @@ jobs:
             --classifier-params "${CLASSIFIER_PARAMS}"
             --components-pca-values "${COMPONENTS_PCA_VALUES}"
             --selection-ensemble-size "${SELECTION_ENSEMBLE_SIZE}"
+            --selection-ensemble-score-normalization "${SELECTION_ENSEMBLE_SCORE_NORMALIZATION}"
             --selection-ensemble-weighting "${SELECTION_ENSEMBLE_WEIGHTING}"
             --selection-ensemble-temperature "${SELECTION_ENSEMBLE_TEMPERATURE}"
             --outer-output "${output_prefix}_outer.csv"
@@ -366,6 +374,7 @@ jobs:
               f"| candidates | {summary['n_candidates']} |",
               f"| outer evaluation mode | {summary.get('outer_evaluation_mode', 'single_best')} |",
               f"| selection ensemble size | {summary.get('selection_ensemble_size', os.environ.get('SELECTION_ENSEMBLE_SIZE', '1'))} |",
+              f"| ensemble score normalization | {summary.get('selection_ensemble_score_normalization', os.environ.get('SELECTION_ENSEMBLE_SCORE_NORMALIZATION', 'row_z_softmax'))} |",
               f"| selection ensemble weighting | {summary.get('selection_ensemble_weighting', os.environ.get('SELECTION_ENSEMBLE_WEIGHTING', 'uniform'))} |",
               f"| selection ensemble temperature | {summary.get('selection_ensemble_temperature', os.environ.get('SELECTION_ENSEMBLE_TEMPERATURE', '0.02'))} |",
               f"| selected ensemble candidate counts | {summary.get('selected_ensemble_candidate_counts', '')} |",

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -123,9 +123,9 @@ on:
         required: true
         default: uniform
         type: choice
-        options: [uniform, inner_softmax]
+        options: [uniform, inner_softmax, inner_lcb_softmax]
       selection_ensemble_temperature:
-        description: Softmax temperature for inner_softmax ensemble weighting.
+        description: Softmax temperature for inner score-based ensemble weighting.
         required: true
         default: "0.02"
         type: string

--- a/scripts/export_stimulus_cross_subject_nested_controlled.py
+++ b/scripts/export_stimulus_cross_subject_nested_controlled.py
@@ -14,6 +14,7 @@ if str(SRC) not in sys.path:
 
 from pymegdec import stimulus_cross_subject as base  # noqa: E402
 from pymegdec.stimulus_cross_subject import (  # noqa: E402
+    AUTO_CLASSIFIER_PARAM_GRID_TOKEN,
     make_cross_subject_candidate_configs,
 )
 from pymegdec.stimulus_cross_subject_controls import (  # noqa: E402
@@ -80,8 +81,11 @@ def _parse_classifier_params(value: str) -> tuple[object, ...]:
         token = token.strip()
         if not token:
             continue
-        if token.lower() in {"default", "nan"}:
+        normalized = token.lower().replace("_", "-")
+        if normalized in {"default", "nan"}:
             params.append(float("nan"))
+        elif normalized == AUTO_CLASSIFIER_PARAM_GRID_TOKEN:
+            params.append(AUTO_CLASSIFIER_PARAM_GRID_TOKEN)
         else:
             try:
                 parsed = ast.literal_eval(token)

--- a/scripts/export_stimulus_cross_subject_nested_controlled.py
+++ b/scripts/export_stimulus_cross_subject_nested_controlled.py
@@ -15,6 +15,7 @@ if str(SRC) not in sys.path:
 from pymegdec import stimulus_cross_subject as base  # noqa: E402
 from pymegdec.stimulus_cross_subject import (  # noqa: E402
     AUTO_CLASSIFIER_PARAM_GRID_TOKEN,
+    AUTO_COMPONENTS_PCA_GRID_TOKEN,
     make_cross_subject_candidate_configs,
 )
 from pymegdec.stimulus_cross_subject_controls import (  # noqa: E402
@@ -68,11 +69,19 @@ def _parse_int_or_inf(value: str):
     return int(value)
 
 
-def _parse_int_or_inf_list(value: str) -> tuple[int | float, ...]:
-    values = tuple(_parse_int_or_inf(token) for token in value.split(",") if token.strip())
+def _parse_int_or_inf_list(value: str) -> tuple[int | float | str, ...]:
+    values = []
+    for token in value.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if token.lower().replace("_", "-") == AUTO_COMPONENTS_PCA_GRID_TOKEN:
+            values.append(AUTO_COMPONENTS_PCA_GRID_TOKEN)
+        else:
+            values.append(_parse_int_or_inf(token))
     if not values:
         raise argparse.ArgumentTypeError("At least one PCA value is required.")
-    return values
+    return tuple(values)
 
 
 def _parse_classifier_params(value: str) -> tuple[object, ...]:

--- a/src/pymegdec/_stimulus_cross_subject_core.py
+++ b/src/pymegdec/_stimulus_cross_subject_core.py
@@ -234,7 +234,7 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
 
 
 def _components_pca_values_for_grid(components_pca_values):
-    values = []
+    values: list[object] = []
     for components_pca in components_pca_values:
         if _is_auto_components_pca_grid(components_pca):
             values.extend(COMPONENTS_PCA_AUTO_GRID)
@@ -250,7 +250,7 @@ def _is_auto_components_pca_grid(value):
 def _classifier_params_for_classifier(classifier, classifier_params):
     """Expand classifier-specific parameter grids while preserving explicit values."""
 
-    params = []
+    params: list[object] = []
     for classifier_param in classifier_params:
         if _is_auto_classifier_param_grid(classifier_param):
             params.extend(CLASSIFIER_AUTO_PARAM_GRIDS.get(str(classifier), (float("nan"),)))

--- a/src/pymegdec/_stimulus_cross_subject_core.py
+++ b/src/pymegdec/_stimulus_cross_subject_core.py
@@ -19,6 +19,17 @@ from pymegdec import _stimulus_cross_subject_legacy as _impl
 DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION = "random"
 DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED = 0
 TRIAL_SELECTION_MODES = ("random", "first")
+AUTO_CLASSIFIER_PARAM_GRID_TOKEN = "auto-grid"
+CLASSIFIER_AUTO_PARAM_GRIDS = {
+    "gaussian-naive-bayes": (1e-12, 1e-9, 1e-6),
+    "multiclass-svm": (0.1, 1.0, 10.0),
+    "multiclass-svm-weighted": (0.1, 1.0, 10.0),
+    "multinomial-logistic": (0.1, 1.0, 10.0),
+    "multinomial-logistic-weighted": (0.1, 1.0, 10.0),
+    "regularized-qda": (0.25, 0.5, 0.75),
+    "shrinkage-lda": ("auto", 0.1, 0.5, 0.9),
+    "shrinkage-prototype": (0.0, 0.25, 0.5, 0.75),
+}
 
 _BASE_CROSS_SUBJECT_CONFIG = _impl.CrossSubjectStimulusConfig
 _BASE_PARTICIPANT_FEATURE_SET = _impl.ParticipantFeatureSet
@@ -208,16 +219,54 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
             signflip_permutations=signflip_permutations,
             signflip_seed=signflip_seed,
         )
-        for window_center, feature_mode, normalization, alignment, classifier, classifier_param, components_pca in _impl.product(
+        for window_center, feature_mode, normalization, alignment, classifier, components_pca in _impl.product(
             window_centers,
             feature_modes,
             normalizations,
             alignments,
             classifiers,
-            classifier_params,
             components_pca_values,
         )
+        for classifier_param in _classifier_params_for_classifier(classifier, classifier_params)
     )
+
+
+def _classifier_params_for_classifier(classifier, classifier_params):
+    """Expand classifier-specific parameter grids while preserving explicit values."""
+
+    params = []
+    for classifier_param in classifier_params:
+        if _is_auto_classifier_param_grid(classifier_param):
+            params.extend(CLASSIFIER_AUTO_PARAM_GRIDS.get(str(classifier), (float("nan"),)))
+        else:
+            params.append(classifier_param)
+    return tuple(_dedupe_classifier_params(params))
+
+
+def _is_auto_classifier_param_grid(value):
+    return isinstance(value, str) and value.strip().lower().replace("_", "-") == AUTO_CLASSIFIER_PARAM_GRID_TOKEN
+
+
+def _dedupe_classifier_params(params):
+    seen = set()
+    for param in params:
+        key = _classifier_param_dedupe_key(param)
+        if key in seen:
+            continue
+        seen.add(key)
+        yield param
+
+
+def _classifier_param_dedupe_key(param):
+    if isinstance(param, float) and np.isnan(param):
+        return ("nan",)
+    if isinstance(param, np.generic):
+        param = param.item()
+    try:
+        hash(param)
+    except TypeError:
+        return ("repr", repr(param))
+    return (type(param).__name__, param)
 
 
 def load_participant_stimulus_features(data_folder, participant, *, config=None):
@@ -524,9 +573,13 @@ def _install_module_fixes():
     _impl.DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION = DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION  # type: ignore[attr-defined]
     _impl.DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED = DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED  # type: ignore[attr-defined]
     _impl.TRIAL_SELECTION_MODES = TRIAL_SELECTION_MODES  # type: ignore[attr-defined]
+    _impl.AUTO_CLASSIFIER_PARAM_GRID_TOKEN = AUTO_CLASSIFIER_PARAM_GRID_TOKEN  # type: ignore[attr-defined]
+    _impl.CLASSIFIER_AUTO_PARAM_GRIDS = CLASSIFIER_AUTO_PARAM_GRIDS  # type: ignore[attr-defined]
     _impl.CrossSubjectStimulusConfig = CrossSubjectStimulusConfig  # type: ignore[misc]
     _impl.ParticipantFeatureSet = ParticipantFeatureSet  # type: ignore[misc]
     _impl.make_cross_subject_candidate_configs = make_cross_subject_candidate_configs
+    _impl._classifier_params_for_classifier = _classifier_params_for_classifier  # type: ignore[attr-defined]
+    _impl._is_auto_classifier_param_grid = _is_auto_classifier_param_grid  # type: ignore[attr-defined]
     _impl.load_participant_stimulus_features = load_participant_stimulus_features
     _impl.summarize_cross_subject_stimulus_smoke = summarize_cross_subject_stimulus_smoke
     _impl._ranked_label_metrics = _ranked_label_metrics

--- a/src/pymegdec/_stimulus_cross_subject_core.py
+++ b/src/pymegdec/_stimulus_cross_subject_core.py
@@ -363,6 +363,18 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
     return outer_row, prediction_rows
 
 
+def _candidate_model_scores(fitted_model, test_set, config):
+    alignment_model = _fitted_alignment_model(fitted_model)
+    test_features = _impl._normalized_subject_features(test_set, config)
+    test_features, _test_alignment_metadata = _align_test_features_by_subject(
+        test_features,
+        test_set,
+        config,
+        alignment_model,
+    )
+    return _impl._model_class_scores(fitted_model["model_bundle"], test_features)
+
+
 def _feature_cache_key(config):
     return (
         float(config.window_center),
@@ -521,6 +533,7 @@ def _install_module_fixes():
     _impl._align_training_features_by_subject = _align_training_features_by_subject
     _impl._align_test_features_by_subject = _align_test_features_by_subject  # type: ignore[attr-defined]
     _impl._score_outer_fold_model = _score_outer_fold_model
+    _impl._candidate_model_scores = _candidate_model_scores
     _impl._feature_cache_key = _feature_cache_key
     _impl._prediction_rows = _prediction_rows
     _impl._selected_trial_indices = _selected_trial_indices

--- a/src/pymegdec/_stimulus_cross_subject_core.py
+++ b/src/pymegdec/_stimulus_cross_subject_core.py
@@ -20,6 +20,8 @@ DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION = "random"
 DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED = 0
 TRIAL_SELECTION_MODES = ("random", "first")
 AUTO_CLASSIFIER_PARAM_GRID_TOKEN = "auto-grid"
+AUTO_COMPONENTS_PCA_GRID_TOKEN = "auto-grid"
+COMPONENTS_PCA_AUTO_GRID = (32, 64, 128)
 CLASSIFIER_AUTO_PARAM_GRIDS = {
     "gaussian-naive-bayes": (1e-12, 1e-9, 1e-6),
     "multiclass-svm": (0.1, 1.0, 10.0),
@@ -225,10 +227,24 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
             normalizations,
             alignments,
             classifiers,
-            components_pca_values,
+            _components_pca_values_for_grid(components_pca_values),
         )
         for classifier_param in _classifier_params_for_classifier(classifier, classifier_params)
     )
+
+
+def _components_pca_values_for_grid(components_pca_values):
+    values = []
+    for components_pca in components_pca_values:
+        if _is_auto_components_pca_grid(components_pca):
+            values.extend(COMPONENTS_PCA_AUTO_GRID)
+        else:
+            values.append(components_pca)
+    return tuple(_dedupe_classifier_params(values))
+
+
+def _is_auto_components_pca_grid(value):
+    return isinstance(value, str) and value.strip().lower().replace("_", "-") == AUTO_COMPONENTS_PCA_GRID_TOKEN
 
 
 def _classifier_params_for_classifier(classifier, classifier_params):
@@ -574,12 +590,16 @@ def _install_module_fixes():
     _impl.DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED = DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED  # type: ignore[attr-defined]
     _impl.TRIAL_SELECTION_MODES = TRIAL_SELECTION_MODES  # type: ignore[attr-defined]
     _impl.AUTO_CLASSIFIER_PARAM_GRID_TOKEN = AUTO_CLASSIFIER_PARAM_GRID_TOKEN  # type: ignore[attr-defined]
+    _impl.AUTO_COMPONENTS_PCA_GRID_TOKEN = AUTO_COMPONENTS_PCA_GRID_TOKEN  # type: ignore[attr-defined]
     _impl.CLASSIFIER_AUTO_PARAM_GRIDS = CLASSIFIER_AUTO_PARAM_GRIDS  # type: ignore[attr-defined]
+    _impl.COMPONENTS_PCA_AUTO_GRID = COMPONENTS_PCA_AUTO_GRID  # type: ignore[attr-defined]
     _impl.CrossSubjectStimulusConfig = CrossSubjectStimulusConfig  # type: ignore[misc]
     _impl.ParticipantFeatureSet = ParticipantFeatureSet  # type: ignore[misc]
     _impl.make_cross_subject_candidate_configs = make_cross_subject_candidate_configs
     _impl._classifier_params_for_classifier = _classifier_params_for_classifier  # type: ignore[attr-defined]
     _impl._is_auto_classifier_param_grid = _is_auto_classifier_param_grid  # type: ignore[attr-defined]
+    _impl._components_pca_values_for_grid = _components_pca_values_for_grid  # type: ignore[attr-defined]
+    _impl._is_auto_components_pca_grid = _is_auto_components_pca_grid  # type: ignore[attr-defined]
     _impl.load_participant_stimulus_features = load_participant_stimulus_features
     _impl.summarize_cross_subject_stimulus_smoke = summarize_cross_subject_stimulus_smoke
     _impl._ranked_label_metrics = _ranked_label_metrics

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -48,6 +48,9 @@ DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA = 64
 DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS = (0.150, 0.175, 0.200)
 DEFAULT_CROSS_SUBJECT_SELECTION_METRIC = "balanced_accuracy"
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE = 1
+DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING = "uniform"
+DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE = 0.02
+SELECTION_ENSEMBLE_WEIGHTING_MODES = ("uniform", "inner_softmax")
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
 NESTED_SCORE_ENSEMBLE_NORMALIZATION = "row_z_softmax"
 FEATURE_MODES = ("sensor_mean", "sensor_flat")
@@ -173,6 +176,8 @@ def evaluate_nested_cross_subject_stimulus(
     candidate_configs,
     outer_participants=None,
     selection_ensemble_size=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
+    selection_ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
+    selection_ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
     progress=None,
     existing_artifacts=None,
     after_outer_fold=None,
@@ -190,6 +195,8 @@ def evaluate_nested_cross_subject_stimulus(
         raise ValueError("At least one candidate configuration is required.")
     outer_participants = _normalize_outer_participants(participants, outer_participants)
     selection_ensemble_size = _normalize_selection_ensemble_size(selection_ensemble_size)
+    selection_ensemble_weighting = _normalize_selection_ensemble_weighting(selection_ensemble_weighting)
+    selection_ensemble_temperature = _normalize_selection_ensemble_temperature(selection_ensemble_temperature)
 
     resumed = _existing_nested_artifact_rows(existing_artifacts)
     inner_rows = resumed["inner_validation"]
@@ -212,6 +219,8 @@ def evaluate_nested_cross_subject_stimulus(
             feature_cache,
             inner_pair_cache,
             selection_ensemble_size=selection_ensemble_size,
+            selection_ensemble_weighting=selection_ensemble_weighting,
+            selection_ensemble_temperature=selection_ensemble_temperature,
             progress=progress,
             label_shuffle_control=label_shuffle_control,
             label_shuffle_seed=label_shuffle_seed,
@@ -421,6 +430,16 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
     label_shuffle_seed = _single_row_value(outer_rows, "label_shuffle_seed", default="")
     outer_evaluation_mode = _single_row_value(outer_rows, "outer_evaluation_mode", default="single_best")
     selection_ensemble_size = _single_row_value(outer_rows, "selection_ensemble_size", default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE)
+    selection_ensemble_weighting = _single_row_value(
+        outer_rows,
+        "selection_ensemble_weighting",
+        default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
+    )
+    selection_ensemble_temperature = _single_row_value(
+        outer_rows,
+        "selection_ensemble_temperature",
+        default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
+    )
     ensemble_candidate_counts = _row_semicolon_value_counts(outer_rows, "selected_candidate_indices")
     return [
         {
@@ -430,6 +449,8 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
             "selection_metric": DEFAULT_CROSS_SUBJECT_SELECTION_METRIC,
             "outer_evaluation_mode": outer_evaluation_mode,
             "selection_ensemble_size": selection_ensemble_size,
+            "selection_ensemble_weighting": selection_ensemble_weighting,
+            "selection_ensemble_temperature": selection_ensemble_temperature,
             "label_shuffle_control": label_shuffle_control,
             "label_shuffle_seed": label_shuffle_seed,
             "n_candidates": int(max(int(row["n_candidates"]) for row in outer_rows)),
@@ -770,6 +791,8 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
     write_incremental=False,
     outer_participants=None,
     selection_ensemble_size=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
+    selection_ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
+    selection_ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
     progress=None,
     label_shuffle_control=False,
     label_shuffle_seed=0,
@@ -809,6 +832,8 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
         existing_artifacts=existing_artifacts,
         after_outer_fold=write_outputs if write_incremental else None,
         selection_ensemble_size=selection_ensemble_size,
+        selection_ensemble_weighting=selection_ensemble_weighting,
+        selection_ensemble_temperature=selection_ensemble_temperature,
         label_shuffle_control=label_shuffle_control,
         label_shuffle_seed=label_shuffle_seed,
     )
@@ -843,6 +868,8 @@ def _evaluate_nested_outer_fold(
     inner_pair_cache,
     *,
     selection_ensemble_size=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
+    selection_ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
+    selection_ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
     progress=None,
     label_shuffle_control=False,
     label_shuffle_seed=0,
@@ -863,6 +890,8 @@ def _evaluate_nested_outer_fold(
     selected_row, selected_candidate_rows = _select_nested_candidate_ensemble(
         outer_inner_rows,
         selection_ensemble_size=selection_ensemble_size,
+        selection_ensemble_weighting=selection_ensemble_weighting,
+        selection_ensemble_temperature=selection_ensemble_temperature,
         candidate_configs=candidate_configs,
     )
     if int(selected_row["selection_ensemble_size"]) == 1:
@@ -904,6 +933,13 @@ def _evaluate_nested_outer_fold(
             test_sets,
             selected_configs,
             selected_candidate_rows,
+            ensemble_weights=_nested_ensemble_weights(
+                selected_candidate_rows,
+                weighting=selected_row["selection_ensemble_weighting"],
+                temperature=selected_row["selection_ensemble_temperature"],
+            ),
+            ensemble_weighting=selected_row["selection_ensemble_weighting"],
+            ensemble_temperature=selected_row["selection_ensemble_temperature"],
             include_predictions=True,
         )
     _add_selected_candidate_fields(outer_row, selected_row)
@@ -914,6 +950,7 @@ def _evaluate_nested_outer_fold(
             "DONE outer_test_participant="
             f"{test_participant} selected_candidate={selected_row['selected_candidate_index']} "
             f"selection_ensemble_size={selected_row['selection_ensemble_size']} "
+            f"selection_ensemble_weighting={selected_row['selection_ensemble_weighting']} "
             f"inner_mean={selected_row['selected_inner_balanced_accuracy_mean']:.4f} "
             f"outer_balanced_accuracy={outer_row['balanced_accuracy']:.4f}"
         )
@@ -1151,20 +1188,30 @@ def _select_nested_candidate(inner_rows):
     return _rank_nested_candidates(inner_rows)[0]
 
 
-def _select_nested_candidate_ensemble(inner_rows, *, selection_ensemble_size, candidate_configs):
+def _select_nested_candidate_ensemble(
+    inner_rows,
+    *,
+    selection_ensemble_size,
+    selection_ensemble_weighting,
+    selection_ensemble_temperature,
+    candidate_configs,
+):
     ranked = _rank_nested_candidates(inner_rows)
     requested_size = _normalize_selection_ensemble_size(selection_ensemble_size)
+    weighting = _normalize_selection_ensemble_weighting(selection_ensemble_weighting)
+    temperature = _normalize_selection_ensemble_temperature(selection_ensemble_temperature)
     selected_rows = tuple(ranked[: min(requested_size, len(ranked))])
+    weights = _nested_ensemble_weights(selected_rows, weighting=weighting, temperature=temperature)
     selected = dict(selected_rows[0])
     selected["selection_ensemble_requested_size"] = int(requested_size)
     selected["selection_ensemble_size"] = int(len(selected_rows))
+    selected["selection_ensemble_weighting"] = weighting
+    selected["selection_ensemble_temperature"] = float(temperature)
     selected["selected_candidate_indices"] = _format_sequence(row["selected_candidate_index"] for row in selected_rows)
     selected["selected_ensemble_inner_balanced_accuracy_means"] = _format_float_mapping(
         (row["selected_candidate_index"], row["selected_inner_balanced_accuracy_mean"]) for row in selected_rows
     )
-    selected["selected_ensemble_weights"] = _format_float_mapping(
-        (row["selected_candidate_index"], 1.0 / len(selected_rows)) for row in selected_rows
-    )
+    selected["selected_ensemble_weights"] = _format_float_mapping((row["selected_candidate_index"], weight) for row, weight in zip(selected_rows, weights))
     selected_configs = tuple(candidate_configs[int(row["selected_candidate_index"]) - 1] for row in selected_rows)
     selected["selected_ensemble_classifier_counts"] = _format_counter(Counter(config.classifier for config in selected_configs))
     selected["selected_ensemble_window_center_counts"] = _format_counter(Counter(float(config.window_center) for config in selected_configs))
@@ -1173,6 +1220,30 @@ def _select_nested_candidate_ensemble(inner_rows, *, selection_ensemble_size, ca
     selected["selected_ensemble_alignment_counts"] = _format_counter(Counter(config.alignment for config in selected_configs))
     selected["selected_ensemble_components_pca_counts"] = _format_counter(Counter(str(config.components_pca) for config in selected_configs))
     return selected, selected_rows
+
+
+def _nested_ensemble_weights(
+    selected_rows,
+    *,
+    weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
+    temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
+):
+    selected_rows = tuple(selected_rows)
+    if not selected_rows:
+        raise ValueError("At least one selected candidate row is required for ensemble weighting.")
+    weighting = _normalize_selection_ensemble_weighting(weighting)
+    temperature = _normalize_selection_ensemble_temperature(temperature)
+    if weighting == "uniform" or len(selected_rows) == 1:
+        return np.full(len(selected_rows), 1.0 / len(selected_rows), dtype=float)
+    scores = np.asarray([float(row["selected_inner_balanced_accuracy_mean"]) for row in selected_rows], dtype=float)
+    if not np.all(np.isfinite(scores)):
+        return np.full(len(selected_rows), 1.0 / len(selected_rows), dtype=float)
+    logits = (scores - np.max(scores)) / float(temperature)
+    weights = np.exp(np.clip(logits, -50.0, 50.0))
+    weight_sum = float(np.sum(weights))
+    if weight_sum <= 0.0 or not np.isfinite(weight_sum):
+        return np.full(len(selected_rows), 1.0 / len(selected_rows), dtype=float)
+    return weights / weight_sum
 
 
 def _rank_nested_candidates(inner_rows):
@@ -1239,6 +1310,8 @@ def _rank_nested_candidates(inner_rows):
         row["selected_inner_winner_margin"] = winner_margin if rank == 1 else selected_mean - float(row["selected_inner_balanced_accuracy_mean"])
         row["selection_ensemble_requested_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
         row["selection_ensemble_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
+        row["selection_ensemble_weighting"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING
+        row["selection_ensemble_temperature"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE
         row["selected_candidate_indices"] = str(row["selected_candidate_index"])
         row["selected_ensemble_inner_balanced_accuracy_means"] = _format_float_mapping(
             ((row["selected_candidate_index"], row["selected_inner_balanced_accuracy_mean"]),)
@@ -1404,7 +1477,17 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
     return outer_row, prediction_rows
 
 
-def _score_outer_fold_ensemble_models(fitted_models, test_sets, configs, selected_rows, *, include_predictions=True):
+def _score_outer_fold_ensemble_models(
+    fitted_models,
+    test_sets,
+    configs,
+    selected_rows,
+    *,
+    ensemble_weights=None,
+    ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
+    ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
+    include_predictions=True,
+):
     fitted_models = tuple(fitted_models)
     test_sets = tuple(test_sets)
     configs = tuple(configs)
@@ -1415,7 +1498,7 @@ def _score_outer_fold_ensemble_models(fitted_models, test_sets, configs, selecte
         raise ValueError("Ensemble fitted models, test sets, configs, and selected rows must have the same length.")
 
     reference_test_set, test_labels, class_order = _validate_ensemble_test_sets(test_sets, configs)
-    weights = np.full(len(fitted_models), 1.0 / len(fitted_models), dtype=float)
+    weights = _normalized_ensemble_weights(ensemble_weights, len(fitted_models))
     probability_matrices = []
     actual_components = []
     for fitted_model, test_set, config in zip(fitted_models, test_sets, configs):
@@ -1454,6 +1537,8 @@ def _score_outer_fold_ensemble_models(fitted_models, test_sets, configs, selecte
         configs,
         weights=weights,
         actual_components=actual_components,
+        ensemble_weighting=ensemble_weighting,
+        ensemble_temperature=ensemble_temperature,
     )
 
     prediction_rows = []
@@ -1474,6 +1559,8 @@ def _score_outer_fold_ensemble_models(fitted_models, test_sets, configs, selecte
                 configs,
                 weights=weights,
                 actual_components=actual_components,
+                ensemble_weighting=ensemble_weighting,
+                ensemble_temperature=ensemble_temperature,
             )
     return outer_row, prediction_rows
 
@@ -1541,6 +1628,21 @@ def _align_score_columns(probabilities, score_classes, class_order):
     return aligned
 
 
+def _normalized_ensemble_weights(weights, expected_size):
+    expected_size = int(expected_size)
+    if weights is None:
+        return np.full(expected_size, 1.0 / expected_size, dtype=float)
+    weights = np.asarray(weights, dtype=float).ravel()
+    if weights.shape[0] != expected_size:
+        raise ValueError("Ensemble weights must match the number of fitted models.")
+    if np.any(weights < 0.0) or not np.all(np.isfinite(weights)):
+        raise ValueError("Ensemble weights must be finite and non-negative.")
+    weight_sum = float(np.sum(weights))
+    if weight_sum <= 0.0:
+        raise ValueError("At least one ensemble weight must be positive.")
+    return weights / weight_sum
+
+
 def _feature_set_trial_indices(feature_set):
     trial_indices = getattr(feature_set, "trial_indices", None)
     if trial_indices is None:
@@ -1548,10 +1650,21 @@ def _feature_set_trial_indices(feature_set):
     return np.asarray(trial_indices, dtype=int).ravel()
 
 
-def _add_ensemble_output_fields(row, selected_rows, configs, *, weights, actual_components):
+def _add_ensemble_output_fields(
+    row,
+    selected_rows,
+    configs,
+    *,
+    weights,
+    actual_components,
+    ensemble_weighting,
+    ensemble_temperature,
+):
     candidate_indices = tuple(int(selected_row["selected_candidate_index"]) for selected_row in selected_rows)
     row["outer_evaluation_mode"] = "topk_score_ensemble"
     row["selection_ensemble_size"] = int(len(candidate_indices))
+    row["selection_ensemble_weighting"] = _normalize_selection_ensemble_weighting(ensemble_weighting)
+    row["selection_ensemble_temperature"] = float(_normalize_selection_ensemble_temperature(ensemble_temperature))
     row["ensemble_score_normalization"] = NESTED_SCORE_ENSEMBLE_NORMALIZATION
     row["ensemble_candidate_indices"] = _format_sequence(candidate_indices)
     row["ensemble_weights"] = _format_float_mapping(zip(candidate_indices, weights))
@@ -2099,6 +2212,20 @@ def _normalize_selection_ensemble_size(value):
     value = int(value)
     if value <= 0:
         raise ValueError("selection_ensemble_size must be positive.")
+    return value
+
+
+def _normalize_selection_ensemble_weighting(value):
+    normalized = str(value).strip().lower().replace("-", "_")
+    if normalized not in SELECTION_ENSEMBLE_WEIGHTING_MODES:
+        raise ValueError(f"selection_ensemble_weighting must be one of {SELECTION_ENSEMBLE_WEIGHTING_MODES}.")
+    return normalized
+
+
+def _normalize_selection_ensemble_temperature(value):
+    value = float(value)
+    if value <= 0.0 or not np.isfinite(value):
+        raise ValueError("selection_ensemble_temperature must be a positive finite value.")
     return value
 
 

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -57,7 +57,7 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax")
 SELECTION_ENSEMBLE_DIVERSITY_MODES = ("none", "window", "classifier", "window_classifier", "full_config")
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
 NESTED_SCORE_ENSEMBLE_NORMALIZATION = DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
-FEATURE_MODES = ("sensor_mean", "sensor_flat")
+FEATURE_MODES = ("sensor_mean", "sensor_flat", "sensor_mean_slope")
 NORMALIZATION_MODES = ("none", "subject_z", "subject_trial_z", "subject_baseline_z", "subject_baseline_whiten")
 ALIGNMENT_MODES = ("none", "train_class_procrustes")
 BASELINE_WHITENING_SHRINKAGE = 0.1
@@ -1135,12 +1135,13 @@ def _participant_class_channel_patterns(features, labels, feature_set, common_cl
 
 def _features_as_trial_channel_matrix(features, feature_set):
     features = np.asarray(features, dtype=float)
-    if features.shape[1] == int(feature_set.n_channels):
+    n_channels = int(feature_set.n_channels)
+    if features.shape[1] == n_channels:
         return features[:, None, :]
-    expected_width = int(feature_set.n_window_samples) * int(feature_set.n_channels)
-    if features.shape[1] != expected_width:
-        raise ValueError("Feature width is incompatible with n_window_samples and n_channels.")
-    return features.reshape(features.shape[0], int(feature_set.n_window_samples), int(feature_set.n_channels))
+    if features.shape[1] % n_channels:
+        raise ValueError("Feature width is incompatible with n_channels.")
+    n_feature_blocks = int(features.shape[1] // n_channels)
+    return features.reshape(features.shape[0], n_feature_blocks, n_channels)
 
 
 def _fit_channel_procrustes_transforms(class_patterns):
@@ -1176,7 +1177,7 @@ def _apply_channel_pattern_transform(patterns, transform):
 def _apply_channel_procrustes_transform(features, feature_set, transform):
     channel_features = _features_as_trial_channel_matrix(features, feature_set)
     aligned = (channel_features - transform["source_center"]) @ transform["rotation"] + transform["target_center"]
-    if feature_set.n_window_samples == 1:
+    if aligned.shape[1] == 1:
         return aligned[:, 0, :]
     return aligned.reshape(features.shape[0], -1)
 
@@ -1929,15 +1930,30 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = np.mean(window_signal, axis=1)
         elif feature_mode == "sensor_flat":
             feature = window_signal.reshape(-1, order="F")
+        elif feature_mode == "sensor_mean_slope":
+            feature = _sensor_mean_slope_feature(window_signal, time_vector[mask])
         else:
             raise ValueError(f"Unsupported feature_mode: {feature_mode}")
         features.append(feature)
     return np.vstack(features), int(np.sum(mask))
 
 
+def _sensor_mean_slope_feature(window_signal, window_time):
+    window_signal = np.asarray(window_signal, dtype=float)
+    window_time = np.asarray(window_time, dtype=float).ravel()
+    means = np.mean(window_signal, axis=1)
+    if window_signal.shape[1] < 2 or np.ptp(window_time) <= 1e-12:
+        slopes = np.zeros(window_signal.shape[0], dtype=float)
+    else:
+        scaled_time = (window_time - np.mean(window_time)) / np.ptp(window_time)
+        denominator = float(np.sum(np.square(scaled_time)))
+        slopes = (window_signal - means[:, None]) @ scaled_time / denominator
+    return np.concatenate((means, slopes))
+
+
 def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
-    if config.feature_mode == "sensor_mean":
-        baseline_features, n_baseline_samples = _extract_window_features(data, config.baseline_window, feature_mode="sensor_mean", trial_indices=trial_indices)
+    if config.feature_mode in {"sensor_mean", "sensor_mean_slope"}:
+        baseline_features, n_baseline_samples = _extract_window_features(data, config.baseline_window, feature_mode=config.feature_mode, trial_indices=trial_indices)
         mean = np.mean(baseline_features, axis=0, keepdims=True)
         std = np.std(baseline_features, axis=0, keepdims=True)
         return mean, _nonzero_std(std), n_baseline_samples
@@ -2143,7 +2159,7 @@ def _baseline_whiten_features(features, config, baseline_feature_mean, baseline_
     whitening_matrix = np.asarray(baseline_whitening_matrix, dtype=float)
     if config.feature_mode == "sensor_mean":
         return centered @ whitening_matrix.T
-    if config.feature_mode == "sensor_flat":
+    if config.feature_mode in {"sensor_flat", "sensor_mean_slope"}:
         return _baseline_whiten_sensor_flat_features(centered, whitening_matrix)
     raise ValueError(f"Unsupported feature_mode: {config.feature_mode}")
 

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -2273,7 +2273,7 @@ def _format_float_mapping(items):
 
 
 def _row_semicolon_value_counts(rows, key):
-    counter = Counter()
+    counter: Counter[str] = Counter()
     for row in rows:
         value = row.get(key)
         if value in (None, ""):

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -51,8 +51,10 @@ DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE = 1
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING = "uniform"
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE = 0.02
 DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION = "row_z_softmax"
+DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY = "none"
 SELECTION_ENSEMBLE_WEIGHTING_MODES = ("uniform", "inner_softmax")
 ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax")
+SELECTION_ENSEMBLE_DIVERSITY_MODES = ("none", "window", "classifier", "window_classifier", "full_config")
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
 NESTED_SCORE_ENSEMBLE_NORMALIZATION = DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
 FEATURE_MODES = ("sensor_mean", "sensor_flat")
@@ -181,6 +183,7 @@ def evaluate_nested_cross_subject_stimulus(
     selection_ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
     selection_ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
     selection_ensemble_score_normalization=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
+    selection_ensemble_diversity=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY,
     progress=None,
     existing_artifacts=None,
     after_outer_fold=None,
@@ -201,6 +204,7 @@ def evaluate_nested_cross_subject_stimulus(
     selection_ensemble_weighting = _normalize_selection_ensemble_weighting(selection_ensemble_weighting)
     selection_ensemble_temperature = _normalize_selection_ensemble_temperature(selection_ensemble_temperature)
     selection_ensemble_score_normalization = _normalize_ensemble_score_normalization(selection_ensemble_score_normalization)
+    selection_ensemble_diversity = _normalize_selection_ensemble_diversity(selection_ensemble_diversity)
 
     resumed = _existing_nested_artifact_rows(existing_artifacts)
     inner_rows = resumed["inner_validation"]
@@ -226,6 +230,7 @@ def evaluate_nested_cross_subject_stimulus(
             selection_ensemble_weighting=selection_ensemble_weighting,
             selection_ensemble_temperature=selection_ensemble_temperature,
             selection_ensemble_score_normalization=selection_ensemble_score_normalization,
+            selection_ensemble_diversity=selection_ensemble_diversity,
             progress=progress,
             label_shuffle_control=label_shuffle_control,
             label_shuffle_seed=label_shuffle_seed,
@@ -435,6 +440,11 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
     label_shuffle_seed = _single_row_value(outer_rows, "label_shuffle_seed", default="")
     outer_evaluation_mode = _single_row_value(outer_rows, "outer_evaluation_mode", default="single_best")
     selection_ensemble_size = _single_row_value(outer_rows, "selection_ensemble_size", default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE)
+    selection_ensemble_diversity = _single_row_value(
+        outer_rows,
+        "selection_ensemble_diversity",
+        default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY,
+    )
     selection_ensemble_score_normalization = _single_row_value(
         outer_rows,
         "selection_ensemble_score_normalization",
@@ -459,6 +469,7 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
             "selection_metric": DEFAULT_CROSS_SUBJECT_SELECTION_METRIC,
             "outer_evaluation_mode": outer_evaluation_mode,
             "selection_ensemble_size": selection_ensemble_size,
+            "selection_ensemble_diversity": selection_ensemble_diversity,
             "selection_ensemble_score_normalization": selection_ensemble_score_normalization,
             "selection_ensemble_weighting": selection_ensemble_weighting,
             "selection_ensemble_temperature": selection_ensemble_temperature,
@@ -805,6 +816,7 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
     selection_ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
     selection_ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
     selection_ensemble_score_normalization=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
+    selection_ensemble_diversity=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY,
     progress=None,
     label_shuffle_control=False,
     label_shuffle_seed=0,
@@ -847,6 +859,7 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
         selection_ensemble_weighting=selection_ensemble_weighting,
         selection_ensemble_temperature=selection_ensemble_temperature,
         selection_ensemble_score_normalization=selection_ensemble_score_normalization,
+        selection_ensemble_diversity=selection_ensemble_diversity,
         label_shuffle_control=label_shuffle_control,
         label_shuffle_seed=label_shuffle_seed,
     )
@@ -884,6 +897,7 @@ def _evaluate_nested_outer_fold(
     selection_ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
     selection_ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
     selection_ensemble_score_normalization=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
+    selection_ensemble_diversity=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY,
     progress=None,
     label_shuffle_control=False,
     label_shuffle_seed=0,
@@ -907,6 +921,7 @@ def _evaluate_nested_outer_fold(
         selection_ensemble_weighting=selection_ensemble_weighting,
         selection_ensemble_temperature=selection_ensemble_temperature,
         selection_ensemble_score_normalization=selection_ensemble_score_normalization,
+        selection_ensemble_diversity=selection_ensemble_diversity,
         candidate_configs=candidate_configs,
     )
     if int(selected_row["selection_ensemble_size"]) == 1:
@@ -966,6 +981,7 @@ def _evaluate_nested_outer_fold(
             "DONE outer_test_participant="
             f"{test_participant} selected_candidate={selected_row['selected_candidate_index']} "
             f"selection_ensemble_size={selected_row['selection_ensemble_size']} "
+            f"selection_ensemble_diversity={selected_row['selection_ensemble_diversity']} "
             f"score_normalization={selected_row['selection_ensemble_score_normalization']} "
             f"selection_ensemble_weighting={selected_row['selection_ensemble_weighting']} "
             f"inner_mean={selected_row['selected_inner_balanced_accuracy_mean']:.4f} "
@@ -1212,6 +1228,7 @@ def _select_nested_candidate_ensemble(
     selection_ensemble_weighting,
     selection_ensemble_temperature,
     selection_ensemble_score_normalization,
+    selection_ensemble_diversity,
     candidate_configs,
 ):
     ranked = _rank_nested_candidates(inner_rows)
@@ -1219,11 +1236,18 @@ def _select_nested_candidate_ensemble(
     weighting = _normalize_selection_ensemble_weighting(selection_ensemble_weighting)
     temperature = _normalize_selection_ensemble_temperature(selection_ensemble_temperature)
     score_normalization = _normalize_ensemble_score_normalization(selection_ensemble_score_normalization)
-    selected_rows = tuple(ranked[: min(requested_size, len(ranked))])
+    diversity = _normalize_selection_ensemble_diversity(selection_ensemble_diversity)
+    selected_rows = _select_diverse_nested_rows(
+        ranked,
+        requested_size=requested_size,
+        candidate_configs=candidate_configs,
+        diversity=diversity,
+    )
     weights = _nested_ensemble_weights(selected_rows, weighting=weighting, temperature=temperature)
     selected = dict(selected_rows[0])
     selected["selection_ensemble_requested_size"] = int(requested_size)
     selected["selection_ensemble_size"] = int(len(selected_rows))
+    selected["selection_ensemble_diversity"] = diversity
     selected["selection_ensemble_score_normalization"] = score_normalization
     selected["selection_ensemble_weighting"] = weighting
     selected["selection_ensemble_temperature"] = float(temperature)
@@ -1239,7 +1263,59 @@ def _select_nested_candidate_ensemble(
     selected["selected_ensemble_normalization_counts"] = _format_counter(Counter(config.normalization for config in selected_configs))
     selected["selected_ensemble_alignment_counts"] = _format_counter(Counter(config.alignment for config in selected_configs))
     selected["selected_ensemble_components_pca_counts"] = _format_counter(Counter(str(config.components_pca) for config in selected_configs))
+    selected["selected_ensemble_diversity_keys"] = _format_sequence(
+        _ensemble_diversity_key(candidate_configs[int(row["selected_candidate_index"]) - 1], diversity)
+        for row in selected_rows
+    )
     return selected, selected_rows
+
+
+def _select_diverse_nested_rows(ranked_rows, *, requested_size, candidate_configs, diversity):
+    ranked_rows = tuple(ranked_rows)
+    requested_size = min(_normalize_selection_ensemble_size(requested_size), len(ranked_rows))
+    diversity = _normalize_selection_ensemble_diversity(diversity)
+    if diversity == "none":
+        return tuple(ranked_rows[:requested_size])
+
+    selected = []
+    selected_indices = set()
+    seen_keys = set()
+    for row in ranked_rows:
+        key = _ensemble_diversity_key(candidate_configs[int(row["selected_candidate_index"]) - 1], diversity)
+        if key in seen_keys:
+            continue
+        selected.append(row)
+        selected_indices.add(int(row["selected_candidate_index"]))
+        seen_keys.add(key)
+        if len(selected) == requested_size:
+            return tuple(selected)
+
+    for row in ranked_rows:
+        candidate_index = int(row["selected_candidate_index"])
+        if candidate_index in selected_indices:
+            continue
+        selected.append(row)
+        if len(selected) == requested_size:
+            break
+    return tuple(selected)
+
+
+def _ensemble_diversity_key(config, diversity):
+    diversity = _normalize_selection_ensemble_diversity(diversity)
+    if diversity == "none":
+        return "all"
+    if diversity == "window":
+        return f"window={float(config.window_center):.6g}/{float(config.window_size):.6g}"
+    if diversity == "classifier":
+        return f"classifier={config.classifier}"
+    if diversity == "window_classifier":
+        return f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},classifier={config.classifier}"
+    return (
+        f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
+        f"feature={config.feature_mode},norm={config.normalization},alignment={config.alignment},"
+        f"classifier={config.classifier},param={config.classifier_param},pca={config.components_pca},"
+        f"trial_cap={config.max_trials_per_class_per_participant}"
+    )
 
 
 def _nested_ensemble_weights(
@@ -1330,6 +1406,7 @@ def _rank_nested_candidates(inner_rows):
         row["selected_inner_winner_margin"] = winner_margin if rank == 1 else selected_mean - float(row["selected_inner_balanced_accuracy_mean"])
         row["selection_ensemble_requested_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
         row["selection_ensemble_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
+        row["selection_ensemble_diversity"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY
         row["selection_ensemble_score_normalization"] = DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
         row["selection_ensemble_weighting"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING
         row["selection_ensemble_temperature"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE
@@ -2270,6 +2347,13 @@ def _normalize_selection_ensemble_size(value):
     if value <= 0:
         raise ValueError("selection_ensemble_size must be positive.")
     return value
+
+
+def _normalize_selection_ensemble_diversity(value):
+    normalized = str(value).strip().lower().replace("-", "_")
+    if normalized not in SELECTION_ENSEMBLE_DIVERSITY_MODES:
+        raise ValueError(f"selection_ensemble_diversity must be one of {SELECTION_ENSEMBLE_DIVERSITY_MODES}.")
+    return normalized
 
 
 def _normalize_ensemble_score_normalization(value):

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -57,7 +57,7 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax")
 SELECTION_ENSEMBLE_DIVERSITY_MODES = ("none", "window", "classifier", "window_classifier", "full_config")
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
 NESTED_SCORE_ENSEMBLE_NORMALIZATION = DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
-FEATURE_MODES = ("sensor_mean", "sensor_flat", "sensor_mean_slope")
+FEATURE_MODES = ("sensor_mean", "sensor_flat", "sensor_mean_slope", "sensor_mean_slope_std")
 NORMALIZATION_MODES = ("none", "subject_z", "subject_trial_z", "subject_baseline_z", "subject_baseline_whiten")
 ALIGNMENT_MODES = ("none", "train_class_procrustes")
 BASELINE_WHITENING_SHRINKAGE = 0.1
@@ -1932,6 +1932,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = window_signal.reshape(-1, order="F")
         elif feature_mode == "sensor_mean_slope":
             feature = _sensor_mean_slope_feature(window_signal, time_vector[mask])
+        elif feature_mode == "sensor_mean_slope_std":
+            feature = _sensor_mean_slope_std_feature(window_signal, time_vector[mask])
         else:
             raise ValueError(f"Unsupported feature_mode: {feature_mode}")
         features.append(feature)
@@ -1942,17 +1944,29 @@ def _sensor_mean_slope_feature(window_signal, window_time):
     window_signal = np.asarray(window_signal, dtype=float)
     window_time = np.asarray(window_time, dtype=float).ravel()
     means = np.mean(window_signal, axis=1)
-    if window_signal.shape[1] < 2 or np.ptp(window_time) <= 1e-12:
-        slopes = np.zeros(window_signal.shape[0], dtype=float)
-    else:
-        scaled_time = (window_time - np.mean(window_time)) / np.ptp(window_time)
-        denominator = float(np.sum(np.square(scaled_time)))
-        slopes = (window_signal - means[:, None]) @ scaled_time / denominator
+    slopes = _sensor_window_slopes(window_signal, window_time, means)
     return np.concatenate((means, slopes))
 
 
+def _sensor_mean_slope_std_feature(window_signal, window_time):
+    window_signal = np.asarray(window_signal, dtype=float)
+    window_time = np.asarray(window_time, dtype=float).ravel()
+    means = np.mean(window_signal, axis=1)
+    slopes = _sensor_window_slopes(window_signal, window_time, means)
+    stds = np.std(window_signal, axis=1)
+    return np.concatenate((means, slopes, stds))
+
+
+def _sensor_window_slopes(window_signal, window_time, means):
+    if window_signal.shape[1] < 2 or np.ptp(window_time) <= 1e-12:
+        return np.zeros(window_signal.shape[0], dtype=float)
+    scaled_time = (window_time - np.mean(window_time)) / np.ptp(window_time)
+    denominator = float(np.sum(np.square(scaled_time)))
+    return (window_signal - means[:, None]) @ scaled_time / denominator
+
+
 def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
-    if config.feature_mode in {"sensor_mean", "sensor_mean_slope"}:
+    if config.feature_mode in {"sensor_mean", "sensor_mean_slope", "sensor_mean_slope_std"}:
         baseline_features, n_baseline_samples = _extract_window_features(data, config.baseline_window, feature_mode=config.feature_mode, trial_indices=trial_indices)
         mean = np.mean(baseline_features, axis=0, keepdims=True)
         std = np.std(baseline_features, axis=0, keepdims=True)
@@ -2159,7 +2173,7 @@ def _baseline_whiten_features(features, config, baseline_feature_mean, baseline_
     whitening_matrix = np.asarray(baseline_whitening_matrix, dtype=float)
     if config.feature_mode == "sensor_mean":
         return centered @ whitening_matrix.T
-    if config.feature_mode in {"sensor_flat", "sensor_mean_slope"}:
+    if config.feature_mode in {"sensor_flat", "sensor_mean_slope", "sensor_mean_slope_std"}:
         return _baseline_whiten_sensor_flat_features(centered, whitening_matrix)
     raise ValueError(f"Unsupported feature_mode: {config.feature_mode}")
 

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -52,7 +52,7 @@ DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING = "uniform"
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE = 0.02
 DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION = "row_z_softmax"
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY = "none"
-SELECTION_ENSEMBLE_WEIGHTING_MODES = ("uniform", "inner_softmax")
+SELECTION_ENSEMBLE_WEIGHTING_MODES = ("uniform", "inner_softmax", "inner_lcb_softmax")
 ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax")
 SELECTION_ENSEMBLE_DIVERSITY_MODES = ("none", "window", "classifier", "window_classifier", "full_config")
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
@@ -1331,7 +1331,7 @@ def _nested_ensemble_weights(
     temperature = _normalize_selection_ensemble_temperature(temperature)
     if weighting == "uniform" or len(selected_rows) == 1:
         return np.full(len(selected_rows), 1.0 / len(selected_rows), dtype=float)
-    scores = np.asarray([float(row["selected_inner_balanced_accuracy_mean"]) for row in selected_rows], dtype=float)
+    scores = _nested_ensemble_weight_scores(selected_rows, weighting=weighting)
     if not np.all(np.isfinite(scores)):
         return np.full(len(selected_rows), 1.0 / len(selected_rows), dtype=float)
     logits = (scores - np.max(scores)) / float(temperature)
@@ -1340,6 +1340,18 @@ def _nested_ensemble_weights(
     if weight_sum <= 0.0 or not np.isfinite(weight_sum):
         return np.full(len(selected_rows), 1.0 / len(selected_rows), dtype=float)
     return weights / weight_sum
+
+
+def _nested_ensemble_weight_scores(selected_rows, *, weighting):
+    weighting = _normalize_selection_ensemble_weighting(weighting)
+    means = np.asarray([float(row["selected_inner_balanced_accuracy_mean"]) for row in selected_rows], dtype=float)
+    if weighting == "inner_softmax":
+        return means
+    if weighting == "inner_lcb_softmax":
+        sems = np.asarray([float(row.get("selected_inner_balanced_accuracy_sem", 0.0)) for row in selected_rows], dtype=float)
+        sems = np.where(np.isfinite(sems), np.maximum(sems, 0.0), 0.0)
+        return means - sems
+    raise ValueError(f"Unsupported selection_ensemble_weighting: {weighting}")
 
 
 def _rank_nested_candidates(inner_rows):

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -50,9 +50,11 @@ DEFAULT_CROSS_SUBJECT_SELECTION_METRIC = "balanced_accuracy"
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE = 1
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING = "uniform"
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE = 0.02
+DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION = "row_z_softmax"
 SELECTION_ENSEMBLE_WEIGHTING_MODES = ("uniform", "inner_softmax")
+ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax")
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
-NESTED_SCORE_ENSEMBLE_NORMALIZATION = "row_z_softmax"
+NESTED_SCORE_ENSEMBLE_NORMALIZATION = DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
 FEATURE_MODES = ("sensor_mean", "sensor_flat")
 NORMALIZATION_MODES = ("none", "subject_z", "subject_trial_z", "subject_baseline_z", "subject_baseline_whiten")
 ALIGNMENT_MODES = ("none", "train_class_procrustes")
@@ -178,6 +180,7 @@ def evaluate_nested_cross_subject_stimulus(
     selection_ensemble_size=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     selection_ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
     selection_ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
+    selection_ensemble_score_normalization=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
     progress=None,
     existing_artifacts=None,
     after_outer_fold=None,
@@ -197,6 +200,7 @@ def evaluate_nested_cross_subject_stimulus(
     selection_ensemble_size = _normalize_selection_ensemble_size(selection_ensemble_size)
     selection_ensemble_weighting = _normalize_selection_ensemble_weighting(selection_ensemble_weighting)
     selection_ensemble_temperature = _normalize_selection_ensemble_temperature(selection_ensemble_temperature)
+    selection_ensemble_score_normalization = _normalize_ensemble_score_normalization(selection_ensemble_score_normalization)
 
     resumed = _existing_nested_artifact_rows(existing_artifacts)
     inner_rows = resumed["inner_validation"]
@@ -221,6 +225,7 @@ def evaluate_nested_cross_subject_stimulus(
             selection_ensemble_size=selection_ensemble_size,
             selection_ensemble_weighting=selection_ensemble_weighting,
             selection_ensemble_temperature=selection_ensemble_temperature,
+            selection_ensemble_score_normalization=selection_ensemble_score_normalization,
             progress=progress,
             label_shuffle_control=label_shuffle_control,
             label_shuffle_seed=label_shuffle_seed,
@@ -430,6 +435,11 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
     label_shuffle_seed = _single_row_value(outer_rows, "label_shuffle_seed", default="")
     outer_evaluation_mode = _single_row_value(outer_rows, "outer_evaluation_mode", default="single_best")
     selection_ensemble_size = _single_row_value(outer_rows, "selection_ensemble_size", default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE)
+    selection_ensemble_score_normalization = _single_row_value(
+        outer_rows,
+        "selection_ensemble_score_normalization",
+        default=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
+    )
     selection_ensemble_weighting = _single_row_value(
         outer_rows,
         "selection_ensemble_weighting",
@@ -449,6 +459,7 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
             "selection_metric": DEFAULT_CROSS_SUBJECT_SELECTION_METRIC,
             "outer_evaluation_mode": outer_evaluation_mode,
             "selection_ensemble_size": selection_ensemble_size,
+            "selection_ensemble_score_normalization": selection_ensemble_score_normalization,
             "selection_ensemble_weighting": selection_ensemble_weighting,
             "selection_ensemble_temperature": selection_ensemble_temperature,
             "label_shuffle_control": label_shuffle_control,
@@ -793,6 +804,7 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
     selection_ensemble_size=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     selection_ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
     selection_ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
+    selection_ensemble_score_normalization=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
     progress=None,
     label_shuffle_control=False,
     label_shuffle_seed=0,
@@ -834,6 +846,7 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
         selection_ensemble_size=selection_ensemble_size,
         selection_ensemble_weighting=selection_ensemble_weighting,
         selection_ensemble_temperature=selection_ensemble_temperature,
+        selection_ensemble_score_normalization=selection_ensemble_score_normalization,
         label_shuffle_control=label_shuffle_control,
         label_shuffle_seed=label_shuffle_seed,
     )
@@ -870,6 +883,7 @@ def _evaluate_nested_outer_fold(
     selection_ensemble_size=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     selection_ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
     selection_ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
+    selection_ensemble_score_normalization=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
     progress=None,
     label_shuffle_control=False,
     label_shuffle_seed=0,
@@ -892,6 +906,7 @@ def _evaluate_nested_outer_fold(
         selection_ensemble_size=selection_ensemble_size,
         selection_ensemble_weighting=selection_ensemble_weighting,
         selection_ensemble_temperature=selection_ensemble_temperature,
+        selection_ensemble_score_normalization=selection_ensemble_score_normalization,
         candidate_configs=candidate_configs,
     )
     if int(selected_row["selection_ensemble_size"]) == 1:
@@ -940,6 +955,7 @@ def _evaluate_nested_outer_fold(
             ),
             ensemble_weighting=selected_row["selection_ensemble_weighting"],
             ensemble_temperature=selected_row["selection_ensemble_temperature"],
+            ensemble_score_normalization=selected_row["selection_ensemble_score_normalization"],
             include_predictions=True,
         )
     _add_selected_candidate_fields(outer_row, selected_row)
@@ -950,6 +966,7 @@ def _evaluate_nested_outer_fold(
             "DONE outer_test_participant="
             f"{test_participant} selected_candidate={selected_row['selected_candidate_index']} "
             f"selection_ensemble_size={selected_row['selection_ensemble_size']} "
+            f"score_normalization={selected_row['selection_ensemble_score_normalization']} "
             f"selection_ensemble_weighting={selected_row['selection_ensemble_weighting']} "
             f"inner_mean={selected_row['selected_inner_balanced_accuracy_mean']:.4f} "
             f"outer_balanced_accuracy={outer_row['balanced_accuracy']:.4f}"
@@ -1194,17 +1211,20 @@ def _select_nested_candidate_ensemble(
     selection_ensemble_size,
     selection_ensemble_weighting,
     selection_ensemble_temperature,
+    selection_ensemble_score_normalization,
     candidate_configs,
 ):
     ranked = _rank_nested_candidates(inner_rows)
     requested_size = _normalize_selection_ensemble_size(selection_ensemble_size)
     weighting = _normalize_selection_ensemble_weighting(selection_ensemble_weighting)
     temperature = _normalize_selection_ensemble_temperature(selection_ensemble_temperature)
+    score_normalization = _normalize_ensemble_score_normalization(selection_ensemble_score_normalization)
     selected_rows = tuple(ranked[: min(requested_size, len(ranked))])
     weights = _nested_ensemble_weights(selected_rows, weighting=weighting, temperature=temperature)
     selected = dict(selected_rows[0])
     selected["selection_ensemble_requested_size"] = int(requested_size)
     selected["selection_ensemble_size"] = int(len(selected_rows))
+    selected["selection_ensemble_score_normalization"] = score_normalization
     selected["selection_ensemble_weighting"] = weighting
     selected["selection_ensemble_temperature"] = float(temperature)
     selected["selected_candidate_indices"] = _format_sequence(row["selected_candidate_index"] for row in selected_rows)
@@ -1310,6 +1330,7 @@ def _rank_nested_candidates(inner_rows):
         row["selected_inner_winner_margin"] = winner_margin if rank == 1 else selected_mean - float(row["selected_inner_balanced_accuracy_mean"])
         row["selection_ensemble_requested_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
         row["selection_ensemble_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
+        row["selection_ensemble_score_normalization"] = DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
         row["selection_ensemble_weighting"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING
         row["selection_ensemble_temperature"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE
         row["selected_candidate_indices"] = str(row["selected_candidate_index"])
@@ -1486,6 +1507,7 @@ def _score_outer_fold_ensemble_models(
     ensemble_weights=None,
     ensemble_weighting=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
     ensemble_temperature=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
+    ensemble_score_normalization=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
     include_predictions=True,
 ):
     fitted_models = tuple(fitted_models)
@@ -1499,11 +1521,12 @@ def _score_outer_fold_ensemble_models(
 
     reference_test_set, test_labels, class_order = _validate_ensemble_test_sets(test_sets, configs)
     weights = _normalized_ensemble_weights(ensemble_weights, len(fitted_models))
+    ensemble_score_normalization = _normalize_ensemble_score_normalization(ensemble_score_normalization)
     probability_matrices = []
     actual_components = []
     for fitted_model, test_set, config in zip(fitted_models, test_sets, configs):
         class_scores, score_classes = _candidate_model_scores(fitted_model, test_set, config)
-        probabilities = _row_softmax_probabilities(class_scores)
+        probabilities = _class_score_probabilities(class_scores, score_normalization=ensemble_score_normalization)
         probability_matrices.append(_align_score_columns(probabilities, score_classes, class_order))
         actual_components.append(fitted_model["model_bundle"].actual_components_pca)
 
@@ -1539,6 +1562,7 @@ def _score_outer_fold_ensemble_models(
         actual_components=actual_components,
         ensemble_weighting=ensemble_weighting,
         ensemble_temperature=ensemble_temperature,
+        ensemble_score_normalization=ensemble_score_normalization,
     )
 
     prediction_rows = []
@@ -1561,6 +1585,7 @@ def _score_outer_fold_ensemble_models(
                 actual_components=actual_components,
                 ensemble_weighting=ensemble_weighting,
                 ensemble_temperature=ensemble_temperature,
+                ensemble_score_normalization=ensemble_score_normalization,
             )
     return outer_row, prediction_rows
 
@@ -1607,6 +1632,36 @@ def _row_softmax_probabilities(scores):
             centered = centered / scale
         logits = centered - np.max(centered)
         exp_logits = np.exp(np.clip(logits, -50.0, 50.0))
+        probabilities[row_index] = exp_logits / np.sum(exp_logits)
+    return probabilities
+
+
+def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION):
+    score_normalization = _normalize_ensemble_score_normalization(score_normalization)
+    if score_normalization == "row_z_softmax":
+        return _row_softmax_probabilities(scores)
+    if score_normalization == "rank_softmax":
+        return _rank_softmax_probabilities(scores)
+    raise ValueError(f"Unsupported ensemble score normalization: {score_normalization}")
+
+
+def _rank_softmax_probabilities(scores):
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError("Nested score ensembling requires a non-empty two-dimensional class-score matrix.")
+    probabilities = np.empty_like(scores, dtype=float)
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        if not np.any(finite):
+            probabilities[row_index] = np.full(row.shape[0], 1.0 / row.shape[0], dtype=float)
+            continue
+        rank_scores = np.where(finite, row, -np.inf)
+        descending_columns = np.argsort(-rank_scores, kind="mergesort")
+        ranks = np.empty(row.shape[0], dtype=float)
+        ranks[descending_columns] = np.arange(row.shape[0], dtype=float)
+        logits = -ranks
+        logits[~finite] = -50.0
+        exp_logits = np.exp(logits - np.max(logits))
         probabilities[row_index] = exp_logits / np.sum(exp_logits)
     return probabilities
 
@@ -1659,13 +1714,15 @@ def _add_ensemble_output_fields(
     actual_components,
     ensemble_weighting,
     ensemble_temperature,
+    ensemble_score_normalization,
 ):
     candidate_indices = tuple(int(selected_row["selected_candidate_index"]) for selected_row in selected_rows)
     row["outer_evaluation_mode"] = "topk_score_ensemble"
     row["selection_ensemble_size"] = int(len(candidate_indices))
+    row["selection_ensemble_score_normalization"] = _normalize_ensemble_score_normalization(ensemble_score_normalization)
     row["selection_ensemble_weighting"] = _normalize_selection_ensemble_weighting(ensemble_weighting)
     row["selection_ensemble_temperature"] = float(_normalize_selection_ensemble_temperature(ensemble_temperature))
-    row["ensemble_score_normalization"] = NESTED_SCORE_ENSEMBLE_NORMALIZATION
+    row["ensemble_score_normalization"] = _normalize_ensemble_score_normalization(ensemble_score_normalization)
     row["ensemble_candidate_indices"] = _format_sequence(candidate_indices)
     row["ensemble_weights"] = _format_float_mapping(zip(candidate_indices, weights))
     row["ensemble_classifiers"] = _format_sequence(config.classifier for config in configs)
@@ -2213,6 +2270,13 @@ def _normalize_selection_ensemble_size(value):
     if value <= 0:
         raise ValueError("selection_ensemble_size must be positive.")
     return value
+
+
+def _normalize_ensemble_score_normalization(value):
+    normalized = str(value).strip().lower().replace("-", "_")
+    if normalized not in ENSEMBLE_SCORE_NORMALIZATION_MODES:
+        raise ValueError(f"selection_ensemble_score_normalization must be one of {ENSEMBLE_SCORE_NORMALIZATION_MODES}.")
+    return normalized
 
 
 def _normalize_selection_ensemble_weighting(value):

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -47,6 +47,9 @@ DEFAULT_CROSS_SUBJECT_CLASSIFIER = "multiclass-svm"
 DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA = 64
 DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS = (0.150, 0.175, 0.200)
 DEFAULT_CROSS_SUBJECT_SELECTION_METRIC = "balanced_accuracy"
+DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE = 1
+NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
+NESTED_SCORE_ENSEMBLE_NORMALIZATION = "row_z_softmax"
 FEATURE_MODES = ("sensor_mean", "sensor_flat")
 NORMALIZATION_MODES = ("none", "subject_z", "subject_trial_z", "subject_baseline_z", "subject_baseline_whiten")
 ALIGNMENT_MODES = ("none", "train_class_procrustes")
@@ -169,6 +172,7 @@ def evaluate_nested_cross_subject_stimulus(
     *,
     candidate_configs,
     outer_participants=None,
+    selection_ensemble_size=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     progress=None,
     existing_artifacts=None,
     after_outer_fold=None,
@@ -185,6 +189,7 @@ def evaluate_nested_cross_subject_stimulus(
     if not candidate_configs:
         raise ValueError("At least one candidate configuration is required.")
     outer_participants = _normalize_outer_participants(participants, outer_participants)
+    selection_ensemble_size = _normalize_selection_ensemble_size(selection_ensemble_size)
 
     resumed = _existing_nested_artifact_rows(existing_artifacts)
     inner_rows = resumed["inner_validation"]
@@ -206,6 +211,7 @@ def evaluate_nested_cross_subject_stimulus(
             candidate_configs,
             feature_cache,
             inner_pair_cache,
+            selection_ensemble_size=selection_ensemble_size,
             progress=progress,
             label_shuffle_control=label_shuffle_control,
             label_shuffle_seed=label_shuffle_seed,
@@ -413,16 +419,22 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
     winner_margins = _finite_metric_values(outer_rows, "selected_inner_winner_margin")
     label_shuffle_control = _single_row_value(outer_rows, "label_shuffle_control", default=False)
     label_shuffle_seed = _single_row_value(outer_rows, "label_shuffle_seed", default="")
+    outer_evaluation_mode = _single_row_value(outer_rows, "outer_evaluation_mode", default="single_best")
+    selection_ensemble_size = _single_row_value(outer_rows, "selection_ensemble_size", default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE)
+    ensemble_candidate_counts = _row_semicolon_value_counts(outer_rows, "selected_candidate_indices")
     return [
         {
             "n_outer_folds": len(outer_rows),
             "n_test_participants": len(outer_rows),
             "selection_mode": "nested_loso",
             "selection_metric": DEFAULT_CROSS_SUBJECT_SELECTION_METRIC,
+            "outer_evaluation_mode": outer_evaluation_mode,
+            "selection_ensemble_size": selection_ensemble_size,
             "label_shuffle_control": label_shuffle_control,
             "label_shuffle_seed": label_shuffle_seed,
             "n_candidates": int(max(int(row["n_candidates"]) for row in outer_rows)),
             "selected_candidate_counts": _format_counter(selected_counts),
+            "selected_ensemble_candidate_counts": _format_counter(ensemble_candidate_counts),
             "selected_classifier_counts": _format_counter(classifier_counts),
             "selected_window_center_counts": _format_counter(window_counts),
             "selected_feature_mode_counts": _format_counter(feature_mode_counts),
@@ -757,6 +769,7 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
     resume=False,
     write_incremental=False,
     outer_participants=None,
+    selection_ensemble_size=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     progress=None,
     label_shuffle_control=False,
     label_shuffle_seed=0,
@@ -795,6 +808,7 @@ def export_nested_cross_subject_stimulus(  # pylint: disable=too-many-arguments
         progress=progress,
         existing_artifacts=existing_artifacts,
         after_outer_fold=write_outputs if write_incremental else None,
+        selection_ensemble_size=selection_ensemble_size,
         label_shuffle_control=label_shuffle_control,
         label_shuffle_seed=label_shuffle_seed,
     )
@@ -828,6 +842,7 @@ def _evaluate_nested_outer_fold(
     feature_cache,
     inner_pair_cache,
     *,
+    selection_ensemble_size=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     progress=None,
     label_shuffle_control=False,
     label_shuffle_seed=0,
@@ -845,20 +860,52 @@ def _evaluate_nested_outer_fold(
         label_shuffle_control=label_shuffle_control,
         label_shuffle_seed=label_shuffle_seed,
     )
-    selected_row = _select_nested_candidate(outer_inner_rows)
-    selected_config = candidate_configs[int(selected_row["selected_candidate_index"]) - 1]
-    selected_feature_sets = feature_cache[_feature_cache_key(selected_config)]
-    train_sets = [selected_feature_sets[participant] for participant in outer_train_participants]
-    test_set = selected_feature_sets[test_participant]
-    outer_row, participant_predictions = _evaluate_outer_fold(
-        train_sets,
-        test_set,
-        config=selected_config,
-        classifier_param=_resolved_classifier_param(selected_config),
-        include_predictions=True,
-        label_shuffle_seed=label_shuffle_seed if label_shuffle_control else None,
-        label_shuffle_context=(int(test_participant), int(selected_row["selected_candidate_index"]), 0),
+    selected_row, selected_candidate_rows = _select_nested_candidate_ensemble(
+        outer_inner_rows,
+        selection_ensemble_size=selection_ensemble_size,
+        candidate_configs=candidate_configs,
     )
+    if int(selected_row["selection_ensemble_size"]) == 1:
+        selected_config = candidate_configs[int(selected_row["selected_candidate_index"]) - 1]
+        selected_feature_sets = feature_cache[_feature_cache_key(selected_config)]
+        train_sets = [selected_feature_sets[participant] for participant in outer_train_participants]
+        test_set = selected_feature_sets[test_participant]
+        outer_row, participant_predictions = _evaluate_outer_fold(
+            train_sets,
+            test_set,
+            config=selected_config,
+            classifier_param=_resolved_classifier_param(selected_config),
+            include_predictions=True,
+            label_shuffle_seed=label_shuffle_seed if label_shuffle_control else None,
+            label_shuffle_context=(int(test_participant), int(selected_row["selected_candidate_index"]), 0),
+        )
+    else:
+        fitted_models = []
+        test_sets = []
+        selected_configs = []
+        for ensemble_rank, candidate_row in enumerate(selected_candidate_rows):
+            candidate_index = int(candidate_row["selected_candidate_index"])
+            selected_config = candidate_configs[candidate_index - 1]
+            selected_feature_sets = feature_cache[_feature_cache_key(selected_config)]
+            train_sets = [selected_feature_sets[participant] for participant in outer_train_participants]
+            fitted_models.append(
+                _fit_outer_fold_model(
+                    train_sets,
+                    selected_config,
+                    _resolved_classifier_param(selected_config),
+                    label_shuffle_seed=label_shuffle_seed if label_shuffle_control else None,
+                    label_shuffle_context=(int(test_participant), candidate_index, ensemble_rank),
+                )
+            )
+            test_sets.append(selected_feature_sets[test_participant])
+            selected_configs.append(selected_config)
+        outer_row, participant_predictions = _score_outer_fold_ensemble_models(
+            fitted_models,
+            test_sets,
+            selected_configs,
+            selected_candidate_rows,
+            include_predictions=True,
+        )
     _add_selected_candidate_fields(outer_row, selected_row)
     for prediction_row in participant_predictions:
         _add_selected_candidate_fields(prediction_row, selected_row)
@@ -866,6 +913,7 @@ def _evaluate_nested_outer_fold(
         progress(
             "DONE outer_test_participant="
             f"{test_participant} selected_candidate={selected_row['selected_candidate_index']} "
+            f"selection_ensemble_size={selected_row['selection_ensemble_size']} "
             f"inner_mean={selected_row['selected_inner_balanced_accuracy_mean']:.4f} "
             f"outer_balanced_accuracy={outer_row['balanced_accuracy']:.4f}"
         )
@@ -1100,6 +1148,34 @@ def _nested_inner_row(row, outer_test_participant, validation_participant, candi
 
 
 def _select_nested_candidate(inner_rows):
+    return _rank_nested_candidates(inner_rows)[0]
+
+
+def _select_nested_candidate_ensemble(inner_rows, *, selection_ensemble_size, candidate_configs):
+    ranked = _rank_nested_candidates(inner_rows)
+    requested_size = _normalize_selection_ensemble_size(selection_ensemble_size)
+    selected_rows = tuple(ranked[: min(requested_size, len(ranked))])
+    selected = dict(selected_rows[0])
+    selected["selection_ensemble_requested_size"] = int(requested_size)
+    selected["selection_ensemble_size"] = int(len(selected_rows))
+    selected["selected_candidate_indices"] = _format_sequence(row["selected_candidate_index"] for row in selected_rows)
+    selected["selected_ensemble_inner_balanced_accuracy_means"] = _format_float_mapping(
+        (row["selected_candidate_index"], row["selected_inner_balanced_accuracy_mean"]) for row in selected_rows
+    )
+    selected["selected_ensemble_weights"] = _format_float_mapping(
+        (row["selected_candidate_index"], 1.0 / len(selected_rows)) for row in selected_rows
+    )
+    selected_configs = tuple(candidate_configs[int(row["selected_candidate_index"]) - 1] for row in selected_rows)
+    selected["selected_ensemble_classifier_counts"] = _format_counter(Counter(config.classifier for config in selected_configs))
+    selected["selected_ensemble_window_center_counts"] = _format_counter(Counter(float(config.window_center) for config in selected_configs))
+    selected["selected_ensemble_feature_mode_counts"] = _format_counter(Counter(config.feature_mode for config in selected_configs))
+    selected["selected_ensemble_normalization_counts"] = _format_counter(Counter(config.normalization for config in selected_configs))
+    selected["selected_ensemble_alignment_counts"] = _format_counter(Counter(config.alignment for config in selected_configs))
+    selected["selected_ensemble_components_pca_counts"] = _format_counter(Counter(str(config.components_pca) for config in selected_configs))
+    return selected, selected_rows
+
+
+def _rank_nested_candidates(inner_rows):
     if not inner_rows:
         raise ValueError("At least one inner-validation row is required for nested selection.")
 
@@ -1157,9 +1233,18 @@ def _select_nested_candidate(inner_rows):
     else:
         second_best_mean = np.nan
         winner_margin = np.nan
-    selected["selected_inner_second_best_balanced_accuracy_mean"] = second_best_mean
-    selected["selected_inner_winner_margin"] = winner_margin
-    return selected
+    for rank, row in enumerate(ranked, start=1):
+        row["selected_inner_rank"] = int(rank)
+        row["selected_inner_second_best_balanced_accuracy_mean"] = second_best_mean
+        row["selected_inner_winner_margin"] = winner_margin if rank == 1 else selected_mean - float(row["selected_inner_balanced_accuracy_mean"])
+        row["selection_ensemble_requested_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
+        row["selection_ensemble_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
+        row["selected_candidate_indices"] = str(row["selected_candidate_index"])
+        row["selected_ensemble_inner_balanced_accuracy_means"] = _format_float_mapping(
+            ((row["selected_candidate_index"], row["selected_inner_balanced_accuracy_mean"]),)
+        )
+        row["selected_ensemble_weights"] = _format_float_mapping(((row["selected_candidate_index"], 1.0),))
+    return ranked
 
 
 def _add_selected_candidate_fields(row, selected_row):
@@ -1317,6 +1402,166 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
             actual_components_pca=model_bundle.actual_components_pca,
         )
     return outer_row, prediction_rows
+
+
+def _score_outer_fold_ensemble_models(fitted_models, test_sets, configs, selected_rows, *, include_predictions=True):
+    fitted_models = tuple(fitted_models)
+    test_sets = tuple(test_sets)
+    configs = tuple(configs)
+    selected_rows = tuple(selected_rows)
+    if not fitted_models:
+        raise ValueError("At least one fitted model is required for nested score ensembling.")
+    if not (len(fitted_models) == len(test_sets) == len(configs) == len(selected_rows)):
+        raise ValueError("Ensemble fitted models, test sets, configs, and selected rows must have the same length.")
+
+    reference_test_set, test_labels, class_order = _validate_ensemble_test_sets(test_sets, configs)
+    weights = np.full(len(fitted_models), 1.0 / len(fitted_models), dtype=float)
+    probability_matrices = []
+    actual_components = []
+    for fitted_model, test_set, config in zip(fitted_models, test_sets, configs):
+        class_scores, score_classes = _candidate_model_scores(fitted_model, test_set, config)
+        probabilities = _row_softmax_probabilities(class_scores)
+        probability_matrices.append(_align_score_columns(probabilities, score_classes, class_order))
+        actual_components.append(fitted_model["model_bundle"].actual_components_pca)
+
+    ensemble_probabilities = np.tensordot(weights, np.stack(probability_matrices, axis=0), axes=(0, 0))
+    predictions = class_order[np.argmax(ensemble_probabilities, axis=1)]
+    rank_metrics = _ranked_label_metrics(test_labels, ensemble_probabilities, class_order)
+    accuracy = float(accuracy_score(test_labels, predictions))
+    balanced_accuracy = float(balanced_accuracy_score(test_labels, predictions))
+
+    outer_row, _template_predictions = _score_outer_fold_model(fitted_models[0], test_sets[0], configs[0], include_predictions=False)
+    outer_row.update(
+        {
+            "classifier": NESTED_SCORE_ENSEMBLE_CLASSIFIER,
+            "classifier_param": "",
+            "accuracy": accuracy,
+            "percent": 100.0 * accuracy,
+            "balanced_accuracy": balanced_accuracy,
+            "balanced_percent": 100.0 * balanced_accuracy,
+            "top2_accuracy": rank_metrics["top2_accuracy"],
+            "top2_percent": 100.0 * rank_metrics["top2_accuracy"],
+            "top3_accuracy": rank_metrics["top3_accuracy"],
+            "top3_percent": 100.0 * rank_metrics["top3_accuracy"],
+            "mean_true_label_rank": rank_metrics["mean_true_label_rank"],
+            "median_true_label_rank": rank_metrics["median_true_label_rank"],
+            "above_chance": bool(balanced_accuracy > outer_row["chance_accuracy"]),
+        }
+    )
+    _add_ensemble_output_fields(
+        outer_row,
+        selected_rows,
+        configs,
+        weights=weights,
+        actual_components=actual_components,
+    )
+
+    prediction_rows = []
+    if include_predictions:
+        prediction_rows = _prediction_rows(
+            reference_test_set,
+            test_labels,
+            predictions,
+            rank_metrics["true_label_ranks"],
+            config=configs[0],
+            actual_components_pca=fitted_models[0]["model_bundle"].actual_components_pca,
+        )
+        for row in prediction_rows:
+            row["classifier"] = NESTED_SCORE_ENSEMBLE_CLASSIFIER
+            _add_ensemble_output_fields(
+                row,
+                selected_rows,
+                configs,
+                weights=weights,
+                actual_components=actual_components,
+            )
+    return outer_row, prediction_rows
+
+
+def _candidate_model_scores(fitted_model, test_set, config):
+    model_bundle = fitted_model["model_bundle"]
+    test_features = _normalized_subject_features(test_set, config)
+    return _model_class_scores(model_bundle, test_features)
+
+
+def _validate_ensemble_test_sets(test_sets, configs):
+    reference_set = test_sets[0]
+    reference_labels = np.asarray(reference_set.labels, dtype=int) - 1
+    reference_trials = _feature_set_trial_indices(reference_set)
+    chance_classes = int(configs[0].chance_classes)
+    class_order = np.arange(chance_classes, dtype=int)
+    for test_set, config in zip(test_sets, configs):
+        labels = np.asarray(test_set.labels, dtype=int) - 1
+        trials = _feature_set_trial_indices(test_set)
+        if int(test_set.participant) != int(reference_set.participant):
+            raise ValueError("Nested score ensembling requires all models to score the same held-out participant.")
+        if int(config.chance_classes) != chance_classes:
+            raise ValueError("Nested score ensembling requires candidate configurations with the same chance_classes value.")
+        if not np.array_equal(labels, reference_labels) or not np.array_equal(trials, reference_trials):
+            raise ValueError("Nested score ensembling requires identical held-out trial labels and trial order across selected candidates.")
+    return reference_set, reference_labels, class_order
+
+
+def _row_softmax_probabilities(scores):
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError("Nested score ensembling requires a non-empty two-dimensional class-score matrix.")
+    probabilities = np.empty_like(scores, dtype=float)
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        if not np.any(finite):
+            probabilities[row_index] = np.full(row.shape[0], 1.0 / row.shape[0], dtype=float)
+            continue
+        sanitized = np.asarray(row, dtype=float).copy()
+        sanitized[~finite] = np.min(sanitized[finite])
+        centered = sanitized - np.mean(sanitized)
+        scale = float(np.std(centered))
+        if scale > 1e-12:
+            centered = centered / scale
+        logits = centered - np.max(centered)
+        exp_logits = np.exp(np.clip(logits, -50.0, 50.0))
+        probabilities[row_index] = exp_logits / np.sum(exp_logits)
+    return probabilities
+
+
+def _align_score_columns(probabilities, score_classes, class_order):
+    probabilities = np.asarray(probabilities, dtype=float)
+    score_classes = np.asarray(score_classes, dtype=int).ravel()
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    aligned = np.zeros((probabilities.shape[0], class_order.shape[0]), dtype=float)
+    class_to_column = {int(class_label): column for column, class_label in enumerate(class_order.tolist())}
+    for source_column, class_label in enumerate(score_classes.tolist()):
+        target_column = class_to_column.get(int(class_label))
+        if target_column is not None:
+            aligned[:, target_column] = probabilities[:, source_column]
+    row_sums = np.sum(aligned, axis=1, keepdims=True)
+    valid = row_sums[:, 0] > 1e-12
+    aligned[valid] = aligned[valid] / row_sums[valid]
+    aligned[~valid] = 1.0 / class_order.shape[0]
+    return aligned
+
+
+def _feature_set_trial_indices(feature_set):
+    trial_indices = getattr(feature_set, "trial_indices", None)
+    if trial_indices is None:
+        return np.arange(np.asarray(feature_set.labels).shape[0], dtype=int)
+    return np.asarray(trial_indices, dtype=int).ravel()
+
+
+def _add_ensemble_output_fields(row, selected_rows, configs, *, weights, actual_components):
+    candidate_indices = tuple(int(selected_row["selected_candidate_index"]) for selected_row in selected_rows)
+    row["outer_evaluation_mode"] = "topk_score_ensemble"
+    row["selection_ensemble_size"] = int(len(candidate_indices))
+    row["ensemble_score_normalization"] = NESTED_SCORE_ENSEMBLE_NORMALIZATION
+    row["ensemble_candidate_indices"] = _format_sequence(candidate_indices)
+    row["ensemble_weights"] = _format_float_mapping(zip(candidate_indices, weights))
+    row["ensemble_classifiers"] = _format_sequence(config.classifier for config in configs)
+    row["ensemble_window_centers_s"] = _format_sequence(config.window_center for config in configs)
+    row["ensemble_feature_modes"] = _format_sequence(config.feature_mode for config in configs)
+    row["ensemble_normalizations"] = _format_sequence(config.normalization for config in configs)
+    row["ensemble_alignments"] = _format_sequence(config.alignment for config in configs)
+    row["ensemble_components_pca"] = _format_sequence(config.components_pca for config in configs)
+    row["ensemble_actual_components_pca"] = _format_sequence(actual_components)
 
 
 def _prediction_rows(test_set, test_labels, predictions, true_label_ranks, *, config, actual_components_pca):
@@ -1730,6 +1975,27 @@ def _format_counter(counter):
     return ";".join(f"{key}:{counter[key]}" for key in sorted(counter))
 
 
+def _format_sequence(values):
+    return ";".join(str(value) for value in values)
+
+
+def _format_float_mapping(items):
+    return ";".join(f"{key}:{float(value):.6g}" for key, value in items)
+
+
+def _row_semicolon_value_counts(rows, key):
+    counter = Counter()
+    for row in rows:
+        value = row.get(key)
+        if value in (None, ""):
+            continue
+        for token in str(value).split(";"):
+            token = token.strip()
+            if token:
+                counter[token] += 1
+    return counter
+
+
 def _row_value_counts(rows, key, *, fallback_key=None, transform=str):
     values = []
     for row in rows:
@@ -1827,6 +2093,13 @@ def _normalized_candidate_configs(candidate_configs):
     if len(chance_classes) != 1:
         raise ValueError("All nested candidate configurations must use the same chance_classes value.")
     return normalized_configs
+
+
+def _normalize_selection_ensemble_size(value):
+    value = int(value)
+    if value <= 0:
+        raise ValueError("selection_ensemble_size must be positive.")
+    return value
 
 
 def _normalize_trial_cap(value):

--- a/src/pymegdec/_stimulus_cross_subject_timefix.py
+++ b/src/pymegdec/_stimulus_cross_subject_timefix.py
@@ -30,6 +30,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = np.mean(window_signal, axis=1)
         elif feature_mode == "sensor_flat":
             feature = window_signal.reshape(-1, order="F")
+        elif feature_mode == "sensor_mean_slope":
+            feature = _impl._sensor_mean_slope_feature(window_signal, time_vector[mask])
         else:
             raise ValueError(f"Unsupported feature_mode: {feature_mode}")
         features.append(feature)

--- a/src/pymegdec/_stimulus_cross_subject_timefix.py
+++ b/src/pymegdec/_stimulus_cross_subject_timefix.py
@@ -32,6 +32,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = window_signal.reshape(-1, order="F")
         elif feature_mode == "sensor_mean_slope":
             feature = _impl._sensor_mean_slope_feature(window_signal, time_vector[mask])
+        elif feature_mode == "sensor_mean_slope_std":
+            feature = _impl._sensor_mean_slope_std_feature(window_signal, time_vector[mask])
         else:
             raise ValueError(f"Unsupported feature_mode: {feature_mode}")
         features.append(feature)

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import numpy as np
 from sklearn.linear_model import LogisticRegression
+from sklearn.naive_bayes import GaussianNB
 
 from reptrace.decoding.classifiers import (
     ClassifierSpec,
@@ -46,6 +47,7 @@ _DecodedLabelClassifier = DecodedLabelClassifier
 _encode_classifier_labels = encode_classifier_labels
 
 PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS = {
+    "gaussian-naive-bayes": 1e-9,
     "multinomial-logistic-weighted": 1.0,
     "shrinkage-prototype": 0.25,
 }
@@ -62,6 +64,10 @@ def _build_weighted_multinomial_logistic(_features, _labels, classifier_param, r
         max_iter=1000,
         random_state=random_state,
     )
+
+
+def _build_gaussian_naive_bayes(_features, _labels, classifier_param, _random_state):
+    return GaussianNB(var_smoothing=float(classifier_param))
 
 
 class ShrinkagePrototypeClassifier:
@@ -121,6 +127,7 @@ def _build_shrinkage_prototype(_features, _labels, classifier_param, _random_sta
 
 CLASSIFIER_REGISTRY = {
     **REPTRACE_CLASSIFIER_REGISTRY,
+    "gaussian-naive-bayes": ClassifierSpec(_build_gaussian_naive_bayes),
     "multinomial-logistic-weighted": ClassifierSpec(_build_weighted_multinomial_logistic),
     "shrinkage-prototype": ClassifierSpec(_build_shrinkage_prototype),
 }

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -1,36 +1,71 @@
-"""Backward-compatible classifier imports.
+"""Backward-compatible classifier adapters.
 
 Classifier implementations now live in :mod:`reptrace.decoding.classifiers`.
-This module preserves historical ``pymegdec.classifiers`` imports without
-owning classifier implementations.
+This module preserves historical ``pymegdec.classifiers`` imports and adds
+PyMEGDec-local registry entries that are useful for the stimulus benchmarks.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from sklearn.linear_model import LogisticRegression
+
 from reptrace.decoding.classifiers import (
-    CLASSIFIER_REGISTRY,
-    DEFAULT_CLASSIFIER_PARAMS,
     ClassifierSpec,
     CorrelationPrototypeClassifier,
     DecodedLabelClassifier,
     _build_pytorch_data_loaders,
     encode_classifier_labels,
-    get_default_classifier_param,
     positive_class_score,
     prediction_scores,
     should_use_default_classifier_param,
     train_binary_svm,
-    train_classifier,
     train_for_stimulus_lasso_glm,
     train_gradient_boosting,
     train_lasso_logistic,
-    train_multiclass_classifier,
+)
+from reptrace.decoding.classifiers import (
+    CLASSIFIER_REGISTRY as REPTRACE_CLASSIFIER_REGISTRY,
+)
+from reptrace.decoding.classifiers import (
+    DEFAULT_CLASSIFIER_PARAMS as REPTRACE_DEFAULT_CLASSIFIER_PARAMS,
+)
+from reptrace.decoding.classifiers import (
+    get_default_classifier_param as get_reptrace_default_classifier_param,
+)
+from reptrace.decoding.classifiers import (
+    train_classifier as train_reptrace_classifier,
+)
+from reptrace.decoding.classifiers import (
+    train_multiclass_classifier as train_reptrace_multiclass_classifier,
 )
 
 _DecodedLabelClassifier = DecodedLabelClassifier
 _encode_classifier_labels = encode_classifier_labels
+
+PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS = {
+    "multinomial-logistic-weighted": 1.0,
+}
+DEFAULT_CLASSIFIER_PARAMS = {
+    **REPTRACE_DEFAULT_CLASSIFIER_PARAMS,
+    **PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS,
+}
+
+
+def _build_weighted_multinomial_logistic(_features, _labels, classifier_param, random_state):
+    return LogisticRegression(
+        C=float(classifier_param),
+        class_weight="balanced",
+        max_iter=1000,
+        random_state=random_state,
+    )
+
+
+CLASSIFIER_REGISTRY = {
+    **REPTRACE_CLASSIFIER_REGISTRY,
+    "multinomial-logistic-weighted": ClassifierSpec(_build_weighted_multinomial_logistic),
+}
 
 __all__ = [
     "CLASSIFIER_REGISTRY",
@@ -50,6 +85,59 @@ __all__ = [
     "train_lasso_logistic",
     "train_multiclass_classifier",
 ]
+
+
+def get_default_classifier_param(classifier: str) -> Any:
+    """Return a defensive copy of the PyMEGDec classifier default."""
+
+    if classifier in DEFAULT_CLASSIFIER_PARAMS:
+        classifier_param = DEFAULT_CLASSIFIER_PARAMS[classifier]
+        if isinstance(classifier_param, dict):
+            return classifier_param.copy()
+        return classifier_param
+    return get_reptrace_default_classifier_param(classifier)
+
+
+def train_classifier(
+    features,
+    labels,
+    classifier: str,
+    classifier_param: Any,
+    random_state: int | None = None,
+    *,
+    registry: dict[str, ClassifierSpec] | None = None,
+):
+    """Build and fit a classifier from the PyMEGDec-extended registry."""
+
+    return train_reptrace_classifier(
+        features,
+        labels,
+        classifier,
+        classifier_param,
+        random_state=random_state,
+        registry=CLASSIFIER_REGISTRY if registry is None else registry,
+    )
+
+
+def train_multiclass_classifier(
+    features,
+    labels,
+    classifier: str,
+    classifier_param: Any,
+    random_state: int | None = None,
+    *,
+    registry: dict[str, ClassifierSpec] | None = None,
+):
+    """Train a multiclass classifier from the PyMEGDec-extended registry."""
+
+    return train_reptrace_multiclass_classifier(
+        features,
+        labels,
+        classifier,
+        classifier_param,
+        random_state=random_state,
+        registry=CLASSIFIER_REGISTRY if registry is None else registry,
+    )
 
 
 def __getattr__(name: str) -> Any:

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
 from sklearn.linear_model import LogisticRegression
 from sklearn.naive_bayes import GaussianNB
 
@@ -49,6 +50,7 @@ _encode_classifier_labels = encode_classifier_labels
 PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS = {
     "gaussian-naive-bayes": 1e-9,
     "multinomial-logistic-weighted": 1.0,
+    "regularized-qda": 0.5,
     "shrinkage-prototype": 0.25,
 }
 DEFAULT_CLASSIFIER_PARAMS = {
@@ -68,6 +70,13 @@ def _build_weighted_multinomial_logistic(_features, _labels, classifier_param, r
 
 def _build_gaussian_naive_bayes(_features, _labels, classifier_param, _random_state):
     return GaussianNB(var_smoothing=float(classifier_param))
+
+
+def _build_regularized_qda(_features, _labels, classifier_param, _random_state):
+    reg_param = PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS["regularized-qda"] if classifier_param is None else float(classifier_param)
+    if not 0.0 <= reg_param <= 1.0:
+        raise ValueError("regularized-qda classifier_param must be a numeric regularization in [0, 1].")
+    return QuadraticDiscriminantAnalysis(reg_param=reg_param)
 
 
 class ShrinkagePrototypeClassifier:
@@ -129,6 +138,7 @@ CLASSIFIER_REGISTRY = {
     **REPTRACE_CLASSIFIER_REGISTRY,
     "gaussian-naive-bayes": ClassifierSpec(_build_gaussian_naive_bayes),
     "multinomial-logistic-weighted": ClassifierSpec(_build_weighted_multinomial_logistic),
+    "regularized-qda": ClassifierSpec(_build_regularized_qda),
     "shrinkage-prototype": ClassifierSpec(_build_shrinkage_prototype),
 }
 

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 from sklearn.linear_model import LogisticRegression
 
 from reptrace.decoding.classifiers import (
@@ -46,6 +47,7 @@ _encode_classifier_labels = encode_classifier_labels
 
 PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS = {
     "multinomial-logistic-weighted": 1.0,
+    "shrinkage-prototype": 0.25,
 }
 DEFAULT_CLASSIFIER_PARAMS = {
     **REPTRACE_DEFAULT_CLASSIFIER_PARAMS,
@@ -62,9 +64,65 @@ def _build_weighted_multinomial_logistic(_features, _labels, classifier_param, r
     )
 
 
+class ShrinkagePrototypeClassifier:
+    """Classify by distance to class prototypes shrunk toward the grand mean."""
+
+    def __init__(self, shrinkage: float = 0.25):
+        self.shrinkage = float(shrinkage)
+        self.classes_: np.ndarray | None = None
+        self.class_prototypes_: np.ndarray | None = None
+        self.global_prototype_: np.ndarray | None = None
+        self.shrunk_prototypes_: np.ndarray | None = None
+
+    def fit(self, features, labels):
+        features = np.asarray(features, dtype=float)
+        labels = np.asarray(labels).ravel()
+        if features.ndim != 2:
+            raise ValueError("features must be a two-dimensional matrix.")
+        if labels.shape[0] != features.shape[0]:
+            raise ValueError("labels must have the same length as features.")
+        if features.shape[0] == 0:
+            raise ValueError("At least one training row is required.")
+        if not 0.0 <= self.shrinkage <= 1.0:
+            raise ValueError("shrinkage-prototype classifier_param must be a numeric shrinkage in [0, 1].")
+
+        self.classes_ = np.unique(labels)
+        self.class_prototypes_ = np.vstack([np.mean(features[labels == class_label], axis=0) for class_label in self.classes_])
+        self.global_prototype_ = np.mean(features, axis=0, keepdims=True)
+        self.shrunk_prototypes_ = (1.0 - self.shrinkage) * self.class_prototypes_ + self.shrinkage * self.global_prototype_
+        return self
+
+    def decision_function(self, features):
+        if self.shrunk_prototypes_ is None:
+            raise RuntimeError("ShrinkagePrototypeClassifier must be fitted before scoring.")
+        features = np.asarray(features, dtype=float)
+        squared_distances = np.sum(np.square(features[:, None, :] - self.shrunk_prototypes_[None, :, :]), axis=2)
+        return -squared_distances
+
+    def predict(self, features):
+        if self.classes_ is None:
+            raise RuntimeError("ShrinkagePrototypeClassifier must be fitted before prediction.")
+        scores = self.decision_function(features)
+        return self.classes_[np.argmax(scores, axis=1)]
+
+
+def _normalize_shrinkage_prototype_param(classifier_param):
+    if classifier_param is None:
+        return PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS["shrinkage-prototype"]
+    shrinkage = float(classifier_param)
+    if not 0.0 <= shrinkage <= 1.0:
+        raise ValueError("shrinkage-prototype classifier_param must be a numeric shrinkage in [0, 1].")
+    return shrinkage
+
+
+def _build_shrinkage_prototype(_features, _labels, classifier_param, _random_state):
+    return ShrinkagePrototypeClassifier(shrinkage=_normalize_shrinkage_prototype_param(classifier_param))
+
+
 CLASSIFIER_REGISTRY = {
     **REPTRACE_CLASSIFIER_REGISTRY,
     "multinomial-logistic-weighted": ClassifierSpec(_build_weighted_multinomial_logistic),
+    "shrinkage-prototype": ClassifierSpec(_build_shrinkage_prototype),
 }
 
 __all__ = [
@@ -73,6 +131,7 @@ __all__ = [
     "ClassifierSpec",
     "CorrelationPrototypeClassifier",
     "DecodedLabelClassifier",
+    "ShrinkagePrototypeClassifier",
     "_build_pytorch_data_loaders",
     "get_default_classifier_param",
     "positive_class_score",

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -39,6 +39,7 @@ from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION,
     DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED,
     DEFAULT_CROSS_SUBJECT_PARTICIPANTS,
+    FEATURE_MODES,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
@@ -274,7 +275,7 @@ def _build_cross_subject_smoke_parser(prog: str | None = None) -> argparse.Argum
     parser.add_argument("--window-size", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE, help="Stimulus decoding window size in seconds.")
     parser.add_argument("--baseline-window", type=_parse_time_window, default=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW, help="Baseline window as start,stop in seconds.")
     parser.add_argument(
-        "--feature-mode", type=_feature_mode_token, default=DEFAULT_CROSS_SUBJECT_FEATURE_MODE, choices=("sensor_mean", "sensor_flat"), help="Feature extraction mode."
+        "--feature-mode", type=_feature_mode_token, default=DEFAULT_CROSS_SUBJECT_FEATURE_MODE, choices=FEATURE_MODES, help="Feature extraction mode."
     )
     parser.add_argument(
         "--normalization",
@@ -386,7 +387,7 @@ def _build_cross_subject_cue_calibrated_parser(prog: str | None = None) -> argpa
     parser.add_argument("--window-size", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE, help="Main-task decoding window size in seconds.")
     parser.add_argument("--baseline-window", type=_parse_time_window, default=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW, help="Main-task baseline window as start,stop in seconds.")
     parser.add_argument(
-        "--feature-mode", type=_feature_mode_token, default=DEFAULT_CROSS_SUBJECT_FEATURE_MODE, choices=("sensor_mean", "sensor_flat"), help="Main-task feature extraction mode."
+        "--feature-mode", type=_feature_mode_token, default=DEFAULT_CROSS_SUBJECT_FEATURE_MODE, choices=FEATURE_MODES, help="Main-task feature extraction mode."
     )
     parser.add_argument(
         "--normalization",
@@ -427,7 +428,7 @@ def _build_cross_subject_cue_calibrated_parser(prog: str | None = None) -> argpa
         "--calibration-feature-mode",
         type=_feature_mode_token,
         default=DECODE_REFERENCE_TOKEN,
-        choices=(DECODE_REFERENCE_TOKEN, "sensor_mean", "sensor_flat"),
+        choices=(DECODE_REFERENCE_TOKEN, *FEATURE_MODES),
         help="Cue calibration feature mode. decode reuses --feature-mode.",
     )
     parser.add_argument(

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -40,9 +40,12 @@ from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED,
     DEFAULT_CROSS_SUBJECT_PARTICIPANTS,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
+    DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
+    DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
     DEFAULT_CROSS_SUBJECT_WINDOW_CENTER,
     DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
     NORMALIZATION_MODES,
+    SELECTION_ENSEMBLE_WEIGHTING_MODES,
     CrossSubjectStimulusConfig,
     TRIAL_SELECTION_MODES,
     export_cross_subject_stimulus_smoke,
@@ -586,6 +589,18 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
         default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
         help="Evaluate a row-z-softmax score ensemble over the top K inner-LOSO candidates instead of only the single winner.",
     )
+    parser.add_argument(
+        "--selection-ensemble-weighting",
+        choices=SELECTION_ENSEMBLE_WEIGHTING_MODES,
+        default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
+        help="Weighting scheme for --selection-ensemble-size values greater than one.",
+    )
+    parser.add_argument(
+        "--selection-ensemble-temperature",
+        type=float,
+        default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
+        help="Softmax temperature for --selection-ensemble-weighting inner_softmax.",
+    )
     parser.add_argument("--chance-classes", type=int, default=DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES, help="Number of stimulus classes used for chance level.")
     parser.add_argument("--random-state", type=int, default=0, help="Random state passed to classifiers.")
     parser.add_argument(
@@ -651,6 +666,8 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         write_incremental=args.write_incremental,
         outer_participants=outer_participants,
         selection_ensemble_size=args.selection_ensemble_size,
+        selection_ensemble_weighting=args.selection_ensemble_weighting,
+        selection_ensemble_temperature=args.selection_ensemble_temperature,
         progress=lambda message: print(message, flush=True),
         label_shuffle_control=args.label_shuffle_control,
         label_shuffle_seed=args.label_shuffle_seed,

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -43,10 +43,12 @@ from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
     DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
+    DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY,
     DEFAULT_CROSS_SUBJECT_WINDOW_CENTER,
     DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
     ENSEMBLE_SCORE_NORMALIZATION_MODES,
     NORMALIZATION_MODES,
+    SELECTION_ENSEMBLE_DIVERSITY_MODES,
     SELECTION_ENSEMBLE_WEIGHTING_MODES,
     CrossSubjectStimulusConfig,
     TRIAL_SELECTION_MODES,
@@ -592,6 +594,12 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
         help="Evaluate a row-z-softmax score ensemble over the top K inner-LOSO candidates instead of only the single winner.",
     )
     parser.add_argument(
+        "--selection-ensemble-diversity",
+        choices=SELECTION_ENSEMBLE_DIVERSITY_MODES,
+        default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY,
+        help="Prefer diverse candidates before filling the nested top-K ensemble.",
+    )
+    parser.add_argument(
         "--selection-ensemble-score-normalization",
         choices=ENSEMBLE_SCORE_NORMALIZATION_MODES,
         default=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
@@ -674,6 +682,7 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         write_incremental=args.write_incremental,
         outer_participants=outer_participants,
         selection_ensemble_size=args.selection_ensemble_size,
+        selection_ensemble_diversity=args.selection_ensemble_diversity,
         selection_ensemble_score_normalization=args.selection_ensemble_score_normalization,
         selection_ensemble_weighting=args.selection_ensemble_weighting,
         selection_ensemble_temperature=args.selection_ensemble_temperature,

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -50,6 +50,7 @@ from pymegdec.stimulus_cross_subject import (
     NORMALIZATION_MODES,
     SELECTION_ENSEMBLE_DIVERSITY_MODES,
     SELECTION_ENSEMBLE_WEIGHTING_MODES,
+    AUTO_CLASSIFIER_PARAM_GRID_TOKEN,
     CrossSubjectStimulusConfig,
     TRIAL_SELECTION_MODES,
     export_cross_subject_stimulus_smoke,
@@ -156,6 +157,8 @@ def _parse_classifier_param_grid(value: str) -> tuple[object, ...]:
             continue
         if token.lower() in {"default", "defaults"}:
             values.append(float("nan"))
+        elif token.lower().replace("_", "-") == AUTO_CLASSIFIER_PARAM_GRID_TOKEN:
+            values.append(AUTO_CLASSIFIER_PARAM_GRID_TOKEN)
         else:
             values.append(parse_classifier_param(token))
     if not values:

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -42,8 +42,10 @@ from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
+    DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
     DEFAULT_CROSS_SUBJECT_WINDOW_CENTER,
     DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
+    ENSEMBLE_SCORE_NORMALIZATION_MODES,
     NORMALIZATION_MODES,
     SELECTION_ENSEMBLE_WEIGHTING_MODES,
     CrossSubjectStimulusConfig,
@@ -590,6 +592,12 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
         help="Evaluate a row-z-softmax score ensemble over the top K inner-LOSO candidates instead of only the single winner.",
     )
     parser.add_argument(
+        "--selection-ensemble-score-normalization",
+        choices=ENSEMBLE_SCORE_NORMALIZATION_MODES,
+        default=DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION,
+        help="Transform per-class candidate scores before top-K ensemble averaging.",
+    )
+    parser.add_argument(
         "--selection-ensemble-weighting",
         choices=SELECTION_ENSEMBLE_WEIGHTING_MODES,
         default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_WEIGHTING,
@@ -666,6 +674,7 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         write_incremental=args.write_incremental,
         outer_participants=outer_participants,
         selection_ensemble_size=args.selection_ensemble_size,
+        selection_ensemble_score_normalization=args.selection_ensemble_score_normalization,
         selection_ensemble_weighting=args.selection_ensemble_weighting,
         selection_ensemble_temperature=args.selection_ensemble_temperature,
         progress=lambda message: print(message, flush=True),

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -39,6 +39,7 @@ from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION,
     DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED,
     DEFAULT_CROSS_SUBJECT_PARTICIPANTS,
+    DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     DEFAULT_CROSS_SUBJECT_WINDOW_CENTER,
     DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
     NORMALIZATION_MODES,
@@ -567,6 +568,24 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
         default=None,
         help="Optional deterministic cap on trials per stimulus class and participant for quick nested screening.",
     )
+    parser.add_argument(
+        "--trial-selection",
+        choices=TRIAL_SELECTION_MODES,
+        default=DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION,
+        help="Trial subset policy used when --max-trials-per-class-per-participant is set.",
+    )
+    parser.add_argument(
+        "--trial-selection-seed",
+        type=int,
+        default=DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED,
+        help="Seed for random trial selection; ignored with --trial-selection first.",
+    )
+    parser.add_argument(
+        "--selection-ensemble-size",
+        type=int,
+        default=DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
+        help="Evaluate a row-z-softmax score ensemble over the top K inner-LOSO candidates instead of only the single winner.",
+    )
     parser.add_argument("--chance-classes", type=int, default=DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES, help="Number of stimulus classes used for chance level.")
     parser.add_argument("--random-state", type=int, default=0, help="Random state passed to classifiers.")
     parser.add_argument(
@@ -631,6 +650,7 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         resume=args.resume,
         write_incremental=args.write_incremental,
         outer_participants=outer_participants,
+        selection_ensemble_size=args.selection_ensemble_size,
         progress=lambda message: print(message, flush=True),
         label_shuffle_control=args.label_shuffle_control,
         label_shuffle_seed=args.label_shuffle_seed,

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -51,6 +51,7 @@ from pymegdec.stimulus_cross_subject import (
     SELECTION_ENSEMBLE_DIVERSITY_MODES,
     SELECTION_ENSEMBLE_WEIGHTING_MODES,
     AUTO_CLASSIFIER_PARAM_GRID_TOKEN,
+    AUTO_COMPONENTS_PCA_GRID_TOKEN,
     CrossSubjectStimulusConfig,
     TRIAL_SELECTION_MODES,
     export_cross_subject_stimulus_smoke,
@@ -142,11 +143,19 @@ def _parse_alignment_list(value: str) -> tuple[str, ...]:
     return tuple(_alignment_token(token) for token in _parse_token_list(value))
 
 
-def _parse_int_or_inf_list(value: str) -> tuple[int | float, ...]:
-    values = tuple(parse_int_or_inf(token.strip()) for token in value.split(",") if token.strip())
+def _parse_int_or_inf_list(value: str) -> tuple[int | float | str, ...]:
+    values = []
+    for token in value.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if token.lower().replace("_", "-") == AUTO_COMPONENTS_PCA_GRID_TOKEN:
+            values.append(AUTO_COMPONENTS_PCA_GRID_TOKEN)
+        else:
+            values.append(parse_int_or_inf(token))
     if not values:
         raise argparse.ArgumentTypeError("At least one value is required.")
-    return values
+    return tuple(values)
 
 
 def _parse_classifier_param_grid(value: str) -> tuple[object, ...]:

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -70,15 +70,39 @@ class TestClassifiers(unittest.TestCase):
         import pymegdec.classifiers as classifiers
 
         self.assertIs(classifiers.train_multiclass_classifier, train_multiclass_classifier)
+        self.assertIn("gaussian-naive-bayes", classifiers.CLASSIFIER_REGISTRY)
         self.assertIn("multinomial-logistic-weighted", classifiers.CLASSIFIER_REGISTRY)
         self.assertIn("shrinkage-prototype", classifiers.CLASSIFIER_REGISTRY)
 
     def test_default_params_for_cross_subject_baseline_classifiers(self):
         self.assertIsNone(get_default_classifier_param("correlation-prototype"))
+        self.assertEqual(get_default_classifier_param("gaussian-naive-bayes"), 1e-9)
         self.assertEqual(get_default_classifier_param("multinomial-logistic"), 1.0)
         self.assertEqual(get_default_classifier_param("multinomial-logistic-weighted"), 1.0)
         self.assertEqual(get_default_classifier_param("shrinkage-prototype"), 0.25)
         self.assertIsNone(get_default_classifier_param("shrinkage-lda"))
+
+    def test_gaussian_naive_bayes_trains_and_predicts_probabilities(self):
+        features = np.asarray(
+            [
+                [0.0, 0.0],
+                [0.0, 0.1],
+                [1.0, 1.0],
+                [1.1, 1.0],
+                [2.0, 0.0],
+                [2.0, 0.1],
+            ],
+            dtype=float,
+        )
+        labels = np.asarray([0, 0, 1, 1, 2, 2], dtype=int)
+
+        model = train_multiclass_classifier(features, labels, "gaussian-naive-bayes", 1e-8)
+        probabilities = model.predict_proba(features[:3])
+
+        self.assertIn("gaussian-naive-bayes", CLASSIFIER_REGISTRY)
+        self.assertEqual(model.model.var_smoothing, 1e-8)
+        self.assertEqual(probabilities.shape, (3, 3))
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(3))
 
     def test_weighted_multinomial_logistic_trains(self):
         features = np.asarray(

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 import numpy as np
 from pymegdec.cli import parse_classifier_param
-from reptrace.decoding.classifiers import (
+from pymegdec.classifiers import (
+    CLASSIFIER_REGISTRY,
     get_default_classifier_param,
     train_multiclass_classifier,
 )
@@ -65,15 +66,36 @@ class TestClassifiers(unittest.TestCase):
         np.testing.assert_array_equal(model.predict(self.features[:2]), np.asarray([10, 20], dtype=int))
         np.testing.assert_allclose(model.decision_function(self.features[:2]), np.asarray([[-0.25, 0.25], [0.50, -0.50]], dtype=float))
 
-    def test_pymegdec_classifier_module_is_compatibility_shim(self):
+    def test_pymegdec_classifier_module_extends_upstream_registry(self):
         import pymegdec.classifiers as classifiers
 
         self.assertIs(classifiers.train_multiclass_classifier, train_multiclass_classifier)
+        self.assertIn("multinomial-logistic-weighted", classifiers.CLASSIFIER_REGISTRY)
 
     def test_default_params_for_cross_subject_baseline_classifiers(self):
         self.assertIsNone(get_default_classifier_param("correlation-prototype"))
         self.assertEqual(get_default_classifier_param("multinomial-logistic"), 1.0)
+        self.assertEqual(get_default_classifier_param("multinomial-logistic-weighted"), 1.0)
         self.assertIsNone(get_default_classifier_param("shrinkage-lda"))
+
+    def test_weighted_multinomial_logistic_trains(self):
+        features = np.asarray(
+            [
+                [0.0, 0.0],
+                [0.0, 0.2],
+                [0.1, 0.0],
+                [1.0, 1.0],
+                [2.0, 2.0],
+            ],
+            dtype=float,
+        )
+        labels = np.asarray([0, 0, 0, 1, 2], dtype=int)
+
+        model = train_multiclass_classifier(features, labels, "multinomial-logistic-weighted", 1.0, random_state=13)
+
+        self.assertIn("multinomial-logistic-weighted", CLASSIFIER_REGISTRY)
+        self.assertEqual(model.model.class_weight, "balanced")
+        self.assertEqual(len(model.predict(features)), len(labels))
 
     def test_parse_classifier_param_accepts_auto(self):
         self.assertEqual(parse_classifier_param("auto"), "auto")

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -72,6 +72,7 @@ class TestClassifiers(unittest.TestCase):
         self.assertIs(classifiers.train_multiclass_classifier, train_multiclass_classifier)
         self.assertIn("gaussian-naive-bayes", classifiers.CLASSIFIER_REGISTRY)
         self.assertIn("multinomial-logistic-weighted", classifiers.CLASSIFIER_REGISTRY)
+        self.assertIn("regularized-qda", classifiers.CLASSIFIER_REGISTRY)
         self.assertIn("shrinkage-prototype", classifiers.CLASSIFIER_REGISTRY)
 
     def test_default_params_for_cross_subject_baseline_classifiers(self):
@@ -79,6 +80,7 @@ class TestClassifiers(unittest.TestCase):
         self.assertEqual(get_default_classifier_param("gaussian-naive-bayes"), 1e-9)
         self.assertEqual(get_default_classifier_param("multinomial-logistic"), 1.0)
         self.assertEqual(get_default_classifier_param("multinomial-logistic-weighted"), 1.0)
+        self.assertEqual(get_default_classifier_param("regularized-qda"), 0.5)
         self.assertEqual(get_default_classifier_param("shrinkage-prototype"), 0.25)
         self.assertIsNone(get_default_classifier_param("shrinkage-lda"))
 
@@ -103,6 +105,29 @@ class TestClassifiers(unittest.TestCase):
         self.assertEqual(model.model.var_smoothing, 1e-8)
         self.assertEqual(probabilities.shape, (3, 3))
         np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(3))
+
+    def test_regularized_qda_trains_and_predicts_probabilities(self):
+        rng = np.random.default_rng(13)
+        features = np.vstack(
+            [
+                rng.normal(loc=(-1.0, -1.0, 0.0), scale=0.2, size=(8, 3)),
+                rng.normal(loc=(1.0, 0.5, 0.0), scale=0.2, size=(8, 3)),
+                rng.normal(loc=(0.0, 1.2, 1.0), scale=0.2, size=(8, 3)),
+            ]
+        )
+        labels = np.repeat(np.arange(3, dtype=int), 8)
+
+        model = train_multiclass_classifier(features, labels, "regularized-qda", 0.25)
+        probabilities = model.predict_proba(features[:4])
+
+        self.assertIn("regularized-qda", CLASSIFIER_REGISTRY)
+        self.assertEqual(model.model.reg_param, 0.25)
+        self.assertEqual(probabilities.shape, (4, 3))
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(4))
+
+    def test_regularized_qda_rejects_invalid_regularization(self):
+        with self.assertRaisesRegex(ValueError, "regularized-qda classifier_param"):
+            train_multiclass_classifier(self.features, self.labels, "regularized-qda", 1.5)
 
     def test_weighted_multinomial_logistic_trains(self):
         features = np.asarray(

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -71,11 +71,13 @@ class TestClassifiers(unittest.TestCase):
 
         self.assertIs(classifiers.train_multiclass_classifier, train_multiclass_classifier)
         self.assertIn("multinomial-logistic-weighted", classifiers.CLASSIFIER_REGISTRY)
+        self.assertIn("shrinkage-prototype", classifiers.CLASSIFIER_REGISTRY)
 
     def test_default_params_for_cross_subject_baseline_classifiers(self):
         self.assertIsNone(get_default_classifier_param("correlation-prototype"))
         self.assertEqual(get_default_classifier_param("multinomial-logistic"), 1.0)
         self.assertEqual(get_default_classifier_param("multinomial-logistic-weighted"), 1.0)
+        self.assertEqual(get_default_classifier_param("shrinkage-prototype"), 0.25)
         self.assertIsNone(get_default_classifier_param("shrinkage-lda"))
 
     def test_weighted_multinomial_logistic_trains(self):
@@ -96,6 +98,33 @@ class TestClassifiers(unittest.TestCase):
         self.assertIn("multinomial-logistic-weighted", CLASSIFIER_REGISTRY)
         self.assertEqual(model.model.class_weight, "balanced")
         self.assertEqual(len(model.predict(features)), len(labels))
+
+    def test_shrinkage_prototype_classifier_trains_and_scores(self):
+        features = np.asarray(
+            [
+                [0.0, 0.0],
+                [0.0, 0.2],
+                [1.0, 1.0],
+                [1.1, 1.0],
+                [2.0, 0.0],
+                [2.1, 0.1],
+            ],
+            dtype=float,
+        )
+        labels = np.asarray([0, 0, 1, 1, 2, 2], dtype=int)
+
+        model = train_multiclass_classifier(features, labels, "shrinkage-prototype", 0.1)
+        predictions = model.predict(np.asarray([[0.0, 0.1], [1.1, 1.0], [2.1, 0.0]], dtype=float))
+        scores = model.decision_function(features[:3])
+
+        self.assertIn("shrinkage-prototype", CLASSIFIER_REGISTRY)
+        self.assertEqual(model.model.shrinkage, 0.1)
+        np.testing.assert_array_equal(predictions, np.asarray([0, 1, 2], dtype=int))
+        self.assertEqual(scores.shape, (3, 3))
+
+    def test_shrinkage_prototype_rejects_invalid_shrinkage(self):
+        with self.assertRaisesRegex(ValueError, "shrinkage-prototype classifier_param"):
+            train_multiclass_classifier(self.features, self.labels, "shrinkage-prototype", 1.5)
 
     def test_parse_classifier_param_accepts_auto(self):
         self.assertEqual(parse_classifier_param("auto"), "auto")

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -137,6 +137,55 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertTrue(np.allclose(np.mean(feature_set.features, axis=1), 0.0))
         self.assertTrue(np.allclose(np.std(feature_set.features, axis=1), 1.0))
 
+    def test_sensor_mean_slope_keeps_channel_mean_and_temporal_trend(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0], [0.0, 0.0, 2.0, 6.0]],
+            [[0.0, 0.0, 2.0, 4.0], [0.0, 0.0, 4.0, 8.0]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean_slope",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 4))
+        np.testing.assert_allclose(feature_set.features[0], np.asarray([2.0, 4.0, 2.0, 4.0]))
+        np.testing.assert_allclose(feature_set.features[1], np.asarray([3.0, 6.0, 2.0, 4.0]))
+
+    def test_sensor_mean_slope_supports_baseline_whitening(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
+        trials = [
+            [[-1.0, -0.8, 1.0, 1.2], [0.5, 0.7, 3.0, 3.2]],
+            [[-0.4, -0.2, 2.0, 2.2], [1.1, 1.3, 4.0, 4.2]],
+            [[0.2, 0.4, 3.0, 3.2], [1.7, 1.9, 5.0, 5.2]],
+            [[0.8, 1.0, 4.0, 4.2], [2.3, 2.5, 6.0, 6.2]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2, 1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean_slope",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (4, 4))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 4))
+        self.assertEqual(feature_set.baseline_whitening_matrix.shape, (2, 2))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
     def test_sensor_flat_subject_baseline_whiten_uses_channel_covariance(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
         trials = [

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -451,14 +451,33 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(len(artifacts["outer"]), 4)
         self.assertEqual({row["classifier"] for row in artifacts["outer"]}, {"nested_topk_score_ensemble"})
         self.assertEqual({row["selection_ensemble_size"] for row in artifacts["selected"]}, {2})
+        self.assertEqual({row["selection_ensemble_weighting"] for row in artifacts["selected"]}, {"uniform"})
         self.assertTrue(all(";" in row["selected_candidate_indices"] for row in artifacts["selected"]))
+        self.assertTrue(all(row["selected_ensemble_weights"] in {"1:0.5;2:0.5", "2:0.5;1:0.5"} for row in artifacts["selected"]))
         self.assertTrue(all(row["ensemble_score_normalization"] == "row_z_softmax" for row in artifacts["outer"]))
         self.assertEqual({row["balanced_accuracy"] for row in artifacts["outer"]}, {1.0})
         self.assertEqual(artifacts["group_summary"][0]["outer_evaluation_mode"], "topk_score_ensemble")
         self.assertEqual(artifacts["group_summary"][0]["selection_ensemble_size"], 2)
+        self.assertEqual(artifacts["group_summary"][0]["selection_ensemble_weighting"], "uniform")
         self.assertIn("1:", artifacts["group_summary"][0]["selected_ensemble_candidate_counts"])
         self.assertIn("2:", artifacts["group_summary"][0]["selected_ensemble_candidate_counts"])
         self.assertEqual(fit_model.call_count, 20)
+
+    def test_nested_ensemble_weights_can_follow_inner_validation_scores(self):
+        rows = [
+            {"selected_inner_balanced_accuracy_mean": 0.70},
+            {"selected_inner_balanced_accuracy_mean": 0.66},
+            {"selected_inner_balanced_accuracy_mean": 0.62},
+        ]
+
+        uniform = cross_subject._nested_ensemble_weights(rows, weighting="uniform", temperature=0.02)  # pylint: disable=protected-access
+        weighted = cross_subject._nested_ensemble_weights(rows, weighting="inner_softmax", temperature=0.02)  # pylint: disable=protected-access
+
+        np.testing.assert_allclose(uniform, np.asarray([1 / 3, 1 / 3, 1 / 3]))
+        self.assertAlmostEqual(float(np.sum(weighted)), 1.0)
+        self.assertGreater(weighted[0], weighted[1])
+        self.assertGreater(weighted[1], weighted[2])
+        self.assertGreater(weighted[0], 0.80)
 
     def test_nested_cross_subject_can_evaluate_outer_subset(self):
         data_by_participant = {

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -160,6 +160,29 @@ class TestStimulusCrossSubject(unittest.TestCase):
         np.testing.assert_allclose(feature_set.features[0], np.asarray([2.0, 4.0, 2.0, 4.0]))
         np.testing.assert_allclose(feature_set.features[1], np.asarray([3.0, 6.0, 2.0, 4.0]))
 
+    def test_sensor_mean_slope_std_keeps_channel_summary_moments(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0], [0.0, 0.0, 2.0, 6.0]],
+            [[0.0, 0.0, 2.0, 4.0], [0.0, 0.0, 4.0, 8.0]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean_slope_std",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        np.testing.assert_allclose(feature_set.features[0], np.asarray([2.0, 4.0, 2.0, 4.0, 1.0, 2.0]))
+        np.testing.assert_allclose(feature_set.features[1], np.asarray([3.0, 6.0, 2.0, 4.0, 1.0, 2.0]))
+
     def test_sensor_mean_slope_supports_baseline_whitening(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
         trials = [
@@ -183,6 +206,32 @@ class TestStimulusCrossSubject(unittest.TestCase):
 
         self.assertEqual(feature_set.features.shape, (4, 4))
         self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 4))
+        self.assertEqual(feature_set.baseline_whitening_matrix.shape, (2, 2))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_mean_slope_std_supports_baseline_whitening(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
+        trials = [
+            [[-1.0, -0.8, 1.0, 1.2], [0.5, 0.7, 3.0, 3.2]],
+            [[-0.4, -0.2, 2.0, 2.2], [1.1, 1.3, 4.0, 4.2]],
+            [[0.2, 0.4, 3.0, 3.2], [1.7, 1.9, 5.0, 5.2]],
+            [[0.8, 1.0, 4.0, 4.2], [2.3, 2.5, 6.0, 6.2]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2, 1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean_slope_std",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (4, 6))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 6))
         self.assertEqual(feature_set.baseline_whitening_matrix.shape, (2, 2))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -481,6 +481,64 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertGreater(weighted[1], weighted[2])
         self.assertGreater(weighted[0], 0.80)
 
+    def test_nested_ensemble_can_prefer_diverse_candidate_windows(self):
+        configs = (
+            CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),
+            CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="shrinkage-lda"),
+            CrossSubjectStimulusConfig(window_center=0.20, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),
+        )
+
+        def inner_row(candidate_index, balanced_accuracy, window_center, classifier):
+            return {
+                "outer_test_participant": 4,
+                "candidate_index": candidate_index,
+                "balanced_accuracy": balanced_accuracy,
+                "accuracy": balanced_accuracy,
+                "train_participants": "1,2,3",
+                "n_train_participants": 3,
+                "window_center_s": window_center,
+                "window_size_s": 0.1,
+                "window_start_s": window_center - 0.05,
+                "window_stop_s": window_center + 0.05,
+                "feature_mode": "sensor_mean",
+                "normalization": "none",
+                "alignment": "none",
+                "classifier": classifier,
+                "classifier_param": 0.5,
+                "components_pca": float("inf"),
+                "max_trials_per_class_per_participant": "",
+            }
+
+        inner_rows = [
+            inner_row(1, 0.90, 0.10, "multiclass-svm"),
+            inner_row(2, 0.85, 0.10, "shrinkage-lda"),
+            inner_row(3, 0.80, 0.20, "multiclass-svm"),
+        ]
+
+        top_two, _top_two_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="none",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+        diverse, _diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+
+        self.assertEqual(top_two["selected_candidate_indices"], "1;2")
+        self.assertEqual(diverse["selected_candidate_indices"], "1;3")
+        self.assertEqual(diverse["selection_ensemble_diversity"], "window")
+        self.assertEqual(diverse["selected_ensemble_window_center_counts"], "0.1:1;0.2:1")
+
     def test_rank_softmax_score_normalization_ignores_score_scale(self):
         small_scale = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
             np.asarray([[0.30, 0.10, 0.20]], dtype=float),

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 import numpy as np
 from pymegdec import stimulus_cross_subject as cross_subject
 from pymegdec.stimulus_cross_subject import (
+    AUTO_CLASSIFIER_PARAM_GRID_TOKEN,
+    CLASSIFIER_AUTO_PARAM_GRIDS,
     CrossSubjectStimulusConfig,
     evaluate_cross_subject_stimulus_smoke,
     evaluate_nested_cross_subject_stimulus,
@@ -227,6 +229,40 @@ class TestStimulusCrossSubject(unittest.TestCase):
 
         self.assertEqual(feature_set.trial_indices.tolist(), [1, 2, 3, 4])
         self.assertEqual(feature_set.labels.tolist(), [2, 1, 2, 1])
+
+    def test_auto_classifier_param_grid_expands_per_classifier(self):
+        candidate_configs = make_cross_subject_candidate_configs(
+            window_centers=(0.2,),
+            window_size=0.1,
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multiclass-svm", "shrinkage-lda", "regularized-qda"),
+            classifier_params=(AUTO_CLASSIFIER_PARAM_GRID_TOKEN,),
+            components_pca_values=(64,),
+        )
+
+        params_by_classifier = {
+            classifier: tuple(config.classifier_param for config in candidate_configs if config.classifier == classifier)
+            for classifier in ("multiclass-svm", "shrinkage-lda", "regularized-qda")
+        }
+
+        self.assertEqual(len(candidate_configs), 10)
+        self.assertEqual(params_by_classifier["multiclass-svm"], CLASSIFIER_AUTO_PARAM_GRIDS["multiclass-svm"])
+        self.assertEqual(params_by_classifier["shrinkage-lda"], CLASSIFIER_AUTO_PARAM_GRIDS["shrinkage-lda"])
+        self.assertEqual(params_by_classifier["regularized-qda"], CLASSIFIER_AUTO_PARAM_GRIDS["regularized-qda"])
+
+    def test_auto_classifier_param_grid_preserves_explicit_classifier_params_once(self):
+        candidate_configs = make_cross_subject_candidate_configs(
+            window_centers=(0.2,),
+            window_size=0.1,
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multiclass-svm",),
+            classifier_params=(AUTO_CLASSIFIER_PARAM_GRID_TOKEN, 1.0, 100.0),
+            components_pca_values=(64,),
+        )
+
+        self.assertEqual(tuple(config.classifier_param for config in candidate_configs), (0.1, 1.0, 10.0, 100.0))
 
     def test_evaluate_cross_subject_stimulus_smoke(self):
         data_by_participant = {

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -451,6 +451,7 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(len(artifacts["outer"]), 4)
         self.assertEqual({row["classifier"] for row in artifacts["outer"]}, {"nested_topk_score_ensemble"})
         self.assertEqual({row["selection_ensemble_size"] for row in artifacts["selected"]}, {2})
+        self.assertEqual({row["selection_ensemble_score_normalization"] for row in artifacts["selected"]}, {"row_z_softmax"})
         self.assertEqual({row["selection_ensemble_weighting"] for row in artifacts["selected"]}, {"uniform"})
         self.assertTrue(all(";" in row["selected_candidate_indices"] for row in artifacts["selected"]))
         self.assertTrue(all(row["selected_ensemble_weights"] in {"1:0.5;2:0.5", "2:0.5;1:0.5"} for row in artifacts["selected"]))
@@ -458,6 +459,7 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual({row["balanced_accuracy"] for row in artifacts["outer"]}, {1.0})
         self.assertEqual(artifacts["group_summary"][0]["outer_evaluation_mode"], "topk_score_ensemble")
         self.assertEqual(artifacts["group_summary"][0]["selection_ensemble_size"], 2)
+        self.assertEqual(artifacts["group_summary"][0]["selection_ensemble_score_normalization"], "row_z_softmax")
         self.assertEqual(artifacts["group_summary"][0]["selection_ensemble_weighting"], "uniform")
         self.assertIn("1:", artifacts["group_summary"][0]["selected_ensemble_candidate_counts"])
         self.assertIn("2:", artifacts["group_summary"][0]["selected_ensemble_candidate_counts"])
@@ -478,6 +480,26 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertGreater(weighted[0], weighted[1])
         self.assertGreater(weighted[1], weighted[2])
         self.assertGreater(weighted[0], 0.80)
+
+    def test_rank_softmax_score_normalization_ignores_score_scale(self):
+        small_scale = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            np.asarray([[0.30, 0.10, 0.20]], dtype=float),
+            score_normalization="rank_softmax",
+        )
+        large_scale = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            np.asarray([[300.0, 100.0, 200.0]], dtype=float),
+            score_normalization="rank-softmax",
+        )
+        row_z = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            np.asarray([[300.0, 100.0, 200.0]], dtype=float),
+            score_normalization="row_z_softmax",
+        )
+
+        np.testing.assert_allclose(small_scale, large_scale)
+        self.assertEqual(int(np.argmax(large_scale[0])), 0)
+        self.assertEqual(int(np.argmax(row_z[0])), 0)
+        self.assertGreater(large_scale[0, 0], large_scale[0, 2])
+        self.assertGreater(large_scale[0, 2], large_scale[0, 1])
 
     def test_nested_cross_subject_can_evaluate_outer_subset(self):
         data_by_participant = {

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -503,19 +503,23 @@ class TestStimulusCrossSubject(unittest.TestCase):
 
     def test_nested_ensemble_weights_can_follow_inner_validation_scores(self):
         rows = [
-            {"selected_inner_balanced_accuracy_mean": 0.70},
-            {"selected_inner_balanced_accuracy_mean": 0.66},
-            {"selected_inner_balanced_accuracy_mean": 0.62},
+            {"selected_inner_balanced_accuracy_mean": 0.70, "selected_inner_balanced_accuracy_sem": 0.07},
+            {"selected_inner_balanced_accuracy_mean": 0.66, "selected_inner_balanced_accuracy_sem": 0.01},
+            {"selected_inner_balanced_accuracy_mean": 0.62, "selected_inner_balanced_accuracy_sem": 0.00},
         ]
 
         uniform = cross_subject._nested_ensemble_weights(rows, weighting="uniform", temperature=0.02)  # pylint: disable=protected-access
         weighted = cross_subject._nested_ensemble_weights(rows, weighting="inner_softmax", temperature=0.02)  # pylint: disable=protected-access
+        lcb_weighted = cross_subject._nested_ensemble_weights(rows, weighting="inner_lcb_softmax", temperature=0.02)  # pylint: disable=protected-access
 
         np.testing.assert_allclose(uniform, np.asarray([1 / 3, 1 / 3, 1 / 3]))
         self.assertAlmostEqual(float(np.sum(weighted)), 1.0)
         self.assertGreater(weighted[0], weighted[1])
         self.assertGreater(weighted[1], weighted[2])
         self.assertGreater(weighted[0], 0.80)
+        self.assertAlmostEqual(float(np.sum(lcb_weighted)), 1.0)
+        self.assertGreater(lcb_weighted[1], lcb_weighted[0])
+        self.assertGreater(lcb_weighted[0], lcb_weighted[2])
 
     def test_nested_ensemble_can_prefer_diverse_candidate_windows(self):
         configs = (

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -418,6 +418,48 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertAlmostEqual(artifacts["group_summary"][0]["one_sided_exact_sign_p_value"], 1 / 16)
         self.assertEqual(fit_model.call_count, 16)
 
+    def test_nested_cross_subject_can_ensemble_top_inner_candidates(self):
+        data_by_participant = {
+            1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),
+            2: _mat_data([1, 2, 1, 2], [-1.0, 1.0, -0.9, 0.9]),
+            3: _mat_data([1, 2, 1, 2], [-1.3, 1.3, -1.2, 1.2]),
+            4: _mat_data([1, 2, 1, 2], [-1.1, 1.1, -1.0, 1.0]),
+        }
+        candidate_configs = make_cross_subject_candidate_configs(
+            window_centers=(0.150, 0.200),
+            window_size=0.1,
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multiclass-svm",),
+            classifier_params=(0.5,),
+            components_pca_values=(float("inf"),),
+            chance_classes=2,
+            signflip_permutations=128,
+        )
+
+        with (
+            patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)),
+            patch("pymegdec.stimulus_cross_subject.fit_reptrace_window_model", wraps=cross_subject.fit_reptrace_window_model) as fit_model,
+        ):
+            artifacts = evaluate_nested_cross_subject_stimulus(
+                "unused",
+                [1, 2, 3, 4],
+                candidate_configs=candidate_configs,
+                selection_ensemble_size=2,
+            )
+
+        self.assertEqual(len(artifacts["outer"]), 4)
+        self.assertEqual({row["classifier"] for row in artifacts["outer"]}, {"nested_topk_score_ensemble"})
+        self.assertEqual({row["selection_ensemble_size"] for row in artifacts["selected"]}, {2})
+        self.assertTrue(all(";" in row["selected_candidate_indices"] for row in artifacts["selected"]))
+        self.assertTrue(all(row["ensemble_score_normalization"] == "row_z_softmax" for row in artifacts["outer"]))
+        self.assertEqual({row["balanced_accuracy"] for row in artifacts["outer"]}, {1.0})
+        self.assertEqual(artifacts["group_summary"][0]["outer_evaluation_mode"], "topk_score_ensemble")
+        self.assertEqual(artifacts["group_summary"][0]["selection_ensemble_size"], 2)
+        self.assertIn("1:", artifacts["group_summary"][0]["selected_ensemble_candidate_counts"])
+        self.assertIn("2:", artifacts["group_summary"][0]["selected_ensemble_candidate_counts"])
+        self.assertEqual(fit_model.call_count, 20)
+
     def test_nested_cross_subject_can_evaluate_outer_subset(self):
         data_by_participant = {
             1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -8,7 +8,9 @@ import numpy as np
 from pymegdec import stimulus_cross_subject as cross_subject
 from pymegdec.stimulus_cross_subject import (
     AUTO_CLASSIFIER_PARAM_GRID_TOKEN,
+    AUTO_COMPONENTS_PCA_GRID_TOKEN,
     CLASSIFIER_AUTO_PARAM_GRIDS,
+    COMPONENTS_PCA_AUTO_GRID,
     CrossSubjectStimulusConfig,
     evaluate_cross_subject_stimulus_smoke,
     evaluate_nested_cross_subject_stimulus,
@@ -263,6 +265,32 @@ class TestStimulusCrossSubject(unittest.TestCase):
         )
 
         self.assertEqual(tuple(config.classifier_param for config in candidate_configs), (0.1, 1.0, 10.0, 100.0))
+
+    def test_auto_components_pca_grid_expands_candidate_configs(self):
+        candidate_configs = make_cross_subject_candidate_configs(
+            window_centers=(0.2,),
+            window_size=0.1,
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multiclass-svm",),
+            classifier_params=(0.5,),
+            components_pca_values=(AUTO_COMPONENTS_PCA_GRID_TOKEN,),
+        )
+
+        self.assertEqual(tuple(config.components_pca for config in candidate_configs), COMPONENTS_PCA_AUTO_GRID)
+
+    def test_auto_components_pca_grid_preserves_explicit_values_once(self):
+        candidate_configs = make_cross_subject_candidate_configs(
+            window_centers=(0.2,),
+            window_size=0.1,
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multiclass-svm",),
+            classifier_params=(0.5,),
+            components_pca_values=(AUTO_COMPONENTS_PCA_GRID_TOKEN, 64, 256),
+        )
+
+        self.assertEqual(tuple(config.components_pca for config in candidate_configs), (32, 64, 128, 256))
 
     def test_evaluate_cross_subject_stimulus_smoke(self):
         data_by_participant = {


### PR DESCRIPTION
## Summary
- Add opt-in nested top-K score ensembling for cross-subject stimulus decoding via `--selection-ensemble-size`.
- Add `--selection-ensemble-diversity {none,window,classifier,window_classifier,full_config}` so top-K ensembles can prefer less redundant candidate sets before filling remaining slots.
- Ensemble selected inner-LOSO candidates after configurable per-candidate score normalization while preserving the default single-winner behavior.
- Add `--selection-ensemble-score-normalization {row_z_softmax,rank_softmax}` so we can compare margin-based averaging against scale-robust rank-based averaging.
- Add `--selection-ensemble-weighting {uniform,inner_softmax,inner_lcb_softmax}` plus `--selection-ensemble-temperature`; `inner_lcb_softmax` weights candidates by inner mean balanced accuracy minus one SEM, favoring stable inner performance.
- Add `classifier_params=auto-grid`, which expands to classifier-specific hyperparameter grids instead of blindly crossing one global parameter list with every classifier.
- Add `components_pca_values=auto-grid`, which expands to `32,64,128` so nested selection can tune dimensionality instead of fixing PCA at 64 components.
- Add `sensor_mean_slope` and `sensor_mean_slope_std`, compact per-channel summary feature modes, and include them alongside `sensor_flat` in the nested workflow default grid.
- Add PyMEGDec-local `multinomial-logistic-weighted`, `shrinkage-prototype`, `gaussian-naive-bayes`, and `regularized-qda`, and include them in the nested workflow default classifier grid.
- Record ensemble provenance in selected, outer, prediction, group-summary, and workflow summary outputs.
- Expose the workflow inputs for manual nested benchmark dispatch.

## Verification
- `python -m pytest tests\test_stimulus_cross_subject.py tests\test_time_axis_handling.py tests\test_stimulus_cue_calibration.py -q`
- `python -m ruff check .`
- `$env:MPLBACKEND='Agg'; python -m pytest -q`

## Next benchmark to try
Run the manual nested workflow with `feature_modes=sensor_flat,sensor_mean_slope,sensor_mean_slope_std`, `classifiers=multinomial-logistic,multinomial-logistic-weighted,shrinkage-lda,shrinkage-prototype,regularized-qda,gaussian-naive-bayes,multiclass-svm`, `classifier_params=auto-grid`, `components_pca_values=auto-grid`, `selection_ensemble_size=3`, `selection_ensemble_diversity=window_classifier`, `selection_ensemble_score_normalization=rank_softmax`, `selection_ensemble_weighting=inner_lcb_softmax`, and `selection_ensemble_temperature=0.02` on the strongest current candidate grid.