### PR TITLE
Apply PyMEGDec patch batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,19 @@ loads participant MATLAB files, prepares MEG windows, runs model-transfer and
 cross-validation workflows, and exports stimulus analysis tables.
 
 Generic decoding summaries and reusable prediction-table diagnostics belong in
-[NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace). PyMEGDec keeps the
-project-specific data conventions, preprocessing defaults, CTF sensor-geometry
-handling, and paper-facing scripts until those pieces have either moved or been
-retired.
+[NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace). PyMEGDec is moving
+toward a compatibility role: dataset file conventions and metadata mappings can
+now be expressed as NeuRepTrace YAML/JSON dataset specs, while highly
+project-specific alpha, CTF geometry, reaction-time, and paper-export scripts
+can remain here until they are generalized.
+
+Write a starter NeuRepTrace dataset spec for the historical `Part*Data.mat` /
+`Part*CueData.mat` convention with:
+
+```bash
+pymegdec data write-neureptrace-spec --out configs/bushmeg.yml
+neureptrace dataset validate configs/bushmeg.yml
+```
 
 The alpha-band, alpha-movement, and alpha/reaction-time workflows are now
 explicitly legacy-only. They remain callable for reproducibility and to regenerate

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 PyMEGDec contains the MEG-specific analysis layer for decoding experiments. It
 loads participant MATLAB files, prepares MEG windows, runs model-transfer and
-cross-validation workflows, and exports stimulus, alpha, and reaction-time
-analysis tables.
+cross-validation workflows, and exports stimulus analysis tables.
 
 Generic decoding summaries and reusable prediction-table diagnostics belong in
 [NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace). PyMEGDec keeps the
 project-specific data conventions, preprocessing defaults, CTF sensor-geometry
-handling, and paper-facing scripts.
+handling, and paper-facing scripts until those pieces have either moved or been
+retired.
+
+The alpha-band, alpha-movement, and alpha/reaction-time workflows are now
+explicitly legacy-only. They remain callable for reproducibility and to regenerate
+existing Bush/MEG CSV exports, but new reusable decoding or dataset-loading work
+should be implemented in NeuRepTrace instead.
 
 ## Quick start
 
@@ -44,8 +49,8 @@ The longer workflow documentation lives in `docs/`:
 - `docs/cli.md` — grouped CLI commands and compatibility entry points.
 - `docs/stimulus-decoding.md` — time-resolved stimulus decoding, diagnostics,
   robustness exports, temporal generalization, and onset scanning.
-- `docs/alpha.md` — alpha metrics, sensor-level alpha movement, and alpha/RT
-  analysis.
+- `docs/alpha.md` — legacy alpha metrics, sensor-level alpha movement, and
+  alpha/RT analysis kept for reproducibility during the PyMEGDec phase-out.
 - `docs/api.md` — public Python entry points and module boundaries.
 - `docs/development.md` — test strategy and documentation maintenance.
 

--- a/docs/alpha.md
+++ b/docs/alpha.md
@@ -3,6 +3,23 @@
 PyMEGDec contains exploratory alpha-band workflows for per-trial alpha metrics,
 sensor-level alpha topography movement, and alpha/reaction-time associations.
 
+## Legacy status
+
+These alpha-family workflows are legacy, project-specific analyses. They are
+kept in PyMEGDec to reproduce existing Bush/MEG exports and to regenerate the CSV
+files used by older analyses. They are not the target architecture for the
+PyMEGDec phase-out, and they should not be used as the template for new reusable
+NeuRepTrace workflows.
+
+Running any grouped alpha command emits a `FutureWarning`. If further alpha or
+reaction-time work is needed, prefer one of these migration paths:
+
+- keep the numerical alpha/RT analysis as a project-specific script or notebook
+  that consumes exported CSV files;
+- move only genuinely reusable signal-processing utilities to NeuRepTrace;
+- remove the workflow entirely once the published/reproducibility artifacts no
+  longer need to be regenerated.
+
 ## Alpha metrics
 
 Prestimulus alpha metrics are exported per trial for downstream plotting or

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,6 +4,9 @@ PyMEGDec exposes one grouped command. Prefer the grouped `pymegdec` command for
 new documentation, CI jobs, and shell scripts. Compatibility aliases and
 historical Python wrappers remain available for existing workflows.
 
+Private-data download helpers are intentionally kept outside the installed
+package. Use `python scripts/download_private_meg_data.py ...` from a checkout.
+
 ```bash
 pymegdec --help
 ```
@@ -33,21 +36,19 @@ pymegdec stimulus temporal-generalization --participants 2 --output outputs/stim
 pymegdec stimulus onset-scan --participants 2 --output outputs/stimulus_onset_scan.csv --events-output outputs/stimulus_onset_events.csv
 ```
 
-### Alpha workflows
+### Legacy alpha workflows
+
+The alpha, movement, and reaction-time commands are retained as legacy
+Bush-MEG/paper-specific analyses. They intentionally remain in PyMEGDec for
+reproducibility while generic FieldTrip/MAT loading and decoding are migrated to
+NeuRepTrace. New NeuRepTrace migration work should not depend on these commands.
+Running any of them emits a `PyMEGDecLegacyWorkflowWarning`.
 
 ```bash
 pymegdec alpha metrics --participant 2 --output outputs/part2_alpha_metrics.csv
 pymegdec alpha movement --participants 2 --trajectory-output outputs/part2_alpha_movement.csv --summary-output outputs/part2_alpha_movement_summary.csv
 pymegdec alpha movement-results --movement-summary outputs/part2_alpha_movement_summary.csv --effect-output outputs/part2_alpha_movement_effects.csv --condition-summary-output outputs/part2_alpha_movement_condition_summary.csv
 pymegdec alpha reaction-time --participants 2 --joined-output outputs/part2_alpha_rt_joined.csv --summary-output outputs/part2_alpha_rt_summary.csv
-```
-
-### Data helpers
-
-```bash
-pymegdec data download --data-dir data --env-name MEG_DATA_URL_LIST
-pymegdec data download --source webdav-rclone --data-dir data --file-indices 2,3
-pymegdec data download --source webdav-rclone --data-dir data --file-names Part2CueData.mat,Part2Data.mat
 ```
 
 ## Backward-compatible aliases
@@ -69,7 +70,6 @@ pymegdec alpha-movement
 pymegdec alpha-movement-results
 pymegdec alpha-reaction-time
 pymegdec alpha-rt
-pymegdec download-meg-data
 ```
 
 The installed script names remain available:
@@ -223,6 +223,11 @@ pymegdec stimulus onset-scan \
 ```
 
 ## Alpha movement result analysis
+
+This is a legacy Bush-MEG analysis endpoint. It is kept to reproduce existing
+alpha-movement summaries and plots, but it is not planned as a NeuRepTrace
+migration target. Prefer moving any future paper-specific alpha analyses into a
+dedicated project analysis repository rather than extending PyMEGDec.
 
 Analyze a movement summary exported by `pymegdec alpha movement`:
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -59,16 +59,26 @@ echo /path/to/MEG-Data > .pymegdec-data-dir
 pymegdec transfer --participant 2 --null-window-center nan
 ```
 
-Download the CI/sample subset from the private OwnCloud WebDAV share:
+## Private-data bootstrap script
+
+Private-data transport is repository infrastructure, not part of the PyMEGDec
+Python package. Use the standalone helper script when a CI job or local checkout
+needs to materialize the private Bush/MEG files:
 
 ```bash
-pymegdec data download --source webdav-rclone --data-dir data --file-names Part2CueData.mat,Part2Data.mat
+python scripts/download_private_meg_data.py --source webdav-rclone --data-dir data --file-names Part2CueData.mat,Part2Data.mat
 ```
 
-The rclone-backed downloader reads `BUSHMEG_WEBDAV_URL`,
-`BUSHMEG_DATA_KEY`, and `BUSHMEG_DATA_PASSWORD` from the environment. Without
-`--file-indices` or `--file-names`, it downloads all files found recursively in
-the selected remote path.
+The script also supports the historical URL-list mode:
+
+```bash
+python scripts/download_private_meg_data.py --data-dir data --env-name MEG_DATA_URL_LIST
+```
+
+The rclone-backed mode reads `BUSHMEG_WEBDAV_URL`, `BUSHMEG_DATA_KEY`, and
+`BUSHMEG_DATA_PASSWORD` from the environment. Without `--file-indices` or
+`--file-names`, it downloads all files found recursively in the selected remote
+path.
 
 ## Participant ranges
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1375,6 +1375,36 @@ extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.1
 test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
+name = "neureptrace"
+version = "0.1.1"
+description = "Probabilistic tracing of neural representations over time."
+optional = false
+python-versions = ">=3.11,<3.14"
+groups = ["main"]
+files = []
+develop = false
+
+[package.dependencies]
+joblib = "*"
+matplotlib = "*"
+mne = "*"
+numpy = "*"
+pandas = "*"
+scikit-learn = "*"
+
+[package.extras]
+all = ["pytorch-lightning", "torch", "xgboost"]
+ml = ["pytorch-lightning", "torch", "xgboost"]
+torch = ["pytorch-lightning", "torch"]
+xgboost = ["xgboost"]
+
+[package.source]
+type = "git"
+url = "https://github.com/IPS-Stuttgart/NeuRepTrace.git"
+reference = "main"
+resolved_reference = "8c82ec9f5d5512453058e8641d8bd85d8ca13693"
+
+[[package]]
 name = "numpy"
 version = "2.2.6"
 description = "Fundamental package for array computing in Python"
@@ -2268,36 +2298,6 @@ files = [
 ]
 
 [[package]]
-name = "reptrace"
-version = "0.1.1"
-description = "Probabilistic tracing of neural representations over time."
-optional = false
-python-versions = ">=3.11,<3.14"
-groups = ["main"]
-files = []
-develop = false
-
-[package.dependencies]
-joblib = "*"
-matplotlib = "*"
-mne = "*"
-numpy = "*"
-pandas = "*"
-scikit-learn = "*"
-
-[package.extras]
-all = ["pytorch-lightning", "torch", "xgboost"]
-ml = ["pytorch-lightning", "torch", "xgboost"]
-torch = ["pytorch-lightning", "torch"]
-xgboost = ["xgboost"]
-
-[package.source]
-type = "git"
-url = "https://github.com/IPS-Stuttgart/NeuRepTrace.git"
-reference = "main"
-resolved_reference = "9e261040b4c829a6615ac6034ea49ff528169d88"
-
-[[package]]
 name = "requests"
 version = "2.33.1"
 description = "Python HTTP for Humans."
@@ -2873,4 +2873,4 @@ xgboost = ["xgboost"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "fc8085effb26f13266e98e46a507ee9340b6e06f5286e939c2d4ed37c3553cab"
+content-hash = "1cde866833afd46a17d478a0a05927257cbf05db2e6de21a1d151f1d75e2eaaa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pymegdec-stimulus-cross-subject-mcca = "pymegdec.stimulus_mcca:main"
 pymegdec-alpha-movement-results = "pymegdec.alpha_cli:alpha_movement_results"
 pymegdec-make-synthetic-data = "pymegdec.synthetic_data_cli:main"
 pymegdec-neureptrace = "pymegdec.neureptrace_compat:main"
+pymegdec-write-neureptrace-spec = "pymegdec.neureptrace_dataset_spec:write_neureptrace_dataset_spec"
 
 [tool.poetry]
 packages = [{ include = "pymegdec", from = "src" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pymegdec-stimulus-decoding = "pymegdec.cli:stimulus_decoding"
 pymegdec-stimulus-cross-subject-cue-calibrated = "pymegdec.stimulus_cli:stimulus_cross_subject_cue_calibrated"
 pymegdec-stimulus-cross-subject-hyperalignment = "pymegdec.stimulus_hyperalignment:main"
 pymegdec-stimulus-cross-subject-mcca = "pymegdec.stimulus_mcca:main"
-pymegdec-alpha-movement-results = "pymegdec.cli:alpha_movement_results"
+pymegdec-alpha-movement-results = "pymegdec.alpha_cli:alpha_movement_results"
 pymegdec-make-synthetic-data = "pymegdec.synthetic_data_cli:main"
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pymegdec-stimulus-cross-subject-hyperalignment = "pymegdec.stimulus_hyperalignme
 pymegdec-stimulus-cross-subject-mcca = "pymegdec.stimulus_mcca:main"
 pymegdec-alpha-movement-results = "pymegdec.alpha_cli:alpha_movement_results"
 pymegdec-make-synthetic-data = "pymegdec.synthetic_data_cli:main"
+pymegdec-neureptrace = "pymegdec.neureptrace_compat:main"
 
 [tool.poetry]
 packages = [{ include = "pymegdec", from = "src" }]

--- a/scripts/download_meg_data_files.py
+++ b/scripts/download_meg_data_files.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
-"""Backward-compatible wrapper for the grouped MEG data download command."""
+"""Repository-local wrapper for private MEG data downloads."""
 
 from __future__ import annotations
 
-import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[1]
-_SRC = _ROOT / "src"
-if _SRC.exists():
-    sys.path.insert(0, str(_SRC))
+_IMPL = _ROOT / "scripts" / "download_private_meg_data.py"
 
-_SPEC = spec_from_file_location("_pymegdec_data_download", _SRC / "pymegdec" / "data_download.py")
+_SPEC = spec_from_file_location("_pymegdec_private_data_download", _IMPL)
 if _SPEC is None or _SPEC.loader is None:
-    raise RuntimeError("Could not load pymegdec.data_download")
+    raise RuntimeError(f"Could not load {_IMPL}")
 _MODULE = module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MODULE)
 download_meg_data_files = _MODULE.download_meg_data_files

--- a/scripts/download_private_meg_data.py
+++ b/scripts/download_private_meg_data.py
@@ -1,4 +1,9 @@
-"""Download helpers for private MEG data files used in PyMEGDec CI/workflows."""
+"""Download private Bush/MEG data files for local scripts and CI bootstrap jobs.
+
+This script intentionally lives outside the importable ``pymegdec`` package so
+private-data transport remains repository infrastructure rather than part of the
+analysis library while PyMEGDec is being phased out.
+"""
 
 from __future__ import annotations
 
@@ -106,7 +111,7 @@ def _filename(response, index: int) -> str:  # noqa: ANN001
 
 
 def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog=prog, description="Download private MEG data files for local runs and CI workflows.")
+    parser = argparse.ArgumentParser(prog=prog, description="Download private Bush/MEG data files for local runs and CI workflows.")
     parser.add_argument("--data-dir", required=True)
     parser.add_argument(
         "--source",
@@ -173,7 +178,7 @@ def _download_from_url_list(args: argparse.Namespace, data_dir: Path) -> list[Pa
     _prepare_data_dir(data_dir)
     downloaded: list[Path] = []
     for index, url in enumerate(urls, start=1):
-        request = urllib.request.Request(_direct_url(url), headers={"User-Agent": "PyMEGDec"})
+        request = urllib.request.Request(_direct_url(url), headers={"User-Agent": "PyMEGDec-private-data-script"})
         with _open_https(request, timeout=180) as response:
             target = data_dir / _filename(response, index)
             counter = 2
@@ -291,5 +296,9 @@ def download_meg_data_files(argv: Sequence[str] | None = None, prog: str | None 
     return 0
 
 
+def main(argv: Sequence[str] | None = None) -> int:
+    return download_meg_data_files(argv)
+
+
 if __name__ == "__main__":
-    raise SystemExit(download_meg_data_files())
+    raise SystemExit(main())

--- a/src/pymegdec/alpha_cli.py
+++ b/src/pymegdec/alpha_cli.py
@@ -19,9 +19,11 @@ from pymegdec.alpha_movement import (
 )
 from pymegdec.cli import (
     add_alpha_metric_arguments,
+    alpha_movement_results as _alpha_movement_results,
     alpha_metric_config_from_args,
     parse_range,
 )
+from pymegdec.legacy import warn_legacy_alpha_workflow
 from pymegdec.reaction_time_analysis import (
     DEFAULT_ALPHA_RT_METRICS,
     AlphaReactionTimeExportConfig,
@@ -56,6 +58,7 @@ def _build_alpha_metrics_parser(prog: str | None = None) -> argparse.ArgumentPar
 def alpha_metrics(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     parser = _build_alpha_metrics_parser(prog=prog)
     args = parser.parse_args(argv)
+    warn_legacy_alpha_workflow(prog or "pymegdec alpha metrics")
 
     config = alpha_metric_config_from_args(args)
     rows = export_participant_alpha_metrics(
@@ -138,6 +141,7 @@ def _build_alpha_movement_parser(prog: str | None = None) -> argparse.ArgumentPa
 def alpha_movement(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     parser = _build_alpha_movement_parser(prog=prog)
     args = parser.parse_args(argv)
+    warn_legacy_alpha_workflow(prog or "pymegdec alpha movement")
 
     participants = _participants(args.participants, args.data_dir, args.cue)
     if not participants:
@@ -163,6 +167,13 @@ def alpha_movement(argv: Sequence[str] | None = None, prog: str | None = None) -
     if args.summary_output:
         print(f"Wrote {len(summary_rows)} summary rows to {args.summary_output}")
     return 0
+
+
+def alpha_movement_results(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    """Run the legacy alpha-movement result analysis with a phase-out warning."""
+
+    warn_legacy_alpha_workflow("pymegdec alpha movement-results")
+    return _alpha_movement_results(argv, prog)
 
 
 def _build_alpha_reaction_time_parser(prog: str | None = None) -> argparse.ArgumentParser:
@@ -234,6 +245,7 @@ def _build_alpha_reaction_time_parser(prog: str | None = None) -> argparse.Argum
 def alpha_reaction_time(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     parser = _build_alpha_reaction_time_parser(prog=prog)
     args = parser.parse_args(argv)
+    warn_legacy_alpha_workflow(prog or "pymegdec alpha reaction-time")
 
     participants = _participants(args.participants, args.data_dir, args.cue)
     if not participants and (not args.alpha_metrics or not args.reaction_times):

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import reptrace.decoding.classifiers as reptrace_classifiers
 from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
 from sklearn.linear_model import LogisticRegression
 from sklearn.naive_bayes import GaussianNB
@@ -36,12 +37,6 @@ from reptrace.decoding.classifiers import (
 )
 from reptrace.decoding.classifiers import (
     get_default_classifier_param as get_reptrace_default_classifier_param,
-)
-from reptrace.decoding.classifiers import (
-    train_classifier as train_reptrace_classifier,
-)
-from reptrace.decoding.classifiers import (
-    train_multiclass_classifier as train_reptrace_multiclass_classifier,
 )
 
 _DecodedLabelClassifier = DecodedLabelClassifier
@@ -185,7 +180,7 @@ def train_classifier(
 ):
     """Build and fit a classifier from the PyMEGDec-extended registry."""
 
-    return train_reptrace_classifier(
+    return reptrace_classifiers.train_classifier(
         features,
         labels,
         classifier,
@@ -206,14 +201,16 @@ def train_multiclass_classifier(
 ):
     """Train a multiclass classifier from the PyMEGDec-extended registry."""
 
-    return train_reptrace_multiclass_classifier(
+    classes, encoded_labels = encode_classifier_labels(labels)
+    model = train_classifier(
         features,
-        labels,
+        encoded_labels,
         classifier,
         classifier_param,
         random_state=random_state,
         registry=CLASSIFIER_REGISTRY if registry is None else registry,
     )
+    return DecodedLabelClassifier(model, classes)
 
 
 def __getattr__(name: str) -> Any:

--- a/src/pymegdec/cli.py
+++ b/src/pymegdec/cli.py
@@ -23,6 +23,7 @@ from .alpha_movement_analysis import (
     export_alpha_movement_analysis,
 )
 from .cross_validation import cross_validate_single_dataset
+from .legacy import warn_legacy_alpha_workflow
 from .model_transfer import evaluate_model_transfer
 from .reaction_time_analysis import available_participants, parse_participant_spec
 from .stimulus_decoding import (
@@ -487,6 +488,7 @@ def _build_alpha_movement_results_parser(
 def alpha_movement_results(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
     parser = _build_alpha_movement_results_parser(prog=prog)
     args = parser.parse_args(argv)
+    warn_legacy_alpha_workflow(prog or "pymegdec alpha movement-results")
     config = AlphaMovementAnalysisConfig(
         pre_window=args.pre_window,
         post_window=args.post_window,

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Sequence
 from pymegdec import alpha_cli, neureptrace_compat
 from pymegdec import cli as legacy_cli
 from pymegdec import stimulus_cli, stimulus_hyperalignment, stimulus_mcca
+from pymegdec.neureptrace_dataset_spec import write_neureptrace_dataset_spec
 from pymegdec.synthetic_data_cli import make_synthetic_data
 
 CommandHandler = Callable[[Sequence[str] | None, str | None], int]
@@ -57,11 +58,16 @@ def _config_handlers() -> dict[str, CommandHandler]:
     return neureptrace_compat.handlers()
 
 
+def _data_handlers() -> dict[str, CommandHandler]:
+    return {"write-neureptrace-spec": write_neureptrace_dataset_spec}
+
+
 def _top_level_handlers() -> dict[str, CommandHandler]:
     return {
         "cross-validate": legacy_cli.cross_validate,
         "transfer": legacy_cli.transfer,
         "make-synthetic-data": make_synthetic_data,
+        "write-neureptrace-spec": write_neureptrace_dataset_spec,
         # Backward-compatible top-level aliases. Prefer grouped forms in new docs.
         "stimulus-decoding": legacy_cli.stimulus_decoding,
         "stimulus-cross-subject-cue-calibrated": stimulus_cli.stimulus_cross_subject_cue_calibrated,
@@ -95,6 +101,7 @@ def _print_main_help() -> None:
         "decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
         "  pymegdec alpha <metrics|movement|movement-results|reaction-time|rt>  # legacy paper-specific analyses\n"
         "  pymegdec config <validate-manifest|mne-time-decode|plot-time-decode>\n"
+        "  pymegdec data <write-neureptrace-spec>\n"
         "\nCore commands:\n"
         "  pymegdec cross-validate ...\n"
         "  pymegdec transfer ...\n"
@@ -119,6 +126,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _dispatch_group("alpha", "Alpha metric, movement, and reaction-time analyses.", _alpha_handlers(), remaining)
     if command == "config":
         return _dispatch_group("config", "NeuRepTrace-owned configuration workflows.", _config_handlers(), remaining)
+    if command == "data":
+        return _dispatch_group("data", "Data configuration and migration helpers.", _data_handlers(), remaining)
     handlers = _top_level_handlers()
     if command in handlers:
         return handlers[command](remaining, f"pymegdec {command}")

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from collections.abc import Callable, Sequence
 
-from pymegdec import alpha_cli
+from pymegdec import alpha_cli, neureptrace_compat
 from pymegdec import cli as legacy_cli
 from pymegdec import stimulus_cli, stimulus_hyperalignment, stimulus_mcca
 from pymegdec.synthetic_data_cli import make_synthetic_data
@@ -53,6 +53,10 @@ def _alpha_handlers() -> dict[str, CommandHandler]:
     }
 
 
+def _config_handlers() -> dict[str, CommandHandler]:
+    return neureptrace_compat.handlers()
+
+
 def _top_level_handlers() -> dict[str, CommandHandler]:
     return {
         "cross-validate": legacy_cli.cross_validate,
@@ -74,6 +78,10 @@ def _top_level_handlers() -> dict[str, CommandHandler]:
         "alpha-movement-results": alpha_cli.alpha_movement_results,
         "alpha-reaction-time": alpha_cli.alpha_reaction_time,
         "alpha-rt": alpha_cli.alpha_reaction_time,
+        # Transitional aliases for NeuRepTrace-owned, config-oriented workflows.
+        "validate-manifest": neureptrace_compat.validate_manifest,
+        "mne-time-decode": neureptrace_compat.mne_time_decode,
+        "plot-time-decode": neureptrace_compat.plot_time_decode,
     }
 
 
@@ -86,11 +94,12 @@ def _print_main_help() -> None:
         "  pymegdec stimulus <cross-subject-cue-calibrated|cross-subject-hyperalignment|cross-subject-mcca|cross-subject-nested|cross-subject-smoke|"
         "decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
         "  pymegdec alpha <metrics|movement|movement-results|reaction-time|rt>  # legacy paper-specific analyses\n"
+        "  pymegdec config <validate-manifest|mne-time-decode|plot-time-decode>\n"
         "\nCore commands:\n"
         "  pymegdec cross-validate ...\n"
         "  pymegdec transfer ...\n"
         "  pymegdec make-synthetic-data ...\n"
-        "\nCompatibility aliases such as pymegdec stimulus-decoding and pymegdec alpha-metrics remain available.\n"
+        "\nCompatibility aliases such as pymegdec stimulus-decoding, pymegdec alpha-metrics, and pymegdec validate-manifest remain available.\n"
         "Alpha commands are retained as legacy Bush-MEG analysis scripts and are not NeuRepTrace migration targets."
     )
 
@@ -108,6 +117,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _dispatch_group("stimulus", "Stimulus decoding and diagnostics.", _stimulus_handlers(), remaining)
     if command == "alpha":
         return _dispatch_group("alpha", "Alpha metric, movement, and reaction-time analyses.", _alpha_handlers(), remaining)
+    if command == "config":
+        return _dispatch_group("config", "NeuRepTrace-owned configuration workflows.", _config_handlers(), remaining)
     handlers = _top_level_handlers()
     if command in handlers:
         return handlers[command](remaining, f"pymegdec {command}")

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -9,7 +9,6 @@ from collections.abc import Callable, Sequence
 from pymegdec import alpha_cli
 from pymegdec import cli as legacy_cli
 from pymegdec import stimulus_cli, stimulus_hyperalignment, stimulus_mcca
-from pymegdec.data_download import download_meg_data_files
 from pymegdec.synthetic_data_cli import make_synthetic_data
 
 CommandHandler = Callable[[Sequence[str] | None, str | None], int]
@@ -48,14 +47,10 @@ def _alpha_handlers() -> dict[str, CommandHandler]:
     return {
         "metrics": alpha_cli.alpha_metrics,
         "movement": alpha_cli.alpha_movement,
-        "movement-results": legacy_cli.alpha_movement_results,
+        "movement-results": alpha_cli.alpha_movement_results,
         "reaction-time": alpha_cli.alpha_reaction_time,
         "rt": alpha_cli.alpha_reaction_time,
     }
-
-
-def _data_handlers() -> dict[str, CommandHandler]:
-    return {"download": download_meg_data_files}
 
 
 def _top_level_handlers() -> dict[str, CommandHandler]:
@@ -76,10 +71,9 @@ def _top_level_handlers() -> dict[str, CommandHandler]:
         "stimulus-onset-scan": stimulus_cli.stimulus_onset_scan,
         "alpha-metrics": alpha_cli.alpha_metrics,
         "alpha-movement": alpha_cli.alpha_movement,
-        "alpha-movement-results": legacy_cli.alpha_movement_results,
+        "alpha-movement-results": alpha_cli.alpha_movement_results,
         "alpha-reaction-time": alpha_cli.alpha_reaction_time,
         "alpha-rt": alpha_cli.alpha_reaction_time,
-        "download-meg-data": download_meg_data_files,
     }
 
 
@@ -91,13 +85,13 @@ def _print_main_help() -> None:
         "\nCommand groups:\n"
         "  pymegdec stimulus <cross-subject-cue-calibrated|cross-subject-hyperalignment|cross-subject-mcca|cross-subject-nested|cross-subject-smoke|"
         "decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
-        "  pymegdec alpha <metrics|movement|movement-results|reaction-time|rt>\n"
-        "  pymegdec data <download>\n"
+        "  pymegdec alpha <metrics|movement|movement-results|reaction-time|rt>  # legacy paper-specific analyses\n"
         "\nCore commands:\n"
         "  pymegdec cross-validate ...\n"
         "  pymegdec transfer ...\n"
         "  pymegdec make-synthetic-data ...\n"
-        "\nCompatibility aliases such as pymegdec stimulus-decoding and pymegdec alpha-metrics remain available."
+        "\nCompatibility aliases such as pymegdec stimulus-decoding and pymegdec alpha-metrics remain available.\n"
+        "Alpha commands are retained as legacy Bush-MEG analysis scripts and are not NeuRepTrace migration targets."
     )
 
 
@@ -114,9 +108,6 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _dispatch_group("stimulus", "Stimulus decoding and diagnostics.", _stimulus_handlers(), remaining)
     if command == "alpha":
         return _dispatch_group("alpha", "Alpha metric, movement, and reaction-time analyses.", _alpha_handlers(), remaining)
-    if command == "data":
-        return _dispatch_group("data", "Data download and data-management helpers.", _data_handlers(), remaining)
-
     handlers = _top_level_handlers()
     if command in handlers:
         return handlers[command](remaining, f"pymegdec {command}")

--- a/src/pymegdec/legacy.py
+++ b/src/pymegdec/legacy.py
@@ -1,0 +1,36 @@
+"""Warnings and helpers for PyMEGDec workflows kept as legacy scripts."""
+
+from __future__ import annotations
+
+import warnings
+
+
+class PyMEGDecLegacyWorkflowWarning(FutureWarning):
+    """Warning for workflows that are intentionally not part of the NeuRepTrace migration."""
+
+
+_ALPHA_PHASEOUT_MESSAGE = (
+    "{command} is a legacy PyMEGDec alpha-analysis workflow. It is kept for "
+    "reproducing the Bush-MEG paper-specific alpha/movement/reaction-time "
+    "analyses, but it is not planned as a NeuRepTrace migration target. "
+    "For the PyMEGDec phase-out, migrate generic decoding and FieldTrip/MAT "
+    "loading to NeuRepTrace, and keep or archive alpha analyses in a "
+    "project-specific analysis repository."
+)
+
+
+def warn_legacy_alpha_workflow(command: str) -> None:
+    """Warn that an alpha workflow is legacy and project-specific.
+
+    The warning category subclasses ``FutureWarning`` rather than
+    ``DeprecationWarning`` so command-line users see the phase-out message by
+    default.  The commands continue to run unchanged; this marks the ownership
+    decision needed to phase out PyMEGDec without silently moving paper-specific
+    alpha analyses into NeuRepTrace.
+    """
+
+    warnings.warn(
+        _ALPHA_PHASEOUT_MESSAGE.format(command=command),
+        PyMEGDecLegacyWorkflowWarning,
+        stacklevel=2,
+    )

--- a/src/pymegdec/neureptrace_compat.py
+++ b/src/pymegdec/neureptrace_compat.py
@@ -1,0 +1,92 @@
+"""Compatibility bridge to NeuRepTrace-owned configuration workflows.
+
+PyMEGDec is being reduced to dataset recipes and temporary aliases.  New
+configuration-driven workflows should live in NeuRepTrace; this module keeps the
+old PyMEGDec command surface usable while making the ownership boundary explicit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+import warnings
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+
+CommandHandler = Callable[[Sequence[str] | None, str | None], int]
+
+_COMMANDS: dict[str, tuple[str, str, str]] = {
+    "validate-manifest": (
+        "neureptrace.validate_manifest",
+        "main",
+        "Validate a NeuRepTrace benchmark manifest.",
+    ),
+    "mne-time-decode": (
+        "neureptrace.mne_time_decode",
+        "main",
+        "Run NeuRepTrace MNE time-resolved decoding.",
+    ),
+    "plot-time-decode": (
+        "neureptrace.plot_time_decode",
+        "main",
+        "Plot NeuRepTrace time-decoding outputs.",
+    ),
+}
+
+
+@contextmanager
+def _patched_argv(prog: str, argv: Sequence[str] | None) -> Iterator[None]:
+    previous = sys.argv[:]
+    sys.argv = [prog, *(list(argv) if argv is not None else [])]
+    try:
+        yield
+    finally:
+        sys.argv = previous
+
+
+def _run_neureptrace(command: str, argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    module_name, function_name, _description = _COMMANDS[command]
+    warnings.warn(
+        (
+            f"pymegdec {command} is a temporary compatibility alias. "
+            f"Use the corresponding NeuRepTrace command/module instead: {module_name}.{function_name}."
+        ),
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    module = importlib.import_module(module_name)
+    entry_point = getattr(module, function_name)
+    with _patched_argv(prog or f"pymegdec {command}", argv):
+        result = entry_point()
+    return int(result or 0)
+
+
+def validate_manifest(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    return _run_neureptrace("validate-manifest", argv, prog)
+
+
+def mne_time_decode(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    return _run_neureptrace("mne-time-decode", argv, prog)
+
+
+def plot_time_decode(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    return _run_neureptrace("plot-time-decode", argv, prog)
+
+
+def handlers() -> dict[str, CommandHandler]:
+    return {
+        "validate-manifest": validate_manifest,
+        "mne-time-decode": mne_time_decode,
+        "plot-time-decode": plot_time_decode,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compatibility bridge to NeuRepTrace workflows.")
+    parser.add_argument("command", nargs="?", choices=sorted(_COMMANDS), help="NeuRepTrace command to run.")
+    parsed, remaining = parser.parse_known_args(argv)
+    if parsed.command is None:
+        parser.print_help()
+        return 0
+    return handlers()[parsed.command](remaining, f"pymegdec-neureptrace {parsed.command}")

--- a/src/pymegdec/neureptrace_dataset_spec.py
+++ b/src/pymegdec/neureptrace_dataset_spec.py
@@ -1,0 +1,138 @@
+"""Helpers for writing NeuRepTrace dataset specs from PyMEGDec conventions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+DEFAULT_PARTICIPANTS = "1-4,6,8,9,10,13-27"
+DEFAULT_ENV_VAR = "PYMEGDEC_DATA_DIR"
+
+TEMPLATE = """schema_version: neureptrace.dataset.v1
+dataset_id: bushmeg
+description: PyMEGDec-style MEG participant files described declaratively.
+
+root:
+{root_path_block}  env: {env_var}
+  fallback_file: .pymegdec-data-dir
+
+subjects:
+  include: "{participants}"
+
+splits:
+  main:
+    loader: matlab_fieldtrip
+    path_template: "Part{{subject}}Data.mat"
+    mat_key: data
+    trial_key: trial
+    time_key: time
+    channel_key: label
+    label_key: trialinfo
+    label_index_base: 1
+    trial_layout: channels_by_time
+
+  cue:
+    loader: matlab_fieldtrip
+    path_template: "Part{{subject}}CueData.mat"
+    mat_key: data
+    trial_key: trial
+    time_key: time
+    channel_key: label
+    label_key: trialinfo
+    label_index_base: 1
+    trial_layout: channels_by_time
+
+labels:
+  chance_classes: 16
+  index_base: 1
+  subtract_one_when_no_null_class: true
+
+preprocessing_defaults:
+  frequency_range_hz: [0.0, .inf]
+  window_size_s: 0.1
+  train_window_center_s: 0.2
+  null_window_center_s: null
+  resample_hz: null
+  pca_components: 100
+
+workflows:
+  stimulus_transfer:
+    split: main
+    manifest:
+      paired_split: cue
+      transfer_direction: main-to-cue
+      classifier: multiclass-svm
+      chance: 0.0625
+      window_start_s: -0.2
+      window_stop_s: 0.6
+      window_step_s: 0.05
+
+  stimulus_transfer_reverse:
+    split: cue
+    manifest:
+      paired_split: main
+      transfer_direction: cue-to-main
+      classifier: multiclass-svm
+      chance: 0.0625
+      window_start_s: -0.2
+      window_stop_s: 0.6
+      window_step_s: 0.05
+
+outputs:
+  default_dir: outputs
+"""
+
+
+def build_neureptrace_dataset_spec_text(
+    *,
+    participants: str = DEFAULT_PARTICIPANTS,
+    env_var: str = DEFAULT_ENV_VAR,
+    data_dir: str | Path | None = None,
+) -> str:
+    """Return a YAML NeuRepTrace dataset spec for PyMEGDec-style files."""
+
+    root_path_block = ""
+    if data_dir is not None:
+        root_path_block = f"  path: {json.dumps(str(data_dir))}\n"
+    return TEMPLATE.format(
+        participants=participants,
+        env_var=env_var,
+        root_path_block=root_path_block,
+    )
+
+
+def write_neureptrace_dataset_spec(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    """Write a NeuRepTrace YAML dataset spec for the historical PyMEGDec file convention."""
+
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description="Write a NeuRepTrace YAML dataset spec for the historical PyMEGDec Part*Data.mat convention.",
+    )
+    parser.add_argument("--out", type=Path, default=Path("configs/bushmeg.yml"), help="Output YAML path.")
+    parser.add_argument("--participants", default=DEFAULT_PARTICIPANTS, help="Participant ids, for example 1-4,6,8.")
+    parser.add_argument("--env-var", default=DEFAULT_ENV_VAR, help="Environment variable used by root.env.")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        help="Optional explicit data root to write into root.path. If omitted, the spec uses env/fallback root resolution.",
+    )
+    args = parser.parse_args(argv)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        build_neureptrace_dataset_spec_text(
+            participants=args.participants,
+            env_var=args.env_var,
+            data_dir=args.data_dir,
+        ),
+        encoding="utf-8",
+    )
+    print(f"Wrote {args.out}")
+    print("Validate with: neureptrace dataset validate", args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(write_neureptrace_dataset_spec())

--- a/tests/test_data_download.py
+++ b/tests/test_data_download.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from pymegdec.data_download import download_meg_data_files
+from scripts.download_private_meg_data import download_meg_data_files
 
 _TEST_ENV = {
     "BUSHMEG_WEBDAV_URL": "https://example.test/public.php/webdav/",
@@ -48,7 +48,7 @@ def _download_with_fake_rclone(fake_run, tmp_dir, selector_name, selector_value)
         "--manifest",
         str(manifest),
     ]
-    with patch.dict(os.environ, _TEST_ENV, clear=False), patch("pymegdec.data_download.subprocess.run", side_effect=fake_run):
+    with patch.dict(os.environ, _TEST_ENV, clear=False), patch("scripts.download_private_meg_data.subprocess.run", side_effect=fake_run):
         return download_meg_data_files(download_args), manifest
 
 

--- a/tests/test_legacy_workflows.py
+++ b/tests/test_legacy_workflows.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import pytest
+import warnings
 
 from pymegdec.legacy import PyMEGDecLegacyWorkflowWarning, warn_legacy_alpha_workflow
 
 
 def test_warn_legacy_alpha_workflow_is_visible_to_cli_users() -> None:
-    with pytest.warns(PyMEGDecLegacyWorkflowWarning) as record:
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
         warn_legacy_alpha_workflow("pymegdec alpha metrics")
 
     assert len(record) == 1

--- a/tests/test_legacy_workflows.py
+++ b/tests/test_legacy_workflows.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from pymegdec.legacy import PyMEGDecLegacyWorkflowWarning, warn_legacy_alpha_workflow
+
+
+def test_warn_legacy_alpha_workflow_is_visible_to_cli_users() -> None:
+    with pytest.warns(PyMEGDecLegacyWorkflowWarning) as record:
+        warn_legacy_alpha_workflow("pymegdec alpha metrics")
+
+    assert len(record) == 1
+    message = str(record[0].message)
+    assert "pymegdec alpha metrics" in message
+    assert "legacy PyMEGDec alpha-analysis workflow" in message
+    assert "not planned as a NeuRepTrace migration target" in message
+    assert issubclass(PyMEGDecLegacyWorkflowWarning, FutureWarning)

--- a/tests/test_neureptrace_compat.py
+++ b/tests/test_neureptrace_compat.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import sys
+import warnings
 from types import SimpleNamespace
-
-import pytest
+from unittest.mock import patch
 
 from pymegdec import neureptrace_compat
 
 
-def test_validate_manifest_delegates_with_patched_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validate_manifest_delegates_with_patched_argv() -> None:
     calls: list[list[str]] = []
 
     def fake_main() -> None:
@@ -18,19 +18,21 @@ def test_validate_manifest_delegates_with_patched_argv(monkeypatch: pytest.Monke
         assert name == "neureptrace.validate_manifest"
         return SimpleNamespace(main=fake_main)
 
-    monkeypatch.setattr(neureptrace_compat.importlib, "import_module", fake_import_module)
-
-    with pytest.warns(DeprecationWarning, match="temporary compatibility alias"):
-        status = neureptrace_compat.validate_manifest(
-            ["manifest.csv", "--label-column", "condition"],
-            "pymegdec config validate-manifest",
-        )
+    with (
+        patch.object(neureptrace_compat.importlib, "import_module", fake_import_module),
+        warnings.catch_warnings(record=True) as record,
+    ):
+        warnings.simplefilter("always")
+        status = neureptrace_compat.validate_manifest(["manifest.csv", "--label-column", "condition"], "pymegdec config validate-manifest")
 
     assert status == 0
     assert calls == [["pymegdec config validate-manifest", "manifest.csv", "--label-column", "condition"]]
+    assert len(record) == 1
+    assert issubclass(record[0].category, DeprecationWarning)
+    assert "temporary compatibility alias" in str(record[0].message)
 
 
-def test_main_dispatches_selected_command(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_dispatches_selected_command() -> None:
     seen: dict[str, object] = {}
 
     def fake_validate(argv, prog):
@@ -38,7 +40,6 @@ def test_main_dispatches_selected_command(monkeypatch: pytest.MonkeyPatch) -> No
         seen["prog"] = prog
         return 7
 
-    monkeypatch.setattr(neureptrace_compat, "validate_manifest", fake_validate)
-
-    assert neureptrace_compat.main(["validate-manifest", "manifest.csv"]) == 7
+    with patch.object(neureptrace_compat, "validate_manifest", fake_validate):
+        assert neureptrace_compat.main(["validate-manifest", "manifest.csv"]) == 7
     assert seen == {"argv": ["manifest.csv"], "prog": "pymegdec-neureptrace validate-manifest"}

--- a/tests/test_neureptrace_compat.py
+++ b/tests/test_neureptrace_compat.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from pymegdec import neureptrace_compat
+
+
+def test_validate_manifest_delegates_with_patched_argv(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_main() -> None:
+        calls.append(sys.argv[:])
+
+    def fake_import_module(name: str) -> SimpleNamespace:
+        assert name == "neureptrace.validate_manifest"
+        return SimpleNamespace(main=fake_main)
+
+    monkeypatch.setattr(neureptrace_compat.importlib, "import_module", fake_import_module)
+
+    with pytest.warns(DeprecationWarning, match="temporary compatibility alias"):
+        status = neureptrace_compat.validate_manifest(
+            ["manifest.csv", "--label-column", "condition"],
+            "pymegdec config validate-manifest",
+        )
+
+    assert status == 0
+    assert calls == [["pymegdec config validate-manifest", "manifest.csv", "--label-column", "condition"]]
+
+
+def test_main_dispatches_selected_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_validate(argv, prog):
+        seen["argv"] = list(argv)
+        seen["prog"] = prog
+        return 7
+
+    monkeypatch.setattr(neureptrace_compat, "validate_manifest", fake_validate)
+
+    assert neureptrace_compat.main(["validate-manifest", "manifest.csv"]) == 7
+    assert seen == {"argv": ["manifest.csv"], "prog": "pymegdec-neureptrace validate-manifest"}

--- a/tests/test_neureptrace_dataset_spec.py
+++ b/tests/test_neureptrace_dataset_spec.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pymegdec.neureptrace_dataset_spec import build_neureptrace_dataset_spec_text, write_neureptrace_dataset_spec
+
+
+def test_build_neureptrace_dataset_spec_text_contains_pymegdec_paths() -> None:
+    text = build_neureptrace_dataset_spec_text(participants="2", env_var="CUSTOM_DATA", data_dir="/tmp/meg")
+
+    assert "path: \"/tmp/meg\"" in text
+    assert "env: CUSTOM_DATA" in text
+    assert "include: \"2\"" in text
+    assert "Part{subject}Data.mat" in text
+    assert "Part{subject}CueData.mat" in text
+    assert "loader: matlab_fieldtrip" in text
+
+
+def test_write_neureptrace_dataset_spec(tmp_path: Path) -> None:
+    out = tmp_path / "configs" / "bushmeg.yml"
+
+    assert write_neureptrace_dataset_spec(["--out", str(out), "--participants", "1-2"]) == 0
+
+    text = out.read_text(encoding="utf-8")
+    assert "dataset_id: bushmeg" in text
+    assert "include: \"1-2\"" in text
+    assert "paired_split: cue" in text

--- a/tests/test_stimulus_decoding.py
+++ b/tests/test_stimulus_decoding.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
@@ -444,8 +445,17 @@ class TestStimulusDecoding(unittest.TestCase):
                 ],
             ),
             patch(
-                "reptrace.decoding.windowed.permutation_accuracy_curve",
-                return_value=np.array([0.0, 0.25, 0.5]),
+                "pymegdec._stimulus_decoding_core.evaluate_feature_transfer",
+                return_value=SimpleNamespace(
+                    model_bundle=SimpleNamespace(
+                        actual_components_pca=2,
+                        explained_variance_percent=100.0,
+                    ),
+                    predictions=np.array([1, 2, 1, 2]),
+                    accuracy=0.75,
+                    permutation_accuracy=np.array([0.0, 0.25, 0.5]),
+                    permutation_p_value=0.25,
+                ),
             ),
         ):
             rows = evaluate_participant_time_resolved_stimulus_transfer("unused", 1, config=config)


### PR DESCRIPTION
﻿## Summary

Applies the queued patch batch for IPS-Stuttgart/PyMEGDec from branch codex/apply-pymegdec-patches-20260520.

## Commits

- 569e37d Retire legacy PyMEGDec helpers - 64c656b Add NeuRepTrace compatibility bridge - 82a50ba Add NeuRepTrace dataset spec writer

## Validation

- Full test suites were not run, per request.
- Patch application used clean apply where possible and manual conflict resolution where needed.
- Local worktree was clean before opening this PR.
