### PR TITLE
Delegate alpha metrics to NeuRepTrace

### DIFF
--- a/src/pymegdec/alpha_metrics.py
+++ b/src/pymegdec/alpha_metrics.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import numpy as np
 import scipy.io as sio
-import scipy.signal
+from neureptrace.features.oscillatory import compute_band_analytic_window, summarize_analytic_window
 from pymegdec.alpha_signal import get_data_field, get_time_vector, get_trial_signal
 from pymegdec.data_config import resolve_data_folder
 from scipy.spatial import Delaunay  # pylint: disable=no-name-in-module
@@ -503,24 +503,19 @@ def _resolve_channel_indices(data, channel_indices, config):
 
 
 def compute_alpha_analytic_window(signal, time_vector, config):
-    """Return alpha-band analytic signal samples in ``config.time_window``."""
+    """Return alpha-band analytic signal samples in ``config.time_window``.
 
-    signal, time_vector, sample_interval = _validate_alpha_signal_time_axis(signal, time_vector)
-    sampling_rate = float(1 / sample_interval)
-    time_indices = np.flatnonzero(_time_mask(time_vector, config.time_window))
-    low_freq, high_freq = config.frequency_range
+    The generic band-pass/Hilbert implementation lives in NeuRepTrace; this
+    wrapper preserves PyMEGDec's ``AlphaMetricConfig`` interface.
+    """
 
-    sos = scipy.signal.butter(
-        config.filter_order,
-        [low_freq, high_freq],
-        btype="bandpass",
-        fs=sampling_rate,
-        output="sos",
+    return compute_band_analytic_window(
+        signal,
+        time_vector,
+        band_hz=config.frequency_range,
+        time_window=config.time_window,
+        filter_order=config.filter_order,
     )
-    alpha_signal = scipy.signal.sosfiltfilt(sos, signal, axis=-1)
-    analytic_signal = scipy.signal.hilbert(alpha_signal, axis=-1)
-    alpha_window = np.take(analytic_signal, time_indices, axis=-1)
-    return alpha_window, time_indices
 
 
 def _alpha_window_and_phase(signal, time_vector, config):
@@ -557,6 +552,10 @@ def compute_alpha_trial_metrics(
     alpha_window, phase = _alpha_window_and_phase(signal, time_vector, config)
     edge_indices, edge_vectors, edge_pinv = _phase_geometry(data, channel_indices, config)
 
+    alpha_features = summarize_analytic_window(
+        alpha_window,
+        outputs=("mean_power", "log_power", "phase_concentration"),
+    )
     row = {
         "participant": participant_id if participant_id is not None else "",
         "dataset": dataset,
@@ -567,9 +566,9 @@ def compute_alpha_trial_metrics(
         "low_freq": config.frequency_range[0],
         "high_freq": config.frequency_range[1],
         "n_channels": int(len(channel_indices)),
-        "alpha_power": float(np.mean(np.abs(alpha_window) ** 2)),
-        "log_alpha_power": float(np.mean(np.log(np.abs(alpha_window) ** 2 + 1e-12))),
-        "phase_concentration": float(np.abs(np.mean(np.exp(1j * phase)))),
+        "alpha_power": alpha_features["mean_power"],
+        "log_alpha_power": alpha_features["log_power"],
+        "phase_concentration": alpha_features["phase_concentration"],
     }
     row.update(
         _phase_gradient_metrics(

--- a/src/pymegdec/alpha_metrics.py
+++ b/src/pymegdec/alpha_metrics.py
@@ -9,10 +9,15 @@ from pathlib import Path
 
 import numpy as np
 import scipy.io as sio
-from neureptrace.features.oscillatory import compute_band_analytic_window, summarize_analytic_window
+import scipy.signal
 from pymegdec.alpha_signal import get_data_field, get_time_vector, get_trial_signal
 from pymegdec.data_config import resolve_data_folder
 from scipy.spatial import Delaunay  # pylint: disable=no-name-in-module
+
+try:  # pragma: no cover - exercised only when NeuRepTrace exposes this module.
+    from neureptrace.features import oscillatory as _neureptrace_oscillatory
+except ImportError:  # pragma: no cover - normal path for older NeuRepTrace versions.
+    _neureptrace_oscillatory = None
 
 DEFAULT_OCCIPITAL_PATTERN = r"^M[LRZ]O"
 DEFAULT_PROJECTION_REFERENCE_PATTERN = r"^M"
@@ -502,20 +507,68 @@ def _resolve_channel_indices(data, channel_indices, config):
     return channel_indices
 
 
+def _neureptrace_oscillatory_function(name):
+    if _neureptrace_oscillatory is None:
+        return None
+    return getattr(_neureptrace_oscillatory, name, None)
+
+
 def compute_alpha_analytic_window(signal, time_vector, config):
     """Return alpha-band analytic signal samples in ``config.time_window``.
 
-    The generic band-pass/Hilbert implementation lives in NeuRepTrace; this
-    wrapper preserves PyMEGDec's ``AlphaMetricConfig`` interface.
+    The generic band-pass/Hilbert implementation is delegated to NeuRepTrace
+    when available. The local fallback preserves PyMEGDec's historical behavior
+    for CI and user environments with older NeuRepTrace versions.
     """
 
-    return compute_band_analytic_window(
-        signal,
-        time_vector,
-        band_hz=config.frequency_range,
-        time_window=config.time_window,
-        filter_order=config.filter_order,
+    compute_band_analytic_window = _neureptrace_oscillatory_function("compute_band_analytic_window")
+    if compute_band_analytic_window is not None:
+        return compute_band_analytic_window(
+            signal,
+            time_vector,
+            band_hz=config.frequency_range,
+            time_window=config.time_window,
+            filter_order=config.filter_order,
+        )
+
+    signal, time_vector, sample_interval = _validate_alpha_signal_time_axis(signal, time_vector)
+    sampling_rate = float(1 / sample_interval)
+    time_indices = np.flatnonzero(_time_mask(time_vector, config.time_window))
+    low_freq, high_freq = config.frequency_range
+
+    sos = scipy.signal.butter(
+        config.filter_order,
+        [low_freq, high_freq],
+        btype="bandpass",
+        fs=sampling_rate,
+        output="sos",
     )
+    alpha_signal = scipy.signal.sosfiltfilt(sos, signal, axis=-1)
+    analytic_signal = scipy.signal.hilbert(alpha_signal, axis=-1)
+    alpha_window = np.take(analytic_signal, time_indices, axis=-1)
+    return alpha_window, time_indices
+
+
+def _summarize_alpha_analytic_window(alpha_window):
+    summarize_analytic_window = _neureptrace_oscillatory_function("summarize_analytic_window")
+    if summarize_analytic_window is not None:
+        features = summarize_analytic_window(
+            alpha_window,
+            outputs=("mean_power", "log_power", "phase_concentration"),
+        )
+        return {
+            "mean_power": float(features["mean_power"]),
+            "log_power": float(features["log_power"]),
+            "phase_concentration": float(features["phase_concentration"]),
+        }
+
+    power = np.abs(alpha_window) ** 2
+    phase = np.angle(alpha_window)
+    return {
+        "mean_power": float(np.mean(power)),
+        "log_power": float(np.mean(np.log(power + 1e-12))),
+        "phase_concentration": float(np.abs(np.mean(np.exp(1j * phase)))),
+    }
 
 
 def _alpha_window_and_phase(signal, time_vector, config):
@@ -552,10 +605,7 @@ def compute_alpha_trial_metrics(
     alpha_window, phase = _alpha_window_and_phase(signal, time_vector, config)
     edge_indices, edge_vectors, edge_pinv = _phase_geometry(data, channel_indices, config)
 
-    alpha_features = summarize_analytic_window(
-        alpha_window,
-        outputs=("mean_power", "log_power", "phase_concentration"),
-    )
+    alpha_features = _summarize_alpha_analytic_window(alpha_window)
     row = {
         "participant": participant_id if participant_id is not None else "",
         "dataset": dataset,

--- a/src/pymegdec/alpha_signal.py
+++ b/src/pymegdec/alpha_signal.py
@@ -1,19 +1,20 @@
 """Compatibility helpers for alpha-band signal extraction.
 
 Generic filtering, Hilbert-phase extraction, sampling-rate validation, and
-phase averaging are delegated to NeuRepTrace.  This module keeps only the
-FieldTrip/MATLAB cell-array accessors and PyMEGDec's historical
-``extract_time_basis`` convenience wrapper.
+phase averaging are delegated to NeuRepTrace when its optional signal helpers
+are available. Local fallbacks keep PyMEGDec's historical public API working in
+environments with older NeuRepTrace installations.
 """
 
 from __future__ import annotations
 
 import numpy as np
-from neureptrace.signal.band import (
-    average_phases,
-    extract_phase,
-    sampling_rate_from_time_vector,
-)
+import scipy.signal
+
+try:  # pragma: no cover - exercised only when NeuRepTrace exposes this module.
+    from neureptrace.signal import band as _neureptrace_band
+except ImportError:  # pragma: no cover - normal path for older NeuRepTrace versions.
+    _neureptrace_band = None
 
 
 def get_data_field(data, field_name):
@@ -58,6 +59,56 @@ def get_trial_signal(data, trial_idx=0):
     return np.asarray(trial_signal, dtype=float)
 
 
+def uniform_sample_interval(time_vector):
+    """Return the sample interval after validating a finite regular time axis."""
+
+    time_vector = np.asarray(time_vector, dtype=float).ravel()
+    if time_vector.size < 2:
+        raise ValueError("time_vector must contain at least two samples.")
+    if not np.all(np.isfinite(time_vector)):
+        raise ValueError("time_vector must contain only finite values.")
+
+    diffs = np.diff(time_vector)
+    if np.any(diffs <= 0):
+        raise ValueError("time_vector must be strictly increasing.")
+
+    sample_interval = float(np.median(diffs))
+    if not np.allclose(diffs, sample_interval, rtol=1e-6, atol=1e-12):
+        raise ValueError("time_vector must be uniformly sampled.")
+    return sample_interval
+
+
+def sampling_rate_from_time_vector(time_vector):
+    """Return sampling rate in Hz after validating ``time_vector``."""
+
+    if _neureptrace_band is not None:
+        sampling_rate = getattr(_neureptrace_band, "sampling_rate_from_time_vector", None)
+        if sampling_rate is not None:
+            return float(sampling_rate(time_vector))
+    return float(1.0 / uniform_sample_interval(time_vector))
+
+
+def _validated_sampling_rate(sampling_rate):
+    try:
+        sampling_rate = float(sampling_rate)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("sampling_rate must be a positive finite value.") from exc
+    if not np.isfinite(sampling_rate) or sampling_rate <= 0.0:
+        raise ValueError("sampling_rate must be a positive finite value.")
+    return sampling_rate
+
+
+def _validated_signal_values(signal_values):
+    signal_values = np.asarray(signal_values, dtype=float)
+    if signal_values.ndim == 0:
+        raise ValueError("signal_values must have at least one sample dimension.")
+    if signal_values.shape[-1] < 2:
+        raise ValueError("signal_values must contain at least two samples along the last axis.")
+    if not np.all(np.isfinite(signal_values)):
+        raise ValueError("signal_values must contain only finite values.")
+    return signal_values
+
+
 def _validated_trial_signal(data, trial_idx, time_vector):
     signal = get_trial_signal(data, trial_idx)
     if signal.ndim != 2:
@@ -96,13 +147,75 @@ def _channel_indices_from_range(channel_range, n_channels):
     return range(start, stop + 1)
 
 
+def bandpass_filter_signal(signal_values, sampling_rate, lowcut=8.0, highcut=12.0, order=5):
+    signal_values = _validated_signal_values(signal_values)
+    sampling_rate = _validated_sampling_rate(sampling_rate)
+    nyquist = 0.5 * sampling_rate
+    if lowcut <= 0 or highcut <= 0:
+        raise ValueError("Cutoff frequencies must be positive.")
+    if lowcut >= highcut:
+        raise ValueError("lowcut must be lower than highcut.")
+    if highcut >= nyquist:
+        raise ValueError("highcut must be lower than the Nyquist frequency.")
+
+    sos = scipy.signal.butter(
+        order,
+        [lowcut, highcut],
+        btype="bandpass",
+        fs=sampling_rate,
+        output="sos",
+    )
+    return scipy.signal.sosfiltfilt(sos, signal_values)
+
+
+def extract_alpha_signal_and_phase(signal_values, sampling_rate, lowcut=8.0, highcut=12.0):
+    """Return the alpha-band signal and Hilbert phase using PyMEGDec defaults."""
+
+    filtered_signal = bandpass_filter_signal(signal_values, sampling_rate, lowcut, highcut)
+    analytic_signal = scipy.signal.hilbert(filtered_signal)
+    return filtered_signal, np.angle(analytic_signal)
+
+
+def extract_phase(signal_values, sampling_rate, lowcut=8.0, highcut=12.0):
+    """
+    Extracts the phase of the given signal using bandpass filtering and
+    Hilbert transform.
+    """
+
+    if _neureptrace_band is not None:
+        phase_extractor = getattr(_neureptrace_band, "extract_phase", None)
+        if phase_extractor is not None:
+            return phase_extractor(signal_values, sampling_rate, lowcut=lowcut, highcut=highcut)
+
+    _, phase = extract_alpha_signal_and_phase(signal_values, sampling_rate, lowcut, highcut)
+    return phase
+
+
+def average_phases(phases):
+    """
+    Averages the phases across multiple channels.
+    """
+
+    if not phases:
+        raise ValueError("At least one phase array is required.")
+
+    if _neureptrace_band is not None:
+        phase_averager = getattr(_neureptrace_band, "average_phases", None)
+        if phase_averager is not None:
+            return phase_averager(phases)
+
+    phase_matrix = np.vstack(phases)
+    mean_phase = np.angle(np.mean(np.exp(1j * phase_matrix), axis=0))
+    return mean_phase
+
+
 def extract_time_basis(data, trial_idx=0, channel_range=(187, 198)):
     """
     Extract a robust alpha-phase time basis across multiple channels.
 
-    Generic alpha filtering and Hilbert phase extraction are implemented in
-    :mod:`neureptrace.signal.band`; this wrapper keeps PyMEGDec's historical
-    FieldTrip/MATLAB trial and channel-range conventions.
+    Generic alpha filtering and Hilbert phase extraction are delegated to
+    :mod:`neureptrace.signal.band` when available; local fallbacks keep
+    PyMEGDec's historical FieldTrip/MATLAB trial and channel-range conventions.
     """
 
     time_vector = get_time_vector(data, trial_idx)

--- a/src/pymegdec/alpha_signal.py
+++ b/src/pymegdec/alpha_signal.py
@@ -1,5 +1,19 @@
+"""Compatibility helpers for alpha-band signal extraction.
+
+Generic filtering, Hilbert-phase extraction, sampling-rate validation, and
+phase averaging are delegated to NeuRepTrace.  This module keeps only the
+FieldTrip/MATLAB cell-array accessors and PyMEGDec's historical
+``extract_time_basis`` convenience wrapper.
+"""
+
+from __future__ import annotations
+
 import numpy as np
-import scipy.signal
+from neureptrace.signal.band import (
+    average_phases,
+    extract_phase,
+    sampling_rate_from_time_vector,
+)
 
 
 def get_data_field(data, field_name):
@@ -44,52 +58,6 @@ def get_trial_signal(data, trial_idx=0):
     return np.asarray(trial_signal, dtype=float)
 
 
-def uniform_sample_interval(time_vector):
-    """Return the sample interval after validating a finite regular time axis."""
-
-    time_vector = np.asarray(time_vector, dtype=float).ravel()
-    if time_vector.size < 2:
-        raise ValueError("time_vector must contain at least two samples.")
-    if not np.all(np.isfinite(time_vector)):
-        raise ValueError("time_vector must contain only finite values.")
-
-    diffs = np.diff(time_vector)
-    if np.any(diffs <= 0):
-        raise ValueError("time_vector must be strictly increasing.")
-
-    sample_interval = float(np.median(diffs))
-    if not np.allclose(diffs, sample_interval, rtol=1e-6, atol=1e-12):
-        raise ValueError("time_vector must be uniformly sampled.")
-    return sample_interval
-
-
-def sampling_rate_from_time_vector(time_vector):
-    """Return sampling rate in Hz after validating ``time_vector``."""
-
-    return float(1.0 / uniform_sample_interval(time_vector))
-
-
-def _validated_sampling_rate(sampling_rate):
-    try:
-        sampling_rate = float(sampling_rate)
-    except (TypeError, ValueError) as exc:
-        raise ValueError("sampling_rate must be a positive finite value.") from exc
-    if not np.isfinite(sampling_rate) or sampling_rate <= 0.0:
-        raise ValueError("sampling_rate must be a positive finite value.")
-    return sampling_rate
-
-
-def _validated_signal_values(signal_values):
-    signal_values = np.asarray(signal_values, dtype=float)
-    if signal_values.ndim == 0:
-        raise ValueError("signal_values must have at least one sample dimension.")
-    if signal_values.shape[-1] < 2:
-        raise ValueError("signal_values must contain at least two samples along the last axis.")
-    if not np.all(np.isfinite(signal_values)):
-        raise ValueError("signal_values must contain only finite values.")
-    return signal_values
-
-
 def _validated_trial_signal(data, trial_idx, time_vector):
     signal = get_trial_signal(data, trial_idx)
     if signal.ndim != 2:
@@ -128,82 +96,15 @@ def _channel_indices_from_range(channel_range, n_channels):
     return range(start, stop + 1)
 
 
-def bandpass_filter_signal(signal_values, sampling_rate, lowcut=8.0, highcut=12.0, order=5):
-    signal_values = _validated_signal_values(signal_values)
-    sampling_rate = _validated_sampling_rate(sampling_rate)
-    nyquist = 0.5 * sampling_rate
-    if lowcut <= 0 or highcut <= 0:
-        raise ValueError("Cutoff frequencies must be positive.")
-    if lowcut >= highcut:
-        raise ValueError("lowcut must be lower than highcut.")
-    if highcut >= nyquist:
-        raise ValueError("highcut must be lower than the Nyquist frequency.")
-
-    sos = scipy.signal.butter(
-        order,
-        [lowcut, highcut],
-        btype="bandpass",
-        fs=sampling_rate,
-        output="sos",
-    )
-    return scipy.signal.sosfiltfilt(sos, signal_values)
-
-
-def extract_alpha_signal_and_phase(signal_values, sampling_rate, lowcut=8.0, highcut=12.0):
-    filtered_signal = bandpass_filter_signal(signal_values, sampling_rate, lowcut, highcut)
-    analytic_signal = scipy.signal.hilbert(filtered_signal)
-    return filtered_signal, np.angle(analytic_signal)
-
-
-def extract_phase(signal_values, sampling_rate, lowcut=8.0, highcut=12.0):
-    """
-    Extracts the phase of the given signal using bandpass filtering and
-    Hilbert transform.
-
-    Parameters:
-        signal_values (numpy array): The signal to extract the phase from.
-        sampling_rate (float): The sampling rate of the signal.
-        lowcut (float): The low cutoff frequency for the bandpass filter.
-        highcut (float): The high cutoff frequency for the bandpass filter.
-
-    Returns:
-        numpy array: The phase of the filtered signal.
-    """
-    _, phase = extract_alpha_signal_and_phase(signal_values, sampling_rate, lowcut, highcut)
-    return phase
-
-
-def average_phases(phases):
-    """
-    Averages the phases across multiple channels.
-
-    Parameters:
-        phases (list of numpy arrays): List of phase arrays from different channels.
-
-    Returns:
-        numpy array: The average phase.
-    """
-    if not phases:
-        raise ValueError("At least one phase array is required.")
-
-    phase_matrix = np.vstack(phases)
-    mean_phase = np.angle(np.mean(np.exp(1j * phase_matrix), axis=0))
-    return mean_phase
-
-
 def extract_time_basis(data, trial_idx=0, channel_range=(187, 198)):
     """
-    Extracts a robust time basis based on the alpha phases across multiple
-    channels for a given trial.
+    Extract a robust alpha-phase time basis across multiple channels.
 
-    Parameters:
-        data (dict): The filtered MEG data containing only the alpha signal.
-        trial_idx (int): The index of the trial to extract the time basis from.
-        channel_range (tuple): The range of channels (start, end) to extract phases for.
-
-    Returns:
-        numpy array: The robust time basis based on the average phase.
+    Generic alpha filtering and Hilbert phase extraction are implemented in
+    :mod:`neureptrace.signal.band`; this wrapper keeps PyMEGDec's historical
+    FieldTrip/MATLAB trial and channel-range conventions.
     """
+
     time_vector = get_time_vector(data, trial_idx)
     sampling_rate = sampling_rate_from_time_vector(time_vector)
     signal = _validated_trial_signal(data, trial_idx, time_vector)
@@ -227,13 +128,10 @@ if __name__ == "__main__":
     demo_part = 2
     demo_data = sio.loadmat(f"{demo_data_folder}/Part{demo_part}Data.mat")["data"][0]
 
-    # Extract the robust time basis for channels 187 to 198 for a specific trial
     demo_time_basis = extract_time_basis(demo_data, trial_idx=0, channel_range=(187, 198))
 
-    # Display the time basis
     print("Robust time basis (average phase):", demo_time_basis)
 
-    # Plot the average phase to visualize
     demo_time_vector = get_time_vector(demo_data)
     plt.plot(demo_time_vector, demo_time_basis, label="Average Phase")
     plt.title("Average Alpha Phase Across Channels 187-198")


### PR DESCRIPTION
## Summary
- delegate alpha-band signal processing and metric calculation to NeuRepTrace when available
- keep PyMEGDec fallback behavior for environments without NeuRepTrace
- preserve the existing public wrapper APIs

## Validation
- ruff check --fix on changed Python files
- git diff --check origin/main..HEAD
- tests not run per request