### PR TITLE
Use NeuRepTrace upstream fixtures

### DIFF
--- a/src/pymegdec/reaction_time_analysis.py
+++ b/src/pymegdec/reaction_time_analysis.py
@@ -579,8 +579,8 @@ try:  # pragma: no cover - exercised once NeuRepTrace carries the upstream helpe
 except ImportError:  # pragma: no cover - fallback keeps historical checkouts usable
     pass
 else:
-    ReactionTimeUnavailableError = _reptrace_rt.ReactionTimeUnavailableError  # type: ignore[assignment, no-redef]
-    ReactionTimeCsvConfig = _reptrace_rt.ReactionTimeCsvConfig  # type: ignore[assignment, no-redef]
+    ReactionTimeUnavailableError = _reptrace_rt.ReactionTimeUnavailableError  # type: ignore[assignment, misc, no-redef]
+    ReactionTimeCsvConfig = _reptrace_rt.ReactionTimeCsvConfig  # type: ignore[assignment, misc, no-redef]
     REACTION_TIME_FIELD_CANDIDATES = _reptrace_rt.REACTION_TIME_FIELD_CANDIDATES
     TRIAL_INDEX_BASE_CHOICES = _reptrace_rt.TRIAL_INDEX_BASE_CHOICES
 

--- a/src/pymegdec/reaction_time_analysis.py
+++ b/src/pymegdec/reaction_time_analysis.py
@@ -567,3 +567,71 @@ def available_participants(data_folder, *, cue=False):
         if participant.isdigit():
             participants.append(int(participant))
     return sorted(participants)
+
+
+# Route reusable reaction-time operations through NeuRepTrace when the upstream
+# module is available.  PyMEGDec keeps only the alpha-specific orchestration,
+# plotting, and MAT-file glue above; the generic CSV parsing, trial-index
+# normalization, row joins, and metric/RT association summaries belong in
+# NeuRepTrace.
+try:  # pragma: no cover - exercised once NeuRepTrace carries the upstream helper
+    from neureptrace.behavior import reaction_time as _reptrace_rt
+except ImportError:  # pragma: no cover - fallback keeps historical checkouts usable
+    pass
+else:
+    ReactionTimeUnavailableError = _reptrace_rt.ReactionTimeUnavailableError  # type: ignore[assignment, no-redef]
+    ReactionTimeCsvConfig = _reptrace_rt.ReactionTimeCsvConfig  # type: ignore[assignment, no-redef]
+    REACTION_TIME_FIELD_CANDIDATES = _reptrace_rt.REACTION_TIME_FIELD_CANDIDATES
+    TRIAL_INDEX_BASE_CHOICES = _reptrace_rt.TRIAL_INDEX_BASE_CHOICES
+
+    _clean_id = _reptrace_rt._clean_id
+    _to_float = _reptrace_rt._to_float
+    _to_int = _reptrace_rt._to_int
+    _validate_trial_index_base = _reptrace_rt._validate_trial_index_base
+    _normalize_csv_trial = _reptrace_rt._normalize_csv_trial
+    _raise_if_likely_one_based_reaction_trials = _reptrace_rt._raise_if_likely_one_based_reaction_trials
+
+    load_reaction_time_csv = _reptrace_rt.load_reaction_time_csv  # type: ignore[assignment]
+
+    def _reaction_time_rows(values, n_trials, participant_id, dataset, reaction_time_scale):  # type: ignore[no-redef]
+        values = np.asarray(values, dtype=float).ravel()
+        if values.size != n_trials:
+            raise ValueError(f"Expected {n_trials} reaction times, got {values.size}.")
+        return _reptrace_rt.reaction_time_rows_from_values(
+            values,
+            participant=participant_id,
+            dataset=dataset,
+            reaction_time_scale=reaction_time_scale,
+        )
+
+    def join_alpha_reaction_times(alpha_rows, reaction_time_rows):  # type: ignore[no-redef]
+        """Join alpha rows with RTs via NeuRepTrace and add alpha direction columns."""
+
+        joined_rows = _reptrace_rt.join_reaction_times(alpha_rows, reaction_time_rows)
+        for joined_row in joined_rows:
+            direction = _to_float(joined_row.get("direction_rad"))
+            joined_row["direction_sin"] = math.sin(direction) if np.isfinite(direction) else np.nan
+            joined_row["direction_cos"] = math.cos(direction) if np.isfinite(direction) else np.nan
+        return joined_rows
+
+    def analyze_alpha_reaction_times(rows, metrics=DEFAULT_ALPHA_RT_METRICS, min_trials=3):  # type: ignore[no-redef]
+        """Compute alpha/RT associations through NeuRepTrace's generic summarizer."""
+
+        return _reptrace_rt.analyze_metric_reaction_times(rows, metrics, min_trials=min_trials)
+
+
+    __all__ = [
+        "DEFAULT_ALPHA_RT_METRICS",
+        "AlphaReactionTimeExportConfig",
+        "ReactionTimeCsvConfig",
+        "ReactionTimeUnavailableError",
+        "analyze_alpha_reaction_times",
+        "available_participants",
+        "export_alpha_reaction_time_analysis",
+        "extract_reaction_times_from_data",
+        "join_alpha_reaction_times",
+        "load_reaction_time_csv",
+        "parse_participant_spec",
+        "write_alpha_reaction_time_plots",
+        "write_csv_rows",
+    ]

--- a/src/pymegdec/synthetic_data.py
+++ b/src/pymegdec/synthetic_data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 import scipy.io as sio
@@ -247,7 +248,6 @@ try:  # pragma: no cover - exercised once NeuRepTrace carries the upstream helpe
 
     from neureptrace.io.synthetic_fieldtrip import (
         SyntheticFieldTripConfig as _SyntheticFieldTripConfig,
-        SyntheticFieldTripOutput as SyntheticDataOutput,
         write_synthetic_fieldtrip_dataset as _write_synthetic_fieldtrip_dataset,
     )
 except ImportError:  # pragma: no cover - fallback keeps historical checkouts usable
@@ -276,11 +276,14 @@ else:
         """
 
         config = config or SyntheticDataConfig()
-        return _write_synthetic_fieldtrip_dataset(
-            data_dir,
-            config,
-            overwrite=overwrite,
-            write_manifest=write_manifest,
+        return cast(
+            SyntheticDataOutput,
+            _write_synthetic_fieldtrip_dataset(
+                data_dir,
+                config,
+                overwrite=overwrite,
+                write_manifest=write_manifest,
+            ),
         )
 
 

--- a/src/pymegdec/synthetic_data.py
+++ b/src/pymegdec/synthetic_data.py
@@ -236,3 +236,56 @@ def write_synthetic_dataset(
         manifest_path.write_text(json.dumps(_manifest(output, config), indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     return output
+
+
+# Prefer the dataset-independent NeuRepTrace implementation when available.
+# The local implementation above remains as a compatibility fallback for old
+# PyMEGDec environments, but new installations should resolve this block through
+# the NeuRepTrace synthetic FieldTrip fixture generator.
+try:  # pragma: no cover - exercised once NeuRepTrace carries the upstream helper
+    from dataclasses import dataclass as _dataclass
+
+    from neureptrace.io.synthetic_fieldtrip import (
+        SyntheticFieldTripConfig as _SyntheticFieldTripConfig,
+        SyntheticFieldTripOutput as SyntheticDataOutput,
+        write_synthetic_fieldtrip_dataset as _write_synthetic_fieldtrip_dataset,
+    )
+except ImportError:  # pragma: no cover - fallback keeps historical checkouts usable
+    pass
+else:
+
+    @_dataclass(frozen=True)
+    class SyntheticDataConfig(_SyntheticFieldTripConfig):  # type: ignore[misc, no-redef]
+        """PyMEGDec-compatible defaults for NeuRepTrace synthetic FieldTrip data."""
+
+        manifest_name: str | None = "synthetic_data_manifest.json"
+
+
+    def write_synthetic_dataset(  # type: ignore[no-redef]
+        data_dir: str | Path,
+        config: SyntheticDataConfig | None = None,
+        *,
+        overwrite: bool = False,
+        write_manifest: bool = True,
+    ) -> SyntheticDataOutput:
+        """Write synthetic MAT files through NeuRepTrace's generic generator.
+
+        The PyMEGDec-facing defaults preserve the historical
+        ``synthetic_data_manifest.json`` file name while delegating the reusable
+        FieldTrip fixture logic to NeuRepTrace.
+        """
+
+        config = config or SyntheticDataConfig()
+        return _write_synthetic_fieldtrip_dataset(
+            data_dir,
+            config,
+            overwrite=overwrite,
+            write_manifest=write_manifest,
+        )
+
+
+    __all__ = [
+        "SyntheticDataConfig",
+        "SyntheticDataOutput",
+        "write_synthetic_dataset",
+    ]


### PR DESCRIPTION
## Summary
- add NeuRepTrace-compatible synthetic data helpers
- expose reaction-time analysis helpers for upstream fixture reuse

## Validation
- `git diff --check`
- conflict-marker search
- `python -m py_compile` on changed Python files