### PR TITLE
Add source-only BUSH-MEG next methods

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -1,0 +1,193 @@
+name: Stimulus source-only next-method grid
+
+on:
+  workflow_dispatch:
+    inputs:
+      participants:
+        description: Participant ids for training/evaluation
+        default: "1-4,6,8,9,10,13-27"
+        required: true
+      outer_participants:
+        description: Optional outer held-out ids; leave empty for all
+        default: ""
+        required: false
+      window_centers:
+        description: Candidate window centers in seconds
+        default: "0.125,0.175,0.250,0.400,0.550"
+        required: true
+      max_trials_per_class:
+        description: Optional cap per subject/class; empty for all trials
+        default: ""
+        required: false
+
+jobs:
+  source-only-next:
+    runs-on: self-hosted
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/prepare-meg-data
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+
+      - name: Run nested source-only next-method grid
+        shell: bash
+        run: |
+          mkdir -p outputs
+          CAP_ARGS=()
+          if [ -n "${{ github.event.inputs.max_trials_per_class }}" ]; then
+            CAP_ARGS+=(--max-trials-per-class-per-participant "${{ github.event.inputs.max_trials_per_class }}")
+          fi
+          OUTER_ARGS=()
+          if [ -n "${{ github.event.inputs.outer_participants }}" ]; then
+            OUTER_ARGS+=(--outer-participants "${{ github.event.inputs.outer_participants }}")
+          fi
+          pymegdec stimulus cross-subject-nested \
+            --participants "${{ github.event.inputs.participants }}" \
+            "${OUTER_ARGS[@]}" \
+            --window-centers "${{ github.event.inputs.window_centers }}" \
+            --window-size 0.100 \
+            --baseline-window=-0.35,-0.05 \
+            --feature-modes sensor_flat,sensor_mean_logpower \
+            --normalizations subject_baseline_whiten \
+            --alignments none \
+            --alignment-alphas 1.0 \
+            --classifiers multinomial-logistic,multiclass-svm \
+            --classifier-params 0.1,1.0 \
+            --components-pca-values 64,128 \
+            --sample-weightings none,subject_class_balanced \
+            --score-calibrations none \
+            --selection-ensemble-size 6 \
+            --selection-ensemble-diversity window_classifier \
+            --selection-ensemble-score-normalization row_z_softmax \
+            --selection-ensemble-weighting inner_lcb_softmax \
+            --write-incremental \
+            --resume \
+            "${CAP_ARGS[@]}" \
+            --outer-output outputs/stimulus_source_only_next_outer.csv \
+            --summary-output outputs/stimulus_source_only_next_group_summary.csv \
+            --inner-validation-output outputs/stimulus_source_only_next_inner_validation.csv \
+            --selected-output outputs/stimulus_source_only_next_selected.csv \
+            --predictions-output outputs/stimulus_source_only_next_predictions.csv \
+            --confusion-output outputs/stimulus_source_only_next_confusion.csv \
+            --per-stimulus-output outputs/stimulus_source_only_next_per_stimulus.csv \
+            --confusion-pairs-output outputs/stimulus_source_only_next_confusion_pairs.csv
+
+      - name: Run source-only class-bias calibration smoke
+        shell: bash
+        run: |
+          OUTER_ARGS=()
+          if [ -n "${{ github.event.inputs.outer_participants }}" ]; then
+            OUTER_ARGS+=(--outer-participants "${{ github.event.inputs.outer_participants }}")
+          fi
+          pymegdec stimulus cross-subject-smoke \
+            --participants "${{ github.event.inputs.participants }}" \
+            --window-center 0.175 \
+            --window-size 0.100 \
+            --baseline-window=-0.35,-0.05 \
+            --feature-mode sensor_flat \
+            --normalization subject_baseline_whiten \
+            --alignment none \
+            --classifier multinomial-logistic \
+            --classifier-param 1.0 \
+            --components-pca 128 \
+            --sample-weighting subject_class_balanced \
+            --score-calibration inner_class_bias \
+            --outer-output outputs/stimulus_source_bias_outer.csv \
+            --summary-output outputs/stimulus_source_bias_group_summary.csv \
+            --predictions-output outputs/stimulus_source_bias_predictions.csv
+
+      - name: Run identity-regularized Procrustes smoke grid
+        shell: bash
+        run: |
+          OUTER_ARGS=()
+          if [ -n "${{ github.event.inputs.outer_participants }}" ]; then
+            OUTER_ARGS+=(--outer-participants "${{ github.event.inputs.outer_participants }}")
+          fi
+          pymegdec stimulus cross-subject-nested \
+            --participants "${{ github.event.inputs.participants }}" \
+            "${OUTER_ARGS[@]}" \
+            --window-centers 0.175 \
+            --window-size 0.100 \
+            --baseline-window=-0.35,-0.05 \
+            --feature-modes sensor_flat \
+            --normalizations subject_baseline_whiten \
+            --alignments train_class_procrustes \
+            --alignment-alphas 0.1,0.25,0.5,1.0 \
+            --classifiers multinomial-logistic \
+            --classifier-params 1.0 \
+            --components-pca-values 128 \
+            --sample-weightings subject_class_balanced \
+            --score-calibrations none \
+            --selection-ensemble-size 2 \
+            --selection-ensemble-diversity full_config \
+            --write-incremental \
+            --resume \
+            --outer-output outputs/stimulus_alignment_alpha_outer.csv \
+            --summary-output outputs/stimulus_alignment_alpha_group_summary.csv \
+            --inner-validation-output outputs/stimulus_alignment_alpha_inner_validation.csv \
+            --selected-output outputs/stimulus_alignment_alpha_selected.csv \
+            --predictions-output outputs/stimulus_alignment_alpha_predictions.csv
+
+      - name: Run cue latency-only calibration
+        shell: bash
+        run: |
+          OUTER_ARGS=()
+          if [ -n "${{ github.event.inputs.outer_participants }}" ]; then
+            OUTER_ARGS+=(--outer-participants "${{ github.event.inputs.outer_participants }}")
+          fi
+          pymegdec stimulus cross-subject-cue-low-capacity \
+            --mode latency_shift \
+            --participants "${{ github.event.inputs.participants }}" \
+            "${OUTER_ARGS[@]}" \
+            --window-center 0.175 \
+            --window-size 0.100 \
+            --baseline-window=-0.35,-0.05 \
+            --feature-mode sensor_flat \
+            --normalization subject_baseline_whiten \
+            --classifier multinomial-logistic \
+            --classifier-param 1.0 \
+            --components-pca 128 \
+            --sample-weighting subject_class_balanced \
+            --score-calibration inner_class_bias \
+            --latency-peak-window -0.05,0.35 \
+            --max-latency-shift-s 0.05 \
+            --outer-output outputs/stimulus_cue_latency_outer.csv \
+            --summary-output outputs/stimulus_cue_latency_group_summary.csv \
+            --predictions-output outputs/stimulus_cue_latency_predictions.csv
+
+      - name: Run cue source-expert mixture
+        shell: bash
+        run: |
+          OUTER_ARGS=()
+          if [ -n "${{ github.event.inputs.outer_participants }}" ]; then
+            OUTER_ARGS+=(--outer-participants "${{ github.event.inputs.outer_participants }}")
+          fi
+          pymegdec stimulus cross-subject-cue-low-capacity \
+            --mode expert_mixture \
+            --participants "${{ github.event.inputs.participants }}" \
+            "${OUTER_ARGS[@]}" \
+            --window-center 0.175 \
+            --window-size 0.100 \
+            --baseline-window=-0.35,-0.05 \
+            --feature-mode sensor_flat \
+            --normalization subject_baseline_whiten \
+            --classifier multinomial-logistic \
+            --classifier-param 1.0 \
+            --components-pca 128 \
+            --sample-weighting subject_class_balanced \
+            --expert-top-k 8 \
+            --expert-temperature 0.25 \
+            --outer-output outputs/stimulus_cue_expert_outer.csv \
+            --summary-output outputs/stimulus_cue_expert_group_summary.csv \
+            --predictions-output outputs/stimulus_cue_expert_predictions.csv
+
+      - name: Upload outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: stimulus-source-only-next-results
+          path: outputs/*.csv

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -1,0 +1,645 @@
+"""Additional source-only and low-capacity calibration hooks for BUSH-MEG.
+
+This module intentionally patches the existing composed cross-subject module in
+the same style as ``_stimulus_cross_subject_core``.  It avoids touching the
+legacy implementation while adding the experiment knobs that are most relevant
+after the cue-alignment runs underperformed source-only decoding.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, fields
+from itertools import product
+
+import numpy as np
+from pymegdec.classifiers import get_default_classifier_param, should_use_default_classifier_param, train_multiclass_classifier
+from reptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
+
+DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING = "none"
+SAMPLE_WEIGHTING_MODES = ("none", "subject_class_balanced")
+DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION = "none"
+SCORE_CALIBRATION_MODES = ("none", "inner_class_bias")
+DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = 1.0
+EXTENDED_FEATURE_MODES = ("sensor_logpower", "sensor_mean_logpower", "sensor_bandpower", "sensor_cov_tangent")
+DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
+SCORE_CALIBRATION_L2 = 1e-3
+
+_impl = None
+_BaseConfig = None
+_previous_normalized_config = None
+_previous_make_candidate_configs = None
+_previous_normalize_feature_mode = None
+_previous_extract_window_features = None
+_previous_baseline_feature_statistics = None
+_previous_normalize_features = None
+_previous_normalized_subject_features = None
+_previous_fit_outer_fold_model = None
+_previous_score_outer_fold_model = None
+_previous_candidate_model_scores = None
+_previous_align_training_features_by_subject = None
+_previous_align_test_features_by_subject = None
+_previous_prediction_rows = None
+_previous_summarize_smoke = None
+_previous_summarize_nested = None
+_previous_rank_nested_candidates = None
+
+CrossSubjectStimulusConfig = None
+
+
+def install(impl) -> None:
+    """Install next-method hooks into the composed cross-subject implementation."""
+
+    global _impl, _BaseConfig, CrossSubjectStimulusConfig
+    global _previous_normalized_config, _previous_make_candidate_configs, _previous_normalize_feature_mode
+    global _previous_extract_window_features, _previous_baseline_feature_statistics, _previous_normalize_features, _previous_normalized_subject_features, _previous_fit_outer_fold_model
+    global _previous_score_outer_fold_model, _previous_candidate_model_scores, _previous_align_training_features_by_subject
+    global _previous_align_test_features_by_subject, _previous_prediction_rows, _previous_summarize_smoke
+    global _previous_summarize_nested, _previous_rank_nested_candidates
+
+    if getattr(impl, "_next_methods_installed", False):
+        return
+
+    _impl = impl
+    _BaseConfig = impl.CrossSubjectStimulusConfig
+    _previous_normalized_config = impl._normalized_config
+    _previous_make_candidate_configs = impl.make_cross_subject_candidate_configs
+    _previous_normalize_feature_mode = impl._normalize_feature_mode
+    _previous_extract_window_features = impl._extract_window_features
+    _previous_baseline_feature_statistics = impl._baseline_feature_statistics
+    _previous_normalize_features = impl._normalize_features
+    _previous_normalized_subject_features = impl._normalized_subject_features
+    _previous_fit_outer_fold_model = impl._fit_outer_fold_model
+    _previous_score_outer_fold_model = impl._score_outer_fold_model
+    _previous_candidate_model_scores = impl._candidate_model_scores
+    _previous_align_training_features_by_subject = impl._align_training_features_by_subject
+    _previous_align_test_features_by_subject = impl._align_test_features_by_subject
+    _previous_prediction_rows = impl._prediction_rows
+    _previous_summarize_smoke = impl.summarize_cross_subject_stimulus_smoke
+    _previous_summarize_nested = impl.summarize_nested_cross_subject_stimulus
+    _previous_rank_nested_candidates = impl._rank_nested_candidates
+
+    @dataclass(frozen=True)
+    class NextCrossSubjectStimulusConfig(_BaseConfig):
+        sample_weighting: str = DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING
+        score_calibration: str = DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION
+        alignment_alpha: float = DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA
+
+    CrossSubjectStimulusConfig = NextCrossSubjectStimulusConfig
+
+    impl.DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING = DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING
+    impl.SAMPLE_WEIGHTING_MODES = SAMPLE_WEIGHTING_MODES
+    impl.DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION = DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION
+    impl.SCORE_CALIBRATION_MODES = SCORE_CALIBRATION_MODES
+    impl.DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA
+    impl.EXTENDED_FEATURE_MODES = EXTENDED_FEATURE_MODES
+    impl.FEATURE_MODES = tuple(dict.fromkeys((*impl.FEATURE_MODES, *EXTENDED_FEATURE_MODES)))
+    impl.CrossSubjectStimulusConfig = NextCrossSubjectStimulusConfig
+
+    impl._normalize_feature_mode = _normalize_feature_mode
+    impl._normalized_config = _normalized_config
+    impl.make_cross_subject_candidate_configs = make_cross_subject_candidate_configs
+    impl._extract_window_features = _extract_window_features
+    impl._baseline_feature_statistics = _baseline_feature_statistics
+    impl._normalize_features = _normalize_features
+    impl._normalized_subject_features = _normalized_subject_features
+    impl._fit_outer_fold_model = _fit_outer_fold_model
+    impl._score_outer_fold_model = _score_outer_fold_model
+    impl._candidate_model_scores = _candidate_model_scores
+    impl._align_training_features_by_subject = _align_training_features_by_subject
+    impl._align_test_features_by_subject = _align_test_features_by_subject
+    impl._prediction_rows = _prediction_rows
+    impl.summarize_cross_subject_stimulus_smoke = summarize_cross_subject_stimulus_smoke
+    impl.summarize_nested_cross_subject_stimulus = summarize_nested_cross_subject_stimulus
+    impl._rank_nested_candidates = _rank_nested_candidates
+    impl.CROSS_SUBJECT_PREDICTION_GROUP_COLUMNS = _prediction_group_columns(impl.CROSS_SUBJECT_PREDICTION_GROUP_COLUMNS)
+    impl._next_methods_installed = True
+
+
+def _prediction_group_columns(columns):
+    output = list(columns)
+    for column in ("sample_weighting", "score_calibration", "alignment_alpha"):
+        if column not in output:
+            output.append(column)
+    return tuple(output)
+
+
+def _normalize_feature_mode(value):
+    token = str(value).strip().lower().replace("-", "_")
+    if token in EXTENDED_FEATURE_MODES:
+        return token
+    return _previous_normalize_feature_mode(value)
+
+
+def _normalize_sample_weighting(value):
+    token = str(value).strip().lower().replace("-", "_")
+    if token not in SAMPLE_WEIGHTING_MODES:
+        raise ValueError(f"sample_weighting must be one of {SAMPLE_WEIGHTING_MODES}.")
+    return token
+
+
+def _normalize_score_calibration(value):
+    token = str(value).strip().lower().replace("-", "_")
+    if token not in SCORE_CALIBRATION_MODES:
+        raise ValueError(f"score_calibration must be one of {SCORE_CALIBRATION_MODES}.")
+    return token
+
+
+def _normalize_alignment_alpha(value):
+    alpha = float(value)
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError("alignment_alpha must be in [0, 1].")
+    return alpha
+
+
+def _normalized_config(config):
+    base = _previous_normalized_config(config)
+    kwargs = {field.name: getattr(base, field.name) for field in fields(base)}
+    kwargs["sample_weighting"] = _normalize_sample_weighting(getattr(config, "sample_weighting", DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING))
+    kwargs["score_calibration"] = _normalize_score_calibration(getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION))
+    kwargs["alignment_alpha"] = _normalize_alignment_alpha(getattr(config, "alignment_alpha", DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA))
+    return CrossSubjectStimulusConfig(**kwargs)
+
+
+def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
+    *,
+    window_centers=None,
+    window_size=None,
+    baseline_window=None,
+    feature_modes=None,
+    normalizations=None,
+    alignments=None,
+    classifiers=None,
+    classifier_params=(float("nan"),),
+    components_pca_values=None,
+    max_trials_per_class_per_participant=None,
+    trial_selection=None,
+    trial_selection_seed=None,
+    sample_weightings=(DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING,),
+    score_calibrations=(DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION,),
+    alignment_alphas=(DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA,),
+    chance_classes=None,
+    random_state=0,
+    signflip_permutations=10_000,
+    signflip_seed=0,
+):
+    window_centers = _impl.DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS if window_centers is None else window_centers
+    window_size = _impl.DEFAULT_CROSS_SUBJECT_WINDOW_SIZE if window_size is None else window_size
+    baseline_window = _impl.DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW if baseline_window is None else baseline_window
+    feature_modes = (_impl.DEFAULT_CROSS_SUBJECT_FEATURE_MODE,) if feature_modes is None else feature_modes
+    normalizations = (_impl.DEFAULT_CROSS_SUBJECT_NORMALIZATION,) if normalizations is None else normalizations
+    alignments = (_impl.DEFAULT_CROSS_SUBJECT_ALIGNMENT,) if alignments is None else alignments
+    classifiers = (_impl.DEFAULT_CROSS_SUBJECT_CLASSIFIER,) if classifiers is None else classifiers
+    components_pca_values = (_impl.DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA,) if components_pca_values is None else components_pca_values
+    trial_selection = getattr(_impl, "DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION", "random") if trial_selection is None else trial_selection
+    trial_selection_seed = getattr(_impl, "DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED", 0) if trial_selection_seed is None else trial_selection_seed
+    chance_classes = _impl.DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES if chance_classes is None else chance_classes
+
+    return tuple(
+        CrossSubjectStimulusConfig(
+            window_center=window_center,
+            window_size=window_size,
+            baseline_window=baseline_window,
+            feature_mode=_normalize_feature_mode(feature_mode),
+            normalization=normalization,
+            alignment=alignment,
+            classifier=classifier,
+            classifier_param=classifier_param,
+            components_pca=components_pca,
+            max_trials_per_class_per_participant=max_trials_per_class_per_participant,
+            trial_selection=trial_selection,
+            trial_selection_seed=trial_selection_seed,
+            sample_weighting=_normalize_sample_weighting(sample_weighting),
+            score_calibration=_normalize_score_calibration(score_calibration),
+            alignment_alpha=_normalize_alignment_alpha(alignment_alpha),
+            chance_classes=chance_classes,
+            random_state=random_state,
+            signflip_permutations=signflip_permutations,
+            signflip_seed=signflip_seed,
+        )
+        for window_center, feature_mode, normalization, alignment, classifier, components_pca, sample_weighting, score_calibration, alignment_alpha in product(
+            window_centers,
+            feature_modes,
+            normalizations,
+            alignments,
+            classifiers,
+            _impl._components_pca_values_for_grid(components_pca_values),
+            sample_weightings,
+            score_calibrations,
+            alignment_alphas,
+        )
+        for classifier_param in _impl._classifier_params_for_classifier(classifier, classifier_params)
+    )
+
+
+def _extract_window_features(data, time_window, *, feature_mode, trial_indices=None):
+    feature_mode = _normalize_feature_mode(feature_mode)
+    if feature_mode not in EXTENDED_FEATURE_MODES:
+        return _previous_extract_window_features(data, time_window, feature_mode=feature_mode, trial_indices=trial_indices)
+
+    time_vector = _impl._time_vector(data, 0)
+    mask = _impl._time_mask(time_vector, time_window)
+    window_time = time_vector[mask]
+    features = []
+    for trial_idx in _impl._iter_trial_indices(data, trial_indices):
+        signal = _impl._trial_signal(data, trial_idx)[:, mask]
+        if feature_mode == "sensor_logpower":
+            feature = _sensor_logpower_feature(signal)
+        elif feature_mode == "sensor_mean_logpower":
+            feature = np.concatenate((np.mean(signal, axis=1), _sensor_logpower_feature(signal)))
+        elif feature_mode == "sensor_bandpower":
+            feature = _sensor_bandpower_feature(signal, window_time)
+        elif feature_mode == "sensor_cov_tangent":
+            feature = _sensor_cov_tangent_feature(signal)
+        else:
+            raise ValueError(f"Unsupported feature_mode: {feature_mode}")
+        features.append(feature)
+    return np.vstack(features), int(np.sum(mask))
+
+
+def _sensor_logpower_feature(window_signal):
+    return np.log(np.mean(np.square(np.asarray(window_signal, dtype=float)), axis=1) + 1e-12)
+
+
+def _sensor_bandpower_feature(window_signal, window_time):
+    signal = np.asarray(window_signal, dtype=float)
+    time = np.asarray(window_time, dtype=float).ravel()
+    if signal.shape[1] < 2 or time.shape[0] < 2:
+        return np.tile(_sensor_logpower_feature(signal), len(DEFAULT_SENSOR_BANDS))
+    dt = float(np.median(np.diff(time)))
+    if dt <= 0.0 or not np.isfinite(dt):
+        return np.tile(_sensor_logpower_feature(signal), len(DEFAULT_SENSOR_BANDS))
+    centered = signal - np.mean(signal, axis=1, keepdims=True)
+    freqs = np.fft.rfftfreq(centered.shape[1], d=dt)
+    spectrum = np.square(np.abs(np.fft.rfft(centered, axis=1)))
+    band_features = []
+    for low, high in DEFAULT_SENSOR_BANDS:
+        mask = (freqs >= low) & (freqs < high)
+        if np.any(mask):
+            power = np.mean(spectrum[:, mask], axis=1)
+        else:
+            power = np.zeros(centered.shape[0], dtype=float)
+        band_features.append(np.log(power + 1e-12))
+    return np.concatenate(band_features)
+
+
+def _sensor_cov_tangent_feature(window_signal):
+    signal = np.asarray(window_signal, dtype=float)
+    n_channels = int(signal.shape[0])
+    if signal.shape[1] < 2:
+        covariance = np.eye(n_channels, dtype=float)
+    else:
+        covariance = np.cov(signal, rowvar=True)
+        covariance = 0.5 * (covariance + covariance.T)
+    trace = float(np.trace(covariance))
+    target = (trace / max(n_channels, 1)) * np.eye(n_channels, dtype=float)
+    covariance = 0.9 * covariance + 0.1 * target
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    floor = max(float(np.max(eigenvalues)) * 1e-6, 1e-12)
+    log_covariance = (eigenvectors * np.log(np.maximum(eigenvalues, floor))) @ eigenvectors.T
+    rows, cols = np.triu_indices(n_channels)
+    feature = log_covariance[rows, cols]
+    off_diag = rows != cols
+    feature = feature.astype(float, copy=True)
+    feature[off_diag] *= np.sqrt(2.0)
+    return feature
+
+
+def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
+    if _normalize_feature_mode(config.feature_mode) in EXTENDED_FEATURE_MODES:
+        baseline_features, n_baseline_samples = _extract_window_features(data, config.baseline_window, feature_mode=config.feature_mode, trial_indices=trial_indices)
+        mean = np.mean(baseline_features, axis=0, keepdims=True)
+        std = np.std(baseline_features, axis=0, keepdims=True)
+        return mean, _impl._nonzero_std(std), n_baseline_samples
+    return _previous_baseline_feature_statistics(data, config, n_window_samples, trial_indices)
+
+
+def _normalize_features(features, config, baseline_feature_mean, baseline_feature_std, baseline_whitening_matrix):
+    if _normalize_feature_mode(config.feature_mode) in EXTENDED_FEATURE_MODES and config.normalization == "subject_baseline_whiten":
+        if baseline_feature_mean is None or baseline_feature_std is None:
+            raise ValueError("Extended feature modes use baseline z-scoring when normalization='subject_baseline_whiten'.")
+        return (np.asarray(features, dtype=float) - baseline_feature_mean) / baseline_feature_std
+    return _previous_normalize_features(features, config, baseline_feature_mean, baseline_feature_std, baseline_whitening_matrix)
+
+
+def _normalized_subject_features(feature_set, config):
+    if _normalize_feature_mode(config.feature_mode) in EXTENDED_FEATURE_MODES and config.normalization == "subject_baseline_whiten":
+        if feature_set.normalization == config.normalization:
+            return feature_set.features
+        if feature_set.baseline_feature_mean is None or feature_set.baseline_feature_std is None:
+            raise ValueError("Extended feature modes require baseline feature statistics for subject_baseline_whiten.")
+        return (np.asarray(feature_set.features, dtype=float) - feature_set.baseline_feature_mean) / feature_set.baseline_feature_std
+    return _previous_normalized_subject_features(feature_set, config)
+
+
+def _align_training_features_by_subject(feature_sets, features_by_subject, labels_by_subject, config):
+    aligned, metadata = _previous_align_training_features_by_subject(feature_sets, features_by_subject, labels_by_subject, config)
+    alpha = _normalize_alignment_alpha(getattr(config, "alignment_alpha", DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA))
+    if getattr(config, "alignment", "none") != "none" and alpha < 1.0:
+        aligned = [(1.0 - alpha) * np.asarray(raw, dtype=float) + alpha * np.asarray(full, dtype=float) for raw, full in zip(features_by_subject, aligned, strict=True)]
+    if isinstance(metadata, dict):
+        if "metadata" in metadata and isinstance(metadata["metadata"], dict):
+            metadata["metadata"]["alignment_alpha"] = alpha
+        else:
+            metadata["alignment_alpha"] = alpha
+    return aligned, metadata
+
+
+def _align_test_features_by_subject(test_features, test_set, config, alignment_model):
+    aligned, metadata = _previous_align_test_features_by_subject(test_features, test_set, config, alignment_model)
+    alpha = _normalize_alignment_alpha(getattr(config, "alignment_alpha", DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA))
+    if getattr(config, "alignment", "none") != "none" and alpha < 1.0:
+        aligned = (1.0 - alpha) * np.asarray(test_features, dtype=float) + alpha * np.asarray(aligned, dtype=float)
+    if isinstance(metadata, dict):
+        metadata["alignment_alpha"] = alpha
+    return aligned, metadata
+
+
+def _fit_outer_fold_model(train_sets, config, classifier_param, *, label_shuffle_seed=None, label_shuffle_context=(), fit_score_calibration=True):
+    config = _normalized_config(config)
+    train_features_by_subject = [_impl._normalized_subject_features(feature_set, config) for feature_set in train_sets]
+    train_label_arrays = [
+        _impl._training_labels(feature_set, label_shuffle_seed=label_shuffle_seed, label_shuffle_context=label_shuffle_context)
+        for feature_set in train_sets
+    ]
+    train_features_by_subject, alignment_metadata = _align_training_features_by_subject(train_sets, train_features_by_subject, train_label_arrays, config)
+    train_features = np.vstack(train_features_by_subject)
+    train_labels_one_based = np.concatenate(train_label_arrays)
+    train_labels = train_labels_one_based - 1
+    sample_weight = _training_sample_weights(train_sets, train_label_arrays, config)
+    feature_transform_metadata = None
+    fit_training_feature_transform = getattr(_impl, "_fit_training_feature_transform", None)
+    if fit_training_feature_transform is not None:
+        train_features, feature_transform_metadata = fit_training_feature_transform(train_features, train_sets, config)
+    train_window = _impl._centered_window(config.window_center, config.window_size)
+    model_bundle = fit_reptrace_window_model(
+        train_features,
+        train_labels,
+        fit_model=lambda features, labels: train_multiclass_classifier(
+            features,
+            labels,
+            config.classifier,
+            classifier_param,
+            random_state=config.random_state,
+            sample_weight=sample_weight,
+        ),
+        components_pca=config.components_pca,
+        train_window=train_window,
+    )
+    fitted_model = {
+        "classifier_param": classifier_param,
+        "model_bundle": model_bundle,
+        "n_train_participants": len(train_sets),
+        "train_class_counts": Counter(train_labels_one_based.tolist()),
+        "train_labels": train_labels,
+        "train_participants": tuple(feature_set.participant for feature_set in train_sets),
+        "train_window": train_window,
+        "label_shuffle_control": label_shuffle_seed is not None,
+        "label_shuffle_seed": "" if label_shuffle_seed is None else int(label_shuffle_seed),
+        "alignment_metadata": alignment_metadata,
+        "sample_weighting": config.sample_weighting,
+    }
+    if feature_transform_metadata is not None:
+        fitted_model["feature_transform_metadata"] = feature_transform_metadata
+    if fit_score_calibration and config.score_calibration == "inner_class_bias":
+        fitted_model["score_calibration_metadata"] = _fit_inner_class_bias_calibration(
+            train_sets,
+            config,
+            classifier_param,
+            label_shuffle_seed=label_shuffle_seed,
+            label_shuffle_context=label_shuffle_context,
+        )
+    else:
+        fitted_model["score_calibration_metadata"] = {"mode": config.score_calibration}
+    return fitted_model
+
+
+def _training_sample_weights(train_sets, label_arrays, config):
+    if _normalize_sample_weighting(getattr(config, "sample_weighting", DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING)) == "none":
+        return None
+    weights = []
+    for labels in label_arrays:
+        counts = Counter(np.asarray(labels, dtype=int).tolist())
+        weights.extend(1.0 / max(counts[int(label)], 1) for label in labels)
+    weights = np.asarray(weights, dtype=float)
+    if weights.size and np.sum(weights) > 0.0:
+        weights *= weights.size / np.sum(weights)
+    return weights
+
+
+def _fit_inner_class_bias_calibration(train_sets, config, classifier_param, *, label_shuffle_seed=None, label_shuffle_context=()):
+    if len(train_sets) < 3:
+        return {"mode": "inner_class_bias", "status": "skipped_not_enough_source_subjects"}
+    all_scores = []
+    all_labels = []
+    class_order = np.arange(int(config.chance_classes), dtype=int)
+    inner_config = _config_with(config, score_calibration="none")
+    for validation_index, validation_set in enumerate(train_sets):
+        inner_train_sets = [feature_set for feature_set in train_sets if int(feature_set.participant) != int(validation_set.participant)]
+        inner_model = _fit_outer_fold_model(
+            inner_train_sets,
+            inner_config,
+            classifier_param,
+            label_shuffle_seed=label_shuffle_seed,
+            label_shuffle_context=(*tuple(label_shuffle_context), int(validation_set.participant), validation_index),
+            fit_score_calibration=False,
+        )
+        scores, score_classes = _previous_candidate_model_scores(inner_model, validation_set, inner_config)
+        all_scores.append(_align_class_score_columns(scores, score_classes, class_order))
+        all_labels.append(np.asarray(validation_set.labels, dtype=int) - 1)
+    scores = np.vstack(all_scores)
+    labels = np.concatenate(all_labels)
+    bias, inner_balanced = _optimize_class_bias(scores, labels, class_order)
+    return {
+        "mode": "inner_class_bias",
+        "classes": class_order,
+        "bias": bias,
+        "inner_balanced_accuracy": inner_balanced,
+        "l2_penalty": SCORE_CALIBRATION_L2,
+    }
+
+
+def _config_with(config, **updates):
+    kwargs = {field.name: getattr(config, field.name) for field in fields(config)}
+    kwargs.update(updates)
+    return CrossSubjectStimulusConfig(**kwargs)
+
+
+def _optimize_class_bias(scores, labels, class_order):
+    scores = np.asarray(scores, dtype=float)
+    labels = np.asarray(labels, dtype=int)
+    class_order = np.asarray(class_order, dtype=int)
+    bias = np.zeros(class_order.shape[0], dtype=float)
+    best = _bias_objective(scores, labels, class_order, bias)
+    for step in (1.0, 0.5, 0.25, 0.1, 0.05, 0.02):
+        improved = True
+        while improved:
+            improved = False
+            for column in range(bias.shape[0]):
+                for direction in (1.0, -1.0):
+                    candidate = bias.copy()
+                    candidate[column] += direction * step
+                    candidate -= np.mean(candidate)
+                    value = _bias_objective(scores, labels, class_order, candidate)
+                    if value > best + 1e-12:
+                        bias = candidate
+                        best = value
+                        improved = True
+    return bias, _balanced_accuracy_for_scores(scores + bias[None, :], labels, class_order)
+
+
+def _bias_objective(scores, labels, class_order, bias):
+    balanced = _balanced_accuracy_for_scores(scores + bias[None, :], labels, class_order)
+    return balanced - SCORE_CALIBRATION_L2 * float(np.mean(np.square(bias)))
+
+
+def _balanced_accuracy_for_scores(scores, labels, class_order):
+    predictions = np.asarray(class_order, dtype=int)[np.argmax(scores, axis=1)]
+    return float(_impl.balanced_accuracy_score(labels, predictions))
+
+
+def _align_class_score_columns(scores, score_classes, class_order):
+    scores = np.asarray(scores, dtype=float)
+    score_classes = np.asarray(score_classes, dtype=int).ravel()
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    if scores.ndim != 2:
+        return np.zeros((0, class_order.shape[0]), dtype=float)
+    if scores.shape[0] == 0 or scores.shape[1] == 0:
+        return np.zeros((scores.shape[0], class_order.shape[0]), dtype=float)
+    aligned = np.zeros((scores.shape[0], class_order.shape[0]), dtype=float)
+    finite_min = np.nanmin(np.where(np.isfinite(scores), scores, np.nan), axis=1)
+    finite_min = np.where(np.isfinite(finite_min), finite_min - 1.0, -1.0)
+    aligned[:] = finite_min[:, None]
+    class_to_column = {int(label): column for column, label in enumerate(class_order.tolist())}
+    for source_column, label in enumerate(score_classes.tolist()):
+        target_column = class_to_column.get(int(label))
+        if target_column is not None:
+            aligned[:, target_column] = scores[:, source_column]
+    return aligned
+
+
+def _candidate_model_scores(fitted_model, test_set, config):
+    scores, classes = _previous_candidate_model_scores(fitted_model, test_set, config)
+    return _apply_score_calibration(scores, classes, fitted_model)
+
+
+def _apply_score_calibration(scores, classes, fitted_model):
+    metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
+    if metadata.get("mode") != "inner_class_bias" or "bias" not in metadata:
+        return scores, classes
+    calibration_classes = np.asarray(metadata["classes"], dtype=int)
+    bias = np.asarray(metadata["bias"], dtype=float)
+    aligned = _align_class_score_columns(scores, classes, calibration_classes)
+    return aligned + bias[None, :], calibration_classes
+
+
+def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictions=True):
+    config = _normalized_config(config)
+    metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
+    if metadata.get("mode") != "inner_class_bias" or "bias" not in metadata:
+        outer_row, prediction_rows = _previous_score_outer_fold_model(fitted_model, test_set, config, include_predictions=include_predictions)
+        _add_next_fields(outer_row, config, fitted_model)
+        for row in prediction_rows:
+            _add_next_fields(row, config, fitted_model)
+        return outer_row, prediction_rows
+
+    outer_row, _unused = _previous_score_outer_fold_model(fitted_model, test_set, config, include_predictions=False)
+    test_features = _impl._normalized_subject_features(test_set, config)
+    alignment_model = _impl._fitted_alignment_model(fitted_model) if hasattr(_impl, "_fitted_alignment_model") else {"metadata": fitted_model.get("alignment_metadata", {})}
+    test_features, test_alignment_metadata = _align_test_features_by_subject(test_features, test_set, config, alignment_model)
+    class_scores, score_classes = _impl._model_class_scores(fitted_model["model_bundle"], test_features)
+    class_scores, score_classes = _apply_score_calibration(class_scores, score_classes, fitted_model)
+    test_labels = np.asarray(test_set.labels, dtype=int) - 1
+    predictions = np.asarray(score_classes, dtype=int)[np.argmax(class_scores, axis=1)]
+    rank_metrics = _impl._ranked_label_metrics(test_labels, class_scores, score_classes)
+    accuracy = float(_impl.accuracy_score(test_labels, predictions))
+    balanced_accuracy = float(_impl.balanced_accuracy_score(test_labels, predictions))
+    outer_row.update(
+        {
+            "accuracy": accuracy,
+            "percent": 100.0 * accuracy,
+            "balanced_accuracy": balanced_accuracy,
+            "balanced_percent": 100.0 * balanced_accuracy,
+            "top2_accuracy": rank_metrics["top2_accuracy"],
+            "top2_percent": 100.0 * rank_metrics["top2_accuracy"],
+            "top3_accuracy": rank_metrics["top3_accuracy"],
+            "top3_percent": 100.0 * rank_metrics["top3_accuracy"],
+            "mean_true_label_rank": rank_metrics["mean_true_label_rank"],
+            "median_true_label_rank": rank_metrics["median_true_label_rank"],
+            "above_chance": bool(balanced_accuracy > outer_row["chance_accuracy"]),
+            "alignment_test_transform": test_alignment_metadata.get("test_transform", ""),
+            "alignment_target_centering": test_alignment_metadata.get("target_centering", ""),
+        }
+    )
+    _add_next_fields(outer_row, config, fitted_model)
+    prediction_rows = []
+    if include_predictions:
+        prediction_rows = _prediction_rows(
+            test_set,
+            test_labels,
+            predictions,
+            rank_metrics["true_label_ranks"],
+            config=config,
+            actual_components_pca=fitted_model["model_bundle"].actual_components_pca,
+        )
+        for row in prediction_rows:
+            _add_next_fields(row, config, fitted_model)
+    return outer_row, prediction_rows
+
+
+def _prediction_rows(test_set, test_labels, predictions, true_label_ranks, *, config, actual_components_pca):
+    rows = _previous_prediction_rows(test_set, test_labels, predictions, true_label_ranks, config=config, actual_components_pca=actual_components_pca)
+    for row in rows:
+        _add_config_fields(row, config)
+    return rows
+
+
+def _add_config_fields(row, config):
+    row["sample_weighting"] = getattr(config, "sample_weighting", DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING)
+    row["score_calibration"] = getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION)
+    row["alignment_alpha"] = getattr(config, "alignment_alpha", DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA)
+
+
+def _add_next_fields(row, config, fitted_model):
+    _add_config_fields(row, config)
+    metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
+    row["score_calibration"] = metadata.get("mode", getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION))
+    row["score_calibration_inner_balanced_accuracy"] = metadata.get("inner_balanced_accuracy", "")
+    row["score_calibration_status"] = metadata.get("status", "")
+
+
+def _rank_nested_candidates(inner_rows):
+    ranked = _previous_rank_nested_candidates(inner_rows)
+    examples = {int(row["candidate_index"]): row for row in inner_rows}
+    for row in ranked:
+        example = examples.get(int(row["selected_candidate_index"]), {})
+        row["selected_sample_weighting"] = example.get("sample_weighting", DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING)
+        row["selected_score_calibration"] = example.get("score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION)
+        row["selected_alignment_alpha"] = example.get("alignment_alpha", DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA)
+    return ranked
+
+
+def summarize_cross_subject_stimulus_smoke(outer_rows, *, config=None):
+    rows = _previous_summarize_smoke(outer_rows, config=config)
+    config = _normalized_config(config or CrossSubjectStimulusConfig())
+    for row in rows:
+        _add_config_fields(row, config)
+    return rows
+
+
+def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations=10_000, signflip_seed=0):
+    rows = _previous_summarize_nested(outer_rows, signflip_permutations=signflip_permutations, signflip_seed=signflip_seed)
+    if not outer_rows:
+        return rows
+    for row in rows:
+        row["selected_sample_weighting_counts"] = _impl._format_counter(Counter(str(value.get("selected_sample_weighting", value.get("sample_weighting", ""))) for value in outer_rows))
+        row["selected_score_calibration_counts"] = _impl._format_counter(Counter(str(value.get("selected_score_calibration", value.get("score_calibration", ""))) for value in outer_rows))
+        row["selected_alignment_alpha_counts"] = _impl._format_counter(Counter(str(value.get("selected_alignment_alpha", value.get("alignment_alpha", ""))) for value in outer_rows))
+    return rows
+
+
+def _resolved_classifier_param(config):
+    classifier_param = config.classifier_param
+    if should_use_default_classifier_param(classifier_param):
+        classifier_param = get_default_classifier_param(config.classifier)
+    return classifier_param

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -14,7 +14,6 @@ from itertools import product
 
 import numpy as np
 from pymegdec.classifiers import get_default_classifier_param, should_use_default_classifier_param, train_multiclass_classifier
-from reptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
 
 DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING = "none"
 SAMPLE_WEIGHTING_MODES = ("none", "subject_class_balanced")
@@ -372,7 +371,7 @@ def _fit_outer_fold_model(train_sets, config, classifier_param, *, label_shuffle
     if fit_training_feature_transform is not None:
         train_features, feature_transform_metadata = fit_training_feature_transform(train_features, train_sets, config)
     train_window = _impl._centered_window(config.window_center, config.window_size)
-    model_bundle = fit_reptrace_window_model(
+    model_bundle = _impl.fit_reptrace_window_model(
         train_features,
         train_labels,
         fit_model=lambda features, labels: train_multiclass_classifier(

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 """Additional source-only and low-capacity calibration hooks for BUSH-MEG.
 
 This module intentionally patches the existing composed cross-subject module in

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -7,7 +7,7 @@ PyMEGDec-local registry entries that are useful for the stimulus benchmarks.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 import warnings
 
 import numpy as np
@@ -75,7 +75,8 @@ def _build_gaussian_naive_bayes(_features, _labels, classifier_param, _random_st
 
 
 def _build_regularized_qda(_features, _labels, classifier_param, _random_state):
-    reg_param = PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS["regularized-qda"] if classifier_param is None else float(classifier_param)
+    default_reg_param = cast(float, PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS["regularized-qda"])
+    reg_param = default_reg_param if classifier_param is None else float(classifier_param)
     if not 0.0 <= reg_param <= 1.0:
         raise ValueError("regularized-qda classifier_param must be a numeric regularization in [0, 1].")
     return QuadraticDiscriminantAnalysis(reg_param=reg_param)

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -8,12 +8,16 @@ PyMEGDec-local registry entries that are useful for the stimulus benchmarks.
 from __future__ import annotations
 
 from typing import Any
+import warnings
 
 import numpy as np
 import reptrace.decoding.classifiers as reptrace_classifiers
 from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
 from sklearn.linear_model import LogisticRegression
+from sklearn.svm import LinearSVC
+from sklearn.multiclass import OneVsOneClassifier, OneVsRestClassifier
 from sklearn.naive_bayes import GaussianNB
+from sklearn.pipeline import Pipeline
 
 from reptrace.decoding.classifiers import (
     ClassifierSpec,
@@ -47,6 +51,9 @@ PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS = {
     "multinomial-logistic-weighted": 1.0,
     "regularized-qda": 0.5,
     "shrinkage-prototype": 0.25,
+    "one-vs-one-linear-svm": 1.0,
+    "one-vs-rest-linear-svm": 1.0,
+    "ecoc-linear-svm": {"C": 1.0, "code_size": 2.0, "random_state": 0},
 }
 DEFAULT_CLASSIFIER_PARAMS = {
     **REPTRACE_DEFAULT_CLASSIFIER_PARAMS,
@@ -129,12 +136,113 @@ def _build_shrinkage_prototype(_features, _labels, classifier_param, _random_sta
     return ShrinkagePrototypeClassifier(shrinkage=_normalize_shrinkage_prototype_param(classifier_param))
 
 
+def _linear_svc(classifier_param, random_state):
+    return LinearSVC(C=float(classifier_param), max_iter=5000, random_state=random_state)
+
+
+def _build_one_vs_one_linear_svm(_features, _labels, classifier_param, random_state):
+    return OneVsOneClassifier(_linear_svc(classifier_param, random_state))
+
+
+def _build_one_vs_rest_linear_svm(_features, _labels, classifier_param, random_state):
+    return OneVsRestClassifier(_linear_svc(classifier_param, random_state))
+
+
+class SampleWeightedECOCLinearSVM:
+    """Small ECOC classifier with LinearSVC binary learners and sample weights.
+
+    scikit-learn's ``OutputCodeClassifier`` is convenient, but older supported
+    versions do not consistently propagate ``sample_weight``.  This local ECOC
+    implementation keeps the BUSH-MEG source-subject weighting experiments from
+    silently dropping weights.
+    """
+
+    def __init__(self, *, C: float = 1.0, code_size: float = 2.0, random_state: int | None = 0):
+        self.C = float(C)
+        self.code_size = float(code_size)
+        self.random_state = random_state
+        self.classes_: np.ndarray | None = None
+        self.code_book_: np.ndarray | None = None
+        self.models_: list[LinearSVC] | None = None
+
+    def fit(self, features, labels, sample_weight=None):
+        features = np.asarray(features, dtype=float)
+        labels = np.asarray(labels).ravel()
+        self.classes_ = np.unique(labels)
+        if self.classes_.size < 2:
+            raise ValueError("ECOC requires at least two classes.")
+        rng = np.random.default_rng(self.random_state)
+        n_bits = max(1, int(np.ceil(self.code_size * self.classes_.size)))
+        self.code_book_ = self._make_code_book(rng, self.classes_.size, n_bits)
+        class_to_index = {label: index for index, label in enumerate(self.classes_.tolist())}
+        encoded = np.asarray([class_to_index[label] for label in labels], dtype=int)
+        self.models_ = []
+        for bit_index in range(n_bits):
+            binary_labels = (self.code_book_[encoded, bit_index] > 0).astype(int)
+            model = LinearSVC(C=self.C, class_weight="balanced", max_iter=5000, random_state=None if self.random_state is None else int(self.random_state) + bit_index)
+            if sample_weight is None:
+                model.fit(features, binary_labels)
+            else:
+                model.fit(features, binary_labels, sample_weight=np.asarray(sample_weight, dtype=float))
+            self.models_.append(model)
+        return self
+
+    def decision_function(self, features):
+        if self.models_ is None or self.code_book_ is None:
+            raise RuntimeError("SampleWeightedECOCLinearSVM must be fitted before scoring.")
+        features = np.asarray(features, dtype=float)
+        margins = np.column_stack([model.decision_function(features) for model in self.models_])
+        distances = np.sum(np.square(margins[:, None, :] - self.code_book_[None, :, :]), axis=2)
+        return -distances
+
+    def predict(self, features):
+        if self.classes_ is None:
+            raise RuntimeError("SampleWeightedECOCLinearSVM must be fitted before prediction.")
+        return self.classes_[np.argmax(self.decision_function(features), axis=1)]
+
+    @staticmethod
+    def _make_code_book(rng, n_classes: int, n_bits: int) -> np.ndarray:
+        for _attempt in range(256):
+            code_book = rng.choice(np.asarray([-1.0, 1.0]), size=(n_classes, n_bits))
+            if np.unique(code_book, axis=0).shape[0] == n_classes and np.all(np.any(code_book > 0, axis=0)) and np.all(np.any(code_book < 0, axis=0)):
+                return code_book
+        # Deterministic fallback: one-vs-rest bits plus random extra bits.
+        code_book = -np.ones((n_classes, max(n_bits, n_classes)), dtype=float)
+        for class_index in range(n_classes):
+            code_book[class_index, class_index] = 1.0
+        if n_bits < n_classes:
+            return code_book[:, :n_bits]
+        return code_book
+
+
+def _normalize_ecoc_param(classifier_param, random_state):
+    if classifier_param is None:
+        classifier_param = PYMEGDEC_DEFAULT_CLASSIFIER_PARAMS["ecoc-linear-svm"]
+    if isinstance(classifier_param, dict):
+        C = float(classifier_param.get("C", 1.0))
+        code_size = float(classifier_param.get("code_size", 2.0))
+        seed = classifier_param.get("random_state", random_state)
+    else:
+        C = float(classifier_param)
+        code_size = 2.0
+        seed = random_state
+    return C, code_size, None if seed is None else int(seed)
+
+
+def _build_ecoc_linear_svm(_features, _labels, classifier_param, random_state):
+    C, code_size, seed = _normalize_ecoc_param(classifier_param, random_state)
+    return SampleWeightedECOCLinearSVM(C=C, code_size=code_size, random_state=seed)
+
+
 CLASSIFIER_REGISTRY = {
     **REPTRACE_CLASSIFIER_REGISTRY,
     "gaussian-naive-bayes": ClassifierSpec(_build_gaussian_naive_bayes),
     "multinomial-logistic-weighted": ClassifierSpec(_build_weighted_multinomial_logistic),
     "regularized-qda": ClassifierSpec(_build_regularized_qda),
     "shrinkage-prototype": ClassifierSpec(_build_shrinkage_prototype),
+    "one-vs-one-linear-svm": ClassifierSpec(_build_one_vs_one_linear_svm),
+    "one-vs-rest-linear-svm": ClassifierSpec(_build_one_vs_rest_linear_svm),
+    "ecoc-linear-svm": ClassifierSpec(_build_ecoc_linear_svm),
 }
 
 __all__ = [
@@ -144,6 +252,7 @@ __all__ = [
     "CorrelationPrototypeClassifier",
     "DecodedLabelClassifier",
     "ShrinkagePrototypeClassifier",
+    "SampleWeightedECOCLinearSVM",
     "_build_pytorch_data_loaders",
     "get_default_classifier_param",
     "positive_class_score",
@@ -169,6 +278,26 @@ def get_default_classifier_param(classifier: str) -> Any:
     return get_reptrace_default_classifier_param(classifier)
 
 
+def _fit_with_optional_sample_weight(model, features, labels, sample_weight=None):
+    if sample_weight is None:
+        return model.fit(features, labels)
+    sample_weight = np.asarray(sample_weight, dtype=float).ravel()
+    if sample_weight.shape[0] != np.asarray(labels).shape[0]:
+        raise ValueError("sample_weight must contain one value per training row.")
+    try:
+        if isinstance(model, Pipeline):
+            final_step_name = model.steps[-1][0]
+            return model.fit(features, labels, **{f"{final_step_name}__sample_weight": sample_weight})
+        return model.fit(features, labels, sample_weight=sample_weight)
+    except TypeError:
+        warnings.warn(
+            f"Classifier {model.__class__.__name__} does not accept sample_weight; fitting without weights.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return model.fit(features, labels)
+
+
 def train_classifier(
     features,
     labels,
@@ -177,17 +306,24 @@ def train_classifier(
     random_state: int | None = None,
     *,
     registry: dict[str, ClassifierSpec] | None = None,
+    sample_weight=None,
 ):
     """Build and fit a classifier from the PyMEGDec-extended registry."""
 
-    return reptrace_classifiers.train_classifier(
-        features,
-        labels,
-        classifier,
-        classifier_param,
-        random_state=random_state,
-        registry=CLASSIFIER_REGISTRY if registry is None else registry,
-    )
+    registry = CLASSIFIER_REGISTRY if registry is None else registry
+    features = np.asarray(features)
+    labels = np.asarray(labels).ravel()
+    try:
+        classifier_spec = registry[classifier]
+    except KeyError:
+        # Preserve upstream error text for callers that rely on it.
+        return reptrace_classifiers.train_classifier(features, labels, classifier, classifier_param, random_state=random_state, registry=registry)
+    model = classifier_spec.builder(features, labels, classifier_param, random_state)
+    if classifier_spec.fits_in_builder:
+        if sample_weight is not None:
+            warnings.warn(f"Classifier {classifier!r} fits inside its builder; sample_weight was not passed.", RuntimeWarning, stacklevel=2)
+        return model
+    return _fit_with_optional_sample_weight(model, features, labels, sample_weight=sample_weight)
 
 
 def train_multiclass_classifier(
@@ -198,6 +334,7 @@ def train_multiclass_classifier(
     random_state: int | None = None,
     *,
     registry: dict[str, ClassifierSpec] | None = None,
+    sample_weight=None,
 ):
     """Train a multiclass classifier from the PyMEGDec-extended registry."""
 
@@ -209,6 +346,7 @@ def train_multiclass_classifier(
         classifier_param,
         random_state=random_state,
         registry=CLASSIFIER_REGISTRY if registry is None else registry,
+        sample_weight=sample_weight,
     )
     return DecodedLabelClassifier(model, classes)
 

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Sequence
 
 from pymegdec import alpha_cli, neureptrace_compat
 from pymegdec import cli as legacy_cli
-from pymegdec import stimulus_cli, stimulus_full_epoch_lowrank, stimulus_hyperalignment, stimulus_mcca
+from pymegdec import stimulus_cli, stimulus_cue_low_capacity, stimulus_full_epoch_lowrank, stimulus_hyperalignment, stimulus_mcca
 from pymegdec.neureptrace_dataset_spec import write_neureptrace_dataset_spec
 from pymegdec.synthetic_data_cli import make_synthetic_data
 
@@ -32,6 +32,7 @@ def _dispatch_group(group: str, description: str, handlers: dict[str, CommandHan
 def _stimulus_handlers() -> dict[str, CommandHandler]:
     return {
         "cross-subject-cue-calibrated": stimulus_cli.stimulus_cross_subject_cue_calibrated,
+        "cross-subject-cue-low-capacity": stimulus_cue_low_capacity.stimulus_cross_subject_cue_low_capacity,
         "cross-subject-full-epoch-lowrank": stimulus_full_epoch_lowrank.stimulus_cross_subject_full_epoch_lowrank,
         "cross-subject-hyperalignment": stimulus_hyperalignment.stimulus_cross_subject_hyperalignment,
         "cross-subject-mcca": stimulus_mcca.stimulus_cross_subject_mcca,
@@ -72,6 +73,7 @@ def _top_level_handlers() -> dict[str, CommandHandler]:
         # Backward-compatible top-level aliases. Prefer grouped forms in new docs.
         "stimulus-decoding": legacy_cli.stimulus_decoding,
         "stimulus-cross-subject-cue-calibrated": stimulus_cli.stimulus_cross_subject_cue_calibrated,
+        "stimulus-cross-subject-cue-low-capacity": stimulus_cue_low_capacity.stimulus_cross_subject_cue_low_capacity,
         "stimulus-cross-subject-full-epoch-lowrank": stimulus_full_epoch_lowrank.stimulus_cross_subject_full_epoch_lowrank,
         "stimulus-cross-subject-hyperalignment": stimulus_hyperalignment.stimulus_cross_subject_hyperalignment,
         "stimulus-cross-subject-mcca": stimulus_mcca.stimulus_cross_subject_mcca,

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -27,6 +27,7 @@ from pymegdec.stimulus_cue_calibration import (
     export_cross_subject_cue_calibrated_stimulus,
 )
 from pymegdec.stimulus_cross_subject import (
+    DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA,
     ALIGNMENT_MODES,
     DEFAULT_CROSS_SUBJECT_ALIGNMENT,
     DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW,
@@ -39,6 +40,8 @@ from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION,
     DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED,
     DEFAULT_CROSS_SUBJECT_PARTICIPANTS,
+    DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING,
+    DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION,
     FEATURE_MODES,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_TEMPERATURE,
@@ -50,6 +53,8 @@ from pymegdec.stimulus_cross_subject import (
     ENSEMBLE_SCORE_NORMALIZATION_MODES,
     NORMALIZATION_MODES,
     SELECTION_ENSEMBLE_DIVERSITY_MODES,
+    SAMPLE_WEIGHTING_MODES,
+    SCORE_CALIBRATION_MODES,
     SELECTION_ENSEMBLE_WEIGHTING_MODES,
     AUTO_CLASSIFIER_PARAM_GRID_TOKEN,
     AUTO_COMPONENTS_PCA_GRID_TOKEN,
@@ -142,6 +147,14 @@ def _parse_normalization_list(value: str) -> tuple[str, ...]:
 
 def _parse_alignment_list(value: str) -> tuple[str, ...]:
     return tuple(_alignment_token(token) for token in _parse_token_list(value))
+
+
+def _parse_sample_weighting_list(value: str) -> tuple[str, ...]:
+    return tuple(token.strip().lower().replace("-", "_") for token in _parse_token_list(value))
+
+
+def _parse_score_calibration_list(value: str) -> tuple[str, ...]:
+    return tuple(token.strip().lower().replace("-", "_") for token in _parse_token_list(value))
 
 
 def _parse_int_or_inf_list(value: str) -> tuple[int | float | str, ...]:
@@ -295,6 +308,19 @@ def _build_cross_subject_smoke_parser(prog: str | None = None) -> argparse.Argum
     parser.add_argument("--classifier-param", default=None, help="Classifier parameter value, JSON, Python literal, numeric value, or nan.")
     parser.add_argument("--components-pca", type=parse_int_or_inf, default=DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA, help="Number of PCA components, or inf.")
     parser.add_argument(
+        "--sample-weighting",
+        choices=SAMPLE_WEIGHTING_MODES,
+        default=DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING,
+        help="Optional pooled-source sample weighting policy.",
+    )
+    parser.add_argument(
+        "--score-calibration",
+        choices=SCORE_CALIBRATION_MODES,
+        default=DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION,
+        help="Optional inner-source calibration of class-score biases before outer scoring.",
+    )
+    parser.add_argument("--alignment-alpha", type=float, default=DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA, help="Blend factor for non-none alignment; 0 keeps raw features, 1 applies full alignment.")
+    parser.add_argument(
         "--max-trials-per-class-per-participant",
         type=int,
         default=None,
@@ -342,6 +368,9 @@ def stimulus_cross_subject_smoke(argv: Sequence[str] | None = None, prog: str | 
         classifier=args.classifier,
         classifier_param=parse_classifier_param(args.classifier_param),
         components_pca=args.components_pca,
+        sample_weighting=args.sample_weighting,
+        score_calibration=args.score_calibration,
+        alignment_alpha=args.alignment_alpha,
         max_trials_per_class_per_participant=args.max_trials_per_class_per_participant,
         trial_selection=args.trial_selection,
         trial_selection_seed=args.trial_selection_seed,
@@ -583,6 +612,24 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
         help="Comma-separated PCA component counts, or inf.",
     )
     parser.add_argument(
+        "--sample-weightings",
+        type=_parse_sample_weighting_list,
+        default=(DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING,),
+        help="Comma-separated sample weighting modes, e.g. none,subject_class_balanced.",
+    )
+    parser.add_argument(
+        "--score-calibrations",
+        type=_parse_score_calibration_list,
+        default=(DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION,),
+        help="Comma-separated score calibration modes, e.g. none,inner_class_bias.",
+    )
+    parser.add_argument(
+        "--alignment-alphas",
+        type=parse_float_list,
+        default=(DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA,),
+        help="Comma-separated alignment blend factors in [0,1].",
+    )
+    parser.add_argument(
         "--max-trials-per-class-per-participant",
         type=int,
         default=None,
@@ -671,6 +718,9 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         classifiers=args.classifiers,
         classifier_params=args.classifier_params,
         components_pca_values=args.components_pca_values,
+        sample_weightings=args.sample_weightings,
+        score_calibrations=args.score_calibrations,
+        alignment_alphas=args.alignment_alphas,
         max_trials_per_class_per_participant=args.max_trials_per_class_per_participant,
         trial_selection=args.trial_selection,
         trial_selection_seed=args.trial_selection_seed,

--- a/src/pymegdec/stimulus_cross_subject.py
+++ b/src/pymegdec/stimulus_cross_subject.py
@@ -7,9 +7,11 @@ import sys
 from pymegdec import _stimulus_cross_subject_core as _core
 from pymegdec import _stimulus_cross_subject_timefix as _timefix  # noqa: F401
 from pymegdec import _stimulus_cross_subject_chance as _chance  # noqa: F401
+from pymegdec import _stimulus_cross_subject_next as _next
 from pymegdec._reptrace_score_overrides import install_cross_subject
 
 _impl = _core._impl
 install_cross_subject(_impl)
+_next.install(_impl)
 sys.modules[__name__] = _impl
 globals().update(_impl.__dict__)

--- a/src/pymegdec/stimulus_cue_low_capacity.py
+++ b/src/pymegdec/stimulus_cue_low_capacity.py
@@ -1,0 +1,429 @@
+"""Low-capacity cue/localizer calibration for cross-subject stimulus decoding."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import scipy.io as sio
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+from pymegdec.cli import normalize_argv, parse_classifier_param, parse_float_or_inf, parse_int_or_inf
+from pymegdec.data_config import resolve_data_folder
+from pymegdec.reaction_time_analysis import parse_participant_spec
+from pymegdec import stimulus_cross_subject as cross_subject
+from pymegdec.stimulus_cue_calibration import load_participant_cue_calibration_features
+from pymegdec.stimulus_cross_subject import CrossSubjectStimulusConfig
+from pymegdec.classifiers import get_default_classifier_param, should_use_default_classifier_param
+
+CUE_LOW_CAPACITY_MODES = ("latency_shift", "expert_mixture")
+DEFAULT_CUE_LATENCY_PEAK_WINDOW = (-0.05, 0.35)
+DEFAULT_MAX_LATENCY_SHIFT_S = 0.05
+DEFAULT_EXPERT_TOP_K = 8
+DEFAULT_EXPERT_TEMPERATURE = 0.25
+
+
+def evaluate_cross_subject_cue_latency_stimulus(  # pylint: disable=too-many-arguments
+    data_folder,
+    participants,
+    *,
+    decode_config=None,
+    outer_participants=None,
+    cue_peak_window=DEFAULT_CUE_LATENCY_PEAK_WINDOW,
+    max_latency_shift_s=DEFAULT_MAX_LATENCY_SHIFT_S,
+    progress=None,
+):
+    """Run LOSO decoding after cue-derived window-center shifts only.
+
+    This uses cue data only to estimate each subject's global cue response peak.
+    It does not fit a spatial transform, and it never uses main-task target labels.
+    """
+
+    decode_config = cross_subject._normalized_config(decode_config or CrossSubjectStimulusConfig())  # pylint: disable=protected-access
+    data_folder = resolve_data_folder(data_folder)
+    participants = tuple(int(participant) for participant in participants)
+    outer_participants = _normalize_outer_participants(participants, outer_participants)
+    classifier_param = _resolved_classifier_param(decode_config)
+    cue_peaks = {participant: estimate_cue_peak_latency(data_folder, participant, peak_window=cue_peak_window) for participant in participants}
+
+    outer_rows = []
+    prediction_rows = []
+    for test_participant in outer_participants:
+        train_participants = tuple(participant for participant in participants if participant != test_participant)
+        reference_peak = float(np.median([cue_peaks[participant] for participant in train_participants]))
+        shifted_sets = {}
+        for participant in participants:
+            shift = float(np.clip(reference_peak - cue_peaks[participant], -max_latency_shift_s, max_latency_shift_s))
+            participant_config = replace(decode_config, window_center=decode_config.window_center + shift)
+            shifted_sets[participant] = cross_subject.load_participant_stimulus_features(data_folder, participant, config=participant_config)
+        train_sets = [shifted_sets[participant] for participant in train_participants]
+        test_set = shifted_sets[test_participant]
+        outer_row, participant_predictions = cross_subject._evaluate_outer_fold(  # pylint: disable=protected-access
+            train_sets,
+            test_set,
+            config=decode_config,
+            classifier_param=classifier_param,
+        )
+        extra = _latency_fields(test_participant, cue_peaks[test_participant], reference_peak, reference_peak - cue_peaks[test_participant], max_latency_shift_s)
+        outer_row.update(extra)
+        for row in participant_predictions:
+            row.update(extra)
+        outer_rows.append(outer_row)
+        prediction_rows.extend(participant_predictions)
+        if progress is not None:
+            progress(f"DONE cue_latency outer_test_participant={test_participant} balanced_accuracy={outer_row['balanced_accuracy']:.4f}")
+    return _assemble_artifacts(outer_rows, prediction_rows, decode_config, mode="latency_shift")
+
+
+def evaluate_cross_subject_cue_expert_mixture_stimulus(  # pylint: disable=too-many-arguments,too-many-locals
+    data_folder,
+    participants,
+    *,
+    decode_config=None,
+    cue_config=None,
+    outer_participants=None,
+    top_k=DEFAULT_EXPERT_TOP_K,
+    temperature=DEFAULT_EXPERT_TEMPERATURE,
+    progress=None,
+):
+    """Train source-subject experts and weight them by cue similarity to target."""
+
+    decode_config = cross_subject._normalized_config(decode_config or CrossSubjectStimulusConfig())  # pylint: disable=protected-access
+    cue_config = cross_subject._normalized_config(cue_config or replace(decode_config, alignment="none"))  # pylint: disable=protected-access
+    data_folder = resolve_data_folder(data_folder)
+    participants = tuple(int(participant) for participant in participants)
+    outer_participants = _normalize_outer_participants(participants, outer_participants)
+    classifier_param = _resolved_classifier_param(decode_config)
+    main_sets = {participant: cross_subject.load_participant_stimulus_features(data_folder, participant, config=decode_config) for participant in participants}
+    cue_sets = {participant: load_participant_cue_calibration_features(data_folder, participant, config=cue_config) for participant in participants}
+
+    outer_rows = []
+    prediction_rows = []
+    for test_participant in outer_participants:
+        source_participants = tuple(participant for participant in participants if participant != test_participant)
+        similarities = np.asarray([_cue_pattern_similarity(cue_sets[participant], cue_sets[test_participant]) for participant in source_participants], dtype=float)
+        selected_positions = _top_k_positions(similarities, min(int(top_k), len(source_participants)))
+        selected_participants = tuple(source_participants[index] for index in selected_positions)
+        weights = _softmax_weights(similarities[selected_positions], temperature=float(temperature))
+        fitted_models = [
+            cross_subject._fit_outer_fold_model(  # pylint: disable=protected-access
+                [main_sets[participant]],
+                decode_config,
+                classifier_param,
+                fit_score_calibration=False,
+            )
+            for participant in selected_participants
+        ]
+        selected_rows = [
+            {
+                "selected_candidate_index": int(participant),
+                "selected_inner_balanced_accuracy_mean": float(similarity),
+                "selected_inner_balanced_accuracy_sem": 0.0,
+            }
+            for participant, similarity in zip(selected_participants, similarities[selected_positions], strict=True)
+        ]
+        outer_row, participant_predictions = cross_subject._score_outer_fold_ensemble_models(  # pylint: disable=protected-access
+            fitted_models,
+            [main_sets[test_participant]] * len(fitted_models),
+            [decode_config] * len(fitted_models),
+            selected_rows,
+            ensemble_weights=weights,
+            ensemble_weighting="uniform",
+            ensemble_temperature=temperature,
+            ensemble_score_normalization="row_z_softmax",
+            include_predictions=True,
+        )
+        extra = _expert_fields(test_participant, selected_participants, weights, similarities[selected_positions], top_k, temperature)
+        outer_row.update(extra)
+        for row in participant_predictions:
+            row.update(extra)
+        outer_rows.append(outer_row)
+        prediction_rows.extend(participant_predictions)
+        if progress is not None:
+            progress(f"DONE cue_expert_mixture outer_test_participant={test_participant} balanced_accuracy={outer_row['balanced_accuracy']:.4f}")
+    return _assemble_artifacts(outer_rows, prediction_rows, decode_config, mode="expert_mixture")
+
+
+def export_cross_subject_cue_low_capacity_stimulus(  # pylint: disable=too-many-arguments
+    data_folder,
+    participants,
+    *,
+    mode,
+    outer_output_path,
+    group_summary_output_path=None,
+    predictions_output_path=None,
+    confusion_output_path=None,
+    per_stimulus_output_path=None,
+    confusion_pairs_output_path=None,
+    decode_config=None,
+    cue_config=None,
+    outer_participants=None,
+    cue_peak_window=DEFAULT_CUE_LATENCY_PEAK_WINDOW,
+    max_latency_shift_s=DEFAULT_MAX_LATENCY_SHIFT_S,
+    expert_top_k=DEFAULT_EXPERT_TOP_K,
+    expert_temperature=DEFAULT_EXPERT_TEMPERATURE,
+    progress=None,
+):
+    mode = _normalize_mode(mode)
+    if mode == "latency_shift":
+        artifacts = evaluate_cross_subject_cue_latency_stimulus(
+            data_folder,
+            participants,
+            decode_config=decode_config,
+            outer_participants=outer_participants,
+            cue_peak_window=cue_peak_window,
+            max_latency_shift_s=max_latency_shift_s,
+            progress=progress,
+        )
+    else:
+        artifacts = evaluate_cross_subject_cue_expert_mixture_stimulus(
+            data_folder,
+            participants,
+            decode_config=decode_config,
+            cue_config=cue_config,
+            outer_participants=outer_participants,
+            top_k=expert_top_k,
+            temperature=expert_temperature,
+            progress=progress,
+        )
+    write_alpha_metrics_csv(artifacts["outer"], outer_output_path)
+    if group_summary_output_path:
+        write_alpha_metrics_csv(artifacts["group_summary"], group_summary_output_path)
+    if predictions_output_path:
+        write_alpha_metrics_csv(artifacts["predictions"], predictions_output_path)
+    if confusion_output_path:
+        write_alpha_metrics_csv(artifacts["confusion"], confusion_output_path)
+    if per_stimulus_output_path:
+        write_alpha_metrics_csv(artifacts["per_stimulus"], per_stimulus_output_path)
+    if confusion_pairs_output_path and artifacts["confusion_pairs"]:
+        write_alpha_metrics_csv(artifacts["confusion_pairs"], confusion_pairs_output_path)
+    return artifacts
+
+
+def estimate_cue_peak_latency(data_folder, participant, *, peak_window=DEFAULT_CUE_LATENCY_PEAK_WINDOW):
+    data_path = Path(resolve_data_folder(data_folder)) / f"Part{int(participant)}CueData.mat"
+    data = sio.loadmat(data_path)["data"][0]
+    time = cross_subject._time_vector(data, 0)  # pylint: disable=protected-access
+    mask = cross_subject._time_mask(time, peak_window)  # pylint: disable=protected-access
+    accumulator = np.zeros(int(np.sum(mask)), dtype=float)
+    n_trials = cross_subject._count_trials(data)  # pylint: disable=protected-access
+    for trial_idx in range(n_trials):
+        signal = cross_subject._trial_signal(data, trial_idx)[:, mask]  # pylint: disable=protected-access
+        accumulator += np.sqrt(np.mean(np.square(signal), axis=0))
+    mean_rms = accumulator / max(n_trials, 1)
+    return float(time[mask][int(np.argmax(mean_rms))])
+
+
+def _cue_pattern_similarity(source_set, target_set):
+    source_labels = np.asarray(source_set.labels, dtype=int)
+    target_labels = np.asarray(target_set.labels, dtype=int)
+    common = tuple(sorted(set(source_labels.tolist()) & set(target_labels.tolist())))
+    if len(common) < 2:
+        return 0.0
+    source = np.concatenate([np.mean(source_set.features[source_labels == label], axis=0) for label in common])
+    target = np.concatenate([np.mean(target_set.features[target_labels == label], axis=0) for label in common])
+    source = source - np.mean(source)
+    target = target - np.mean(target)
+    denom = float(np.linalg.norm(source) * np.linalg.norm(target))
+    if denom <= 1e-12:
+        return 0.0
+    return float(np.dot(source, target) / denom)
+
+
+def _top_k_positions(values, k):
+    values = np.asarray(values, dtype=float)
+    order = np.argsort(-values, kind="mergesort")
+    return order[: int(k)]
+
+
+def _softmax_weights(values, temperature):
+    values = np.asarray(values, dtype=float)
+    if values.size == 0 or not np.all(np.isfinite(values)):
+        return np.full(values.size, 1.0 / max(values.size, 1), dtype=float)
+    temperature = max(float(temperature), 1e-6)
+    logits = (values - np.max(values)) / temperature
+    weights = np.exp(np.clip(logits, -50.0, 50.0))
+    return weights / np.sum(weights)
+
+
+def _latency_fields(participant, peak, reference_peak, shift, max_shift):
+    clipped_shift = float(np.clip(shift, -max_shift, max_shift))
+    return {
+        "cue_low_capacity_mode": "latency_shift",
+        "calibration_data": "cue",
+        "calibration_alignment": "latency_shift",
+        "target_calibration_participant": int(participant),
+        "cue_latency_peak_s": float(peak),
+        "cue_latency_reference_peak_s": float(reference_peak),
+        "cue_latency_shift_s": clipped_shift,
+        "cue_latency_max_shift_s": float(max_shift),
+    }
+
+
+def _expert_fields(participant, selected_participants, weights, similarities, top_k, temperature):
+    return {
+        "cue_low_capacity_mode": "expert_mixture",
+        "calibration_data": "cue",
+        "calibration_alignment": "source_expert_weighting",
+        "target_calibration_participant": int(participant),
+        "cue_expert_top_k": int(top_k),
+        "cue_expert_temperature": float(temperature),
+        "cue_expert_participants": ";".join(str(int(value)) for value in selected_participants),
+        "cue_expert_weights": ";".join(f"{int(participant)}:{float(weight):.6g}" for participant, weight in zip(selected_participants, weights, strict=True)),
+        "cue_expert_similarities": ";".join(f"{int(participant)}:{float(value):.6g}" for participant, value in zip(selected_participants, similarities, strict=True)),
+    }
+
+
+def _assemble_artifacts(outer_rows, prediction_rows, decode_config, *, mode):
+    group_summary_rows = cross_subject.summarize_cross_subject_stimulus_smoke(outer_rows, config=decode_config)
+    for row in group_summary_rows:
+        row["cue_low_capacity_mode"] = mode
+        row["calibration_data"] = "cue"
+    confusion_rows, per_stimulus_rows = cross_subject.summarize_cross_subject_predictions(prediction_rows)
+    confusion_pair_rows = cross_subject.summarize_cross_subject_confusion_pairs(prediction_rows)
+    return {
+        "outer": outer_rows,
+        "predictions": prediction_rows,
+        "group_summary": group_summary_rows,
+        "confusion": confusion_rows,
+        "per_stimulus": per_stimulus_rows,
+        "confusion_pairs": confusion_pair_rows,
+    }
+
+
+def _normalize_outer_participants(participants, outer_participants):
+    if outer_participants is None:
+        return tuple(participants)
+    outer_participants = tuple(int(participant) for participant in outer_participants)
+    unknown = sorted(set(outer_participants) - set(participants))
+    if unknown:
+        raise ValueError(f"Outer participants must be part of participants: {unknown}")
+    return outer_participants
+
+
+def _normalize_mode(mode):
+    token = str(mode).strip().lower().replace("-", "_")
+    if token not in CUE_LOW_CAPACITY_MODES:
+        raise ValueError(f"mode must be one of {CUE_LOW_CAPACITY_MODES}.")
+    return token
+
+
+def _resolved_classifier_param(config):
+    classifier_param = config.classifier_param
+    if should_use_default_classifier_param(classifier_param):
+        return get_default_classifier_param(config.classifier)
+    return classifier_param
+
+
+def _parse_time_window(value: str) -> tuple[float, float]:
+    parts = tuple(float(token.strip()) for token in value.split(",", maxsplit=1))
+    if len(parts) != 2 or parts[0] > parts[1]:
+        raise argparse.ArgumentTypeError("Time window must have the form start,stop with start <= stop.")
+    return parts
+
+
+def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Run low-capacity cue-calibrated LOSO stimulus decoding.")
+    parser.add_argument("--data-dir", dest="data_folder", default=None, help="Directory containing Part*Data.mat and Part*CueData.mat files.")
+    parser.add_argument("--participants", default=cross_subject.DEFAULT_CROSS_SUBJECT_PARTICIPANTS, help="Participant ids such as 1-4,6,8.")
+    parser.add_argument("--outer-participants", default=None, help="Optional held-out participant ids to evaluate in this run.")
+    parser.add_argument("--mode", choices=CUE_LOW_CAPACITY_MODES, default="latency_shift")
+    parser.add_argument("--window-center", type=float, default=cross_subject.DEFAULT_CROSS_SUBJECT_WINDOW_CENTER)
+    parser.add_argument("--window-size", type=float, default=cross_subject.DEFAULT_CROSS_SUBJECT_WINDOW_SIZE)
+    parser.add_argument("--baseline-window", type=_parse_time_window, default=cross_subject.DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW)
+    parser.add_argument("--feature-mode", default=cross_subject.DEFAULT_CROSS_SUBJECT_FEATURE_MODE, choices=cross_subject.FEATURE_MODES)
+    parser.add_argument("--normalization", default=cross_subject.DEFAULT_CROSS_SUBJECT_NORMALIZATION, choices=cross_subject.NORMALIZATION_MODES)
+    parser.add_argument("--classifier", default=cross_subject.DEFAULT_CROSS_SUBJECT_CLASSIFIER)
+    parser.add_argument("--classifier-param", default=None)
+    parser.add_argument("--components-pca", type=parse_int_or_inf, default=cross_subject.DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA)
+    parser.add_argument("--sample-weighting", default=cross_subject.DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING, choices=cross_subject.SAMPLE_WEIGHTING_MODES)
+    parser.add_argument("--score-calibration", default=cross_subject.DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION, choices=cross_subject.SCORE_CALIBRATION_MODES)
+    parser.add_argument("--alignment-alpha", type=float, default=cross_subject.DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA)
+    parser.add_argument("--max-trials-per-class-per-participant", type=int, default=None)
+    parser.add_argument("--chance-classes", type=int, default=cross_subject.DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES)
+    parser.add_argument("--random-state", type=int, default=0)
+    parser.add_argument("--signflip-permutations", type=int, default=10000)
+    parser.add_argument("--signflip-seed", type=int, default=0)
+    parser.add_argument("--cue-window-center", type=float, default=None)
+    parser.add_argument("--cue-window-size", type=float, default=None)
+    parser.add_argument("--cue-baseline-window", type=_parse_time_window, default=None)
+    parser.add_argument("--cue-feature-mode", default=None, choices=cross_subject.FEATURE_MODES)
+    parser.add_argument("--cue-normalization", default=None, choices=cross_subject.NORMALIZATION_MODES)
+    parser.add_argument("--latency-peak-window", type=_parse_time_window, default=DEFAULT_CUE_LATENCY_PEAK_WINDOW)
+    parser.add_argument("--max-latency-shift-s", type=float, default=DEFAULT_MAX_LATENCY_SHIFT_S)
+    parser.add_argument("--expert-top-k", type=int, default=DEFAULT_EXPERT_TOP_K)
+    parser.add_argument("--expert-temperature", type=float, default=DEFAULT_EXPERT_TEMPERATURE)
+    parser.add_argument("--outer-output", default="outputs/stimulus_cross_subject_cue_low_capacity_outer.csv")
+    parser.add_argument("--summary-output", default="outputs/stimulus_cross_subject_cue_low_capacity_group_summary.csv")
+    parser.add_argument("--predictions-output", default="outputs/stimulus_cross_subject_cue_low_capacity_predictions.csv")
+    parser.add_argument("--confusion-output", default="outputs/stimulus_cross_subject_cue_low_capacity_confusion.csv")
+    parser.add_argument("--per-stimulus-output", default="outputs/stimulus_cross_subject_cue_low_capacity_per_stimulus.csv")
+    parser.add_argument("--confusion-pairs-output", default="outputs/stimulus_cross_subject_cue_low_capacity_confusion_pairs.csv")
+    return parser
+
+
+def stimulus_cross_subject_cue_low_capacity(argv=None, prog=None) -> int:
+    parser = _build_parser(prog=prog)
+    args = parser.parse_args(normalize_argv(argv))
+    decode_config = CrossSubjectStimulusConfig(
+        window_center=args.window_center,
+        window_size=args.window_size,
+        baseline_window=args.baseline_window,
+        feature_mode=args.feature_mode,
+        normalization=args.normalization,
+        alignment="none",
+        classifier=args.classifier,
+        classifier_param=parse_classifier_param(args.classifier_param),
+        components_pca=args.components_pca,
+        max_trials_per_class_per_participant=args.max_trials_per_class_per_participant,
+        sample_weighting=args.sample_weighting,
+        score_calibration=args.score_calibration,
+        alignment_alpha=args.alignment_alpha,
+        chance_classes=args.chance_classes,
+        random_state=args.random_state,
+        signflip_permutations=args.signflip_permutations,
+        signflip_seed=args.signflip_seed,
+    )
+    cue_config = replace(
+        decode_config,
+        window_center=args.cue_window_center if args.cue_window_center is not None else args.window_center,
+        window_size=args.cue_window_size if args.cue_window_size is not None else args.window_size,
+        baseline_window=args.cue_baseline_window if args.cue_baseline_window is not None else args.baseline_window,
+        feature_mode=args.cue_feature_mode if args.cue_feature_mode is not None else args.feature_mode,
+        normalization=args.cue_normalization if args.cue_normalization is not None else args.normalization,
+        score_calibration="none",
+    )
+    participants = parse_participant_spec(args.participants)
+    outer_participants = parse_participant_spec(args.outer_participants) if args.outer_participants else None
+    artifacts = export_cross_subject_cue_low_capacity_stimulus(
+        resolve_data_folder(args.data_folder),
+        participants,
+        mode=args.mode,
+        outer_output_path=args.outer_output,
+        group_summary_output_path=args.summary_output,
+        predictions_output_path=args.predictions_output,
+        confusion_output_path=args.confusion_output,
+        per_stimulus_output_path=args.per_stimulus_output,
+        confusion_pairs_output_path=args.confusion_pairs_output,
+        decode_config=decode_config,
+        cue_config=cue_config,
+        outer_participants=outer_participants,
+        cue_peak_window=args.latency_peak_window,
+        max_latency_shift_s=args.max_latency_shift_s,
+        expert_top_k=args.expert_top_k,
+        expert_temperature=args.expert_temperature,
+        progress=lambda message: print(message, flush=True),
+    )
+    print(f"Wrote {len(artifacts['outer'])} cue-low-capacity held-out participant rows to {args.outer_output}")
+    print(f"Wrote {len(artifacts['group_summary'])} group summary rows to {args.summary_output}")
+    print(f"Wrote {len(artifacts['predictions'])} trial prediction rows to {args.predictions_output}")
+    return 0
+
+
+def main(argv=None) -> int:
+    return stimulus_cross_subject_cue_low_capacity(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pymegdec/stimulus_cue_low_capacity.py
+++ b/src/pymegdec/stimulus_cue_low_capacity.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import numpy as np
 import scipy.io as sio
 from pymegdec.alpha_metrics import write_alpha_metrics_csv
-from pymegdec.cli import normalize_argv, parse_classifier_param, parse_float_or_inf, parse_int_or_inf
+from pymegdec.cli import normalize_argv, parse_classifier_param, parse_int_or_inf
 from pymegdec.data_config import resolve_data_folder
 from pymegdec.reaction_time_analysis import parse_participant_spec
 from pymegdec import stimulus_cross_subject as cross_subject

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -1,0 +1,105 @@
+import re
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from pymegdec import stimulus_cross_subject as cross_subject
+from pymegdec.stimulus_cross_subject import CrossSubjectStimulusConfig, load_participant_stimulus_features, make_cross_subject_candidate_configs
+from tests.matlab_fixtures import cell_array
+
+
+def _mat_data_from_trials(labels, trials, time):
+    return {
+        "trial": cell_array([np.asarray(trial, dtype=float) for trial in trials]),
+        "time": cell_array([np.asarray(time, dtype=float) for _ in trials]),
+        "trialinfo": np.array([[np.asarray(labels, dtype=int)]], dtype=object),
+    }
+
+
+def _loadmat_side_effect(data_by_participant):
+    def loadmat(path):
+        match = re.search(r"Part(\d+)Data\.mat$", str(path))
+        if not match:
+            raise AssertionError(f"Unexpected MAT path: {path}")
+        participant = int(match.group(1))
+        return {"data": np.array([data_by_participant[participant]], dtype=object)}
+
+    return loadmat
+
+
+class TestStimulusCrossSubjectNext(unittest.TestCase):
+    def test_extended_feature_modes_are_exported(self):
+        self.assertIn("sensor_logpower", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_mean_logpower", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_bandpower", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_cov_tangent", cross_subject.FEATURE_MODES)
+
+    def test_sensor_mean_logpower_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0], [0.0, 0.0, 2.0, 6.0]],
+            [[0.0, 0.0, 2.0, 4.0], [0.0, 0.0, 4.0, 8.0]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean_logpower",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 4))
+        np.testing.assert_allclose(feature_set.features[0, :2], np.asarray([2.0, 4.0]))
+        np.testing.assert_allclose(feature_set.features[1, :2], np.asarray([3.0, 6.0]))
+        self.assertTrue(np.all(np.isfinite(feature_set.features[:, 2:])))
+
+    def test_cov_tangent_feature_width(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0, 5.0], [0.0, 0.0, 2.0, 6.0, 8.0], [0.0, 0.0, 3.0, 1.0, 0.5]],
+            [[0.0, 0.0, 2.0, 4.0, 6.0], [0.0, 0.0, 4.0, 8.0, 9.0], [0.0, 0.0, 1.0, 3.0, 5.0]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            feature_mode="sensor_cov_tangent",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_candidate_grid_expands_next_knobs(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            alignments=("none", "train_class_procrustes"),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            sample_weightings=("none", "subject_class_balanced"),
+            score_calibrations=("none", "inner_class_bias"),
+            alignment_alphas=(0.25, 1.0),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 16)
+        self.assertEqual({config.sample_weighting for config in configs}, {"none", "subject_class_balanced"})
+        self.assertEqual({config.score_calibration for config in configs}, {"none", "inner_class_bias"})
+        self.assertEqual({config.alignment_alpha for config in configs}, {0.25, 1.0})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add source-only BUSH-MEG next-methods workflows and helpers
- add grouped/stimulus CLI coverage for the new next-methods path
- add focused tests for the new source-only behavior

## Validation
- python -m py_compile on changed Python files
- git diff --check
- conflict marker scan