### PR TITLE
Use NeuRepTrace upstream dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ cross-validation workflows, and exports stimulus, alpha, and reaction-time
 analysis tables.
 
 Generic decoding summaries and reusable prediction-table diagnostics belong in
-[RepTrace](https://github.com/IPS-Stuttgart/RepTrace). PyMEGDec keeps the
+[NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace). PyMEGDec keeps the
 project-specific data conventions, preprocessing defaults, CTF sensor-geometry
 handling, and paper-facing scripts.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -85,7 +85,7 @@ argument parsing only.
 
 ## Classifiers
 
-`pymegdec.classifiers.CLASSIFIER_REGISTRY` extends the RepTrace classifier
+`pymegdec.classifiers.CLASSIFIER_REGISTRY` extends the NeuRepTrace classifier
 registry with PyMEGDec-specific optional backends:
 
 - `xgboost`, installed with the `xgboost` extra.

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,7 +46,7 @@ Recommended structure for future additions:
   page.
 - New output table: document the producer command, row granularity, and the most
   important columns near the workflow that creates it.
-- New reusable decoding method: consider whether it belongs in RepTrace instead
+- New reusable decoding method: consider whether it belongs in NeuRepTrace instead
   of PyMEGDec.
 
 Preview locally:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ poetry run python -m unittest discover -v
 
 ## Optional classifier backends
 
-The default install includes the core scientific stack and the RepTrace-backed
+The default install includes the core scientific stack and the NeuRepTrace-backed
 classifier registry. Additional classifier backends are available through extras:
 
 ```bash
@@ -38,7 +38,7 @@ The PyMEGDec-specific classifier additions are:
 - `xgboost`, which requires the `xgboost` extra.
 - `pytorch-mlp`, which requires the `torch` extra.
 
-Other classifier names are inherited from RepTrace's classifier registry.
+Other classifier names are inherited from NeuRepTrace's classifier registry.
 
 ## Smoke tests
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ The usual workflow is:
    sensor-level alpha-movement export, or alpha/reaction-time analysis.
 4. Analyze the exported CSV tables and plots.
 
-## Boundary with RepTrace
+## Boundary with NeuRepTrace
 
 PyMEGDec should keep code that is tied to this MEG dataset and its analysis
 scripts:
@@ -25,7 +25,7 @@ scripts:
 - Compatibility wrappers for existing scripts.
 
 Reusable decoding functionality should live in
-[RepTrace](https://github.com/IPS-Stuttgart/RepTrace) and be imported here:
+[NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace) and be imported here:
 
 - Feature-matrix and MNE `Epochs` decoding helpers.
 - Classifier calibration and prediction diagnostics.

--- a/docs/stimulus-decoding.md
+++ b/docs/stimulus-decoding.md
@@ -158,7 +158,7 @@ written as `stimulus_cross_subject_nested_label_shuffle_*.csv`.
 ## Cross-subject shared-space alignment benchmarks
 
 Use the manual `stimulus-cross-subject-alignment-benchmarks.yml` workflow to
-compare RepTrace-backed Procrustes hyperalignment and M-CCA on the same
+compare NeuRepTrace-backed Procrustes hyperalignment and M-CCA on the same
 `Part*Data.mat` LOSO image-identity task. This workflow is separate from the
 nested candidate-grid workflow because hyperalignment and M-CCA use dedicated
 shared-space fitting code and expose additional method-specific parameters.

--- a/poetry.lock
+++ b/poetry.lock
@@ -2293,9 +2293,9 @@ xgboost = ["xgboost"]
 
 [package.source]
 type = "git"
-url = "https://github.com/IPS-Stuttgart/RepTrace.git"
+url = "https://github.com/IPS-Stuttgart/NeuRepTrace.git"
 reference = "main"
-resolved_reference = "e50bc1ea95926ec2e2b9acab344f8a843bb7efe5"
+resolved_reference = "9e261040b4c829a6615ac6034ea49ff528169d88"
 
 [[package]]
 name = "requests"
@@ -2873,4 +2873,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "1ac5f76e8e285824cae06ea6c687619f73b721e3da733a879d4a102864a6f0f0"
+content-hash = "fc8085effb26f13266e98e46a507ee9340b6e06f5286e939c2d4ed37c3553cab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas>=3.0.3,<4.0.0",
-    "reptrace @ git+https://github.com/IPS-Stuttgart/RepTrace.git@main",
+    "reptrace @ git+https://github.com/IPS-Stuttgart/NeuRepTrace.git@main",
     "scikit-learn",
     "scipy",
 ]

--- a/src/pymegdec/_reptrace_score_overrides.py
+++ b/src/pymegdec/_reptrace_score_overrides.py
@@ -1,4 +1,4 @@
-"""Thin PyMEGDec adapters for upstream RepTrace class-score helpers."""
+"""Thin PyMEGDec adapters for upstream NeuRepTrace class-score helpers."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from reptrace.metrics import rank_class_scores
 
 
 def mcca_score_matrix(bundle, features):
-    """Return upstream RepTrace per-class scores for a fitted M-CCA window bundle."""
+    """Return upstream NeuRepTrace per-class scores for a fitted M-CCA window bundle."""
 
     if hasattr(bundle, "pca_coeff") and hasattr(bundle, "train_features_mean"):
         return predict_window_class_scores(bundle, features)
@@ -16,7 +16,7 @@ def mcca_score_matrix(bundle, features):
 
 
 def mcca_rank_metrics(scores, classes, y_true):
-    """Return the legacy PyMEGDec tuple shape from RepTrace rank summaries."""
+    """Return the legacy PyMEGDec tuple shape from NeuRepTrace rank summaries."""
 
     summary = rank_class_scores(scores, classes, y_true, top_k=(2, 3), row_top_k=3, class_column="stimulus")
     top_k_accuracy = summary["top_k_accuracy"]
@@ -30,14 +30,14 @@ def hyperalignment_class_score_matrix(model_bundle, features):
 
 
 def true_label_ranks(true_labels, class_scores, score_classes):
-    """Return only true-label ranks using RepTrace's ranking semantics."""
+    """Return only true-label ranks using NeuRepTrace's ranking semantics."""
 
     summary = rank_class_scores(class_scores, score_classes, true_labels, top_k=(), row_top_k=0)
     return summary["true_label_ranks"]
 
 
 def topk_and_rank_metrics(true_labels, class_scores, score_classes):
-    """Return PyMEGDec's top-k metric dict using upstream RepTrace ranking."""
+    """Return PyMEGDec's top-k metric dict using upstream NeuRepTrace ranking."""
 
     summary = rank_class_scores(class_scores, score_classes, true_labels, top_k=(2, 3), row_top_k=0)
     top_k_accuracy = summary["top_k_accuracy"]
@@ -58,7 +58,7 @@ def cross_subject_model_class_scores(model_bundle, features):
 
 
 def cross_subject_ranked_label_metrics(true_labels, class_scores, score_classes):
-    """Return PyMEGDec cross-subject rank metrics using RepTrace summaries."""
+    """Return PyMEGDec cross-subject rank metrics using NeuRepTrace summaries."""
 
     summary = rank_class_scores(class_scores, score_classes, true_labels, top_k=(2, 3), row_top_k=0)
     top_k_accuracy = summary["top_k_accuracy"]

--- a/src/pymegdec/_stimulus_mcca_legacy.py
+++ b/src/pymegdec/_stimulus_mcca_legacy.py
@@ -1,4 +1,4 @@
-"""LOSO cross-subject stimulus decoding with RepTrace M-CCA alignment."""
+"""LOSO cross-subject stimulus decoding with NeuRepTrace M-CCA alignment."""
 
 from __future__ import annotations
 
@@ -617,7 +617,7 @@ def _optional_int(value: str):
 
 
 def _parser(prog=None):
-    parser = argparse.ArgumentParser(prog=prog, description="Run LOSO stimulus decoding with RepTrace M-CCA alignment.")
+    parser = argparse.ArgumentParser(prog=prog, description="Run LOSO stimulus decoding with NeuRepTrace M-CCA alignment.")
     parser.add_argument("--data-dir", dest="data_folder", default=None)
     parser.add_argument("--participants", default=DEFAULT_CROSS_SUBJECT_PARTICIPANTS)
     parser.add_argument("--outer-participants", default=None)

--- a/src/pymegdec/_stimulus_trial_sampling.py
+++ b/src/pymegdec/_stimulus_trial_sampling.py
@@ -1,4 +1,4 @@
-"""RepTrace-backed trial-selection bridge for stimulus decoding."""
+"""NeuRepTrace-backed trial-selection bridge for stimulus decoding."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ def _selected_trial_indices(
     participant=None,
     seed_context=None,
 ):
-    """Select trial indices through RepTrace's generic class-limited sampler."""
+    """Select trial indices through NeuRepTrace's generic class-limited sampler."""
 
     if seed_context is None and participant is not None:
         seed_context = participant

--- a/src/pymegdec/alignment_window.py
+++ b/src/pymegdec/alignment_window.py
@@ -1,4 +1,4 @@
-"""Compatibility layer for alignment-window helpers now provided by RepTrace."""
+"""Compatibility layer for alignment-window helpers now provided by NeuRepTrace."""
 
 from reptrace.decoding.alignment_window import AlignmentWindow
 from reptrace.decoding.alignment_window import WindowedFeatureSet

--- a/src/pymegdec/stimulus_mcca.py
+++ b/src/pymegdec/stimulus_mcca.py
@@ -1,4 +1,4 @@
-"""Public facade for RepTrace M-CCA stimulus decoding."""
+"""Public facade for NeuRepTrace M-CCA stimulus decoding."""
 
 from __future__ import annotations
 

--- a/tests/test_stimulus_alignment_benchmarks.py
+++ b/tests/test_stimulus_alignment_benchmarks.py
@@ -253,7 +253,7 @@ def test_cross_subject_hyperalignment_mean_initialization_uses_mean_path():
     )
 
     def fail_pca_path(*_args, **_kwargs):
-        raise AssertionError("mean initialization must not use RepTrace's PCA-default fit_class_hyperalignment path")
+        raise AssertionError("mean initialization must not use NeuRepTrace's PCA-default fit_class_hyperalignment path")
 
     with patch("pymegdec._stimulus_hyperalignment_legacy.fit_class_hyperalignment", side_effect=fail_pca_path), patch(
         "pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(_toy_data_by_participant())


### PR DESCRIPTION
## Summary
- Switch the `reptrace` Git dependency from `IPS-Stuttgart/RepTrace` to `IPS-Stuttgart/NeuRepTrace` and refresh the lockfile to the current NeuRepTrace `main` commit.
- Update PyMEGDec docs and user-facing adapter text from RepTrace to NeuRepTrace.
- Keep lowercase `reptrace` imports and compatibility helper names unchanged because the upstream Python package namespace is still `reptrace`.

## Validation
- `poetry install`
- `git diff --check origin/main..HEAD`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest`