### PR TITLE
Delegate onset scan to NeuRepTrace onset detection

### DIFF
--- a/.github/workflows/stimulus-onset-benchmark.yml
+++ b/.github/workflows/stimulus-onset-benchmark.yml
@@ -1,4 +1,4 @@
-name: Manual stimulus onset benchmark
+name: Manual NeuRepTrace onset benchmark
 #checkov:skip=CKV_GHA_7:Manual workflow inputs are constrained to analysis parameters and used only after shell quoting.
 
 on:
@@ -9,45 +9,10 @@ on:
         required: true
         default: "3.13"
         type: string
-      use_nextcloud_data:
-        description: Restore/download/cache the MEG data before running.
+      observation_csvs:
+        description: Space-separated NeuRepTrace probability observation CSV paths or glob patterns.
         required: true
-        default: true
-        type: boolean
-      data_cache_version:
-        description: MEG data cache version.
-        required: true
-        default: v2
-        type: string
-      data_dir:
-        description: Relative data directory to restore/populate.
-        required: true
-        default: .cache/meg-data-all
-        type: string
-      participants:
-        description: Participant ids such as 1-4,6,8.
-        required: true
-        default: "1-4,6,8,9,10,13-27"
-        type: string
-      train_window_center:
-        description: Known-onset training window center in seconds.
-        required: true
-        default: "0.175"
-        type: string
-      scan_time_window:
-        description: Scan window-center range as start,stop in seconds.
-        required: true
-        default: "-0.4,0.8"
-        type: string
-      window_step_s:
-        description: Step between scan window centers in seconds.
-        required: true
-        default: "0.025"
-        type: string
-      window_size:
-        description: Window size in seconds.
-        required: true
-        default: "0.1"
+        default: "outputs/stimulus_probability_observations.csv"
         type: string
       threshold_window:
         description: Baseline threshold window as start,stop in seconds.
@@ -85,18 +50,11 @@ permissions:
 
 jobs:
   onset-benchmark:
-    name: Export onset benchmark
+    name: Detect onsets from NeuRepTrace observations
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 120
     env:
-      DATA_DIR: ${{ inputs.data_dir }}
-      USE_NEXTCLOUD_DATA: ${{ inputs.use_nextcloud_data }}
-      DATA_CACHE_VERSION: ${{ inputs.data_cache_version }}
-      PARTICIPANTS: ${{ inputs.participants }}
-      TRAIN_WINDOW_CENTER: ${{ inputs.train_window_center }}
-      SCAN_TIME_WINDOW: ${{ inputs.scan_time_window }}
-      WINDOW_STEP_S: ${{ inputs.window_step_s }}
-      WINDOW_SIZE: ${{ inputs.window_size }}
+      OBSERVATION_CSVS: ${{ inputs.observation_csvs }}
       THRESHOLD_WINDOW: ${{ inputs.threshold_window }}
       THRESHOLD_QUANTILE: ${{ inputs.threshold_quantile }}
       DETECTION_START_S: ${{ inputs.detection_start_s }}
@@ -107,16 +65,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-
-      - name: Prepare MEG data
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
-        uses: ./.github/actions/prepare-meg-data
-        with:
-          data-dir: ${{ env.DATA_DIR }}
-          cache-version: ${{ env.DATA_CACHE_VERSION }}
-          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
-          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
-          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -130,51 +78,45 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .
 
-      - name: Resolve MEG data directory
+      - name: Resolve observation CSV inputs
         shell: bash
         run: |
           set -euo pipefail
           python - <<'PY'
           from pathlib import Path
+          import glob
           import os
+          import shlex
 
-          root = Path(os.environ["DATA_DIR"])
-          if not root.exists():
-              raise SystemExit(f"Data directory does not exist: {root}")
-
-          candidates = {}
-          for file in root.rglob("Part*Data.mat"):
-              if file.name.endswith("CueData.mat"):
-                  continue
-              main, cue = candidates.get(file.parent, (0, 0))
-              candidates[file.parent] = (main + 1, cue)
-          for file in root.rglob("Part*CueData.mat"):
-              main, cue = candidates.get(file.parent, (0, 0))
-              candidates[file.parent] = (main, cue + 1)
-
-          valid = [(path, counts) for path, counts in candidates.items() if counts[0] and counts[1]]
-          if not valid:
-              raise SystemExit(f"No directory containing both main and cue MAT files was found under {root}.")
-          resolved, counts = max(valid, key=lambda item: (item[1][0] + item[1][1], str(item[0])))
-          print(f"Resolved MEG data directory: {resolved}")
-          print(f"Found {counts[0]} main MAT files and {counts[1]} cue MAT files.")
+          patterns = shlex.split(os.environ["OBSERVATION_CSVS"])
+          if not patterns:
+              raise SystemExit("No observation CSV inputs were provided.")
+          resolved = []
+          for pattern in patterns:
+              matches = sorted(glob.glob(pattern))
+              if matches:
+                  resolved.extend(matches)
+              elif Path(pattern).exists():
+                  resolved.append(pattern)
+              else:
+                  raise SystemExit(f"Observation CSV input does not exist or match any file: {pattern}")
           with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as handle:
-              handle.write(f"PYMEGDEC_ANALYSIS_DATA_DIR={resolved}\n")
+              handle.write("RESOLVED_OBSERVATION_CSVS=" + " ".join(shlex.quote(path) for path in resolved) + "\n")
+          print("Resolved observation CSVs:")
+          for path in resolved:
+              print(f"  {path}")
           PY
 
-      - name: Run robust onset scan
+      - name: Run robust onset detection
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p outputs
+          # shellcheck disable=SC2206
+          observations=( ${RESOLVED_OBSERVATION_CSVS} )
           args=(
             python scripts/export_stimulus_onset_scan.py
-            --data-dir "${PYMEGDEC_ANALYSIS_DATA_DIR}"
-            --participants "${PARTICIPANTS}"
-            --train-window-center "${TRAIN_WINDOW_CENTER}"
-            "--scan-time-window=${SCAN_TIME_WINDOW}"
-            --window-step-s "${WINDOW_STEP_S}"
-            --window-size "${WINDOW_SIZE}"
+            --observation-csv "${observations[@]}"
             "--threshold-window=${THRESHOLD_WINDOW}"
             --threshold-quantile "${THRESHOLD_QUANTILE}"
             --threshold-method max_run
@@ -196,14 +138,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # shellcheck disable=SC2206
+          observations=( ${RESOLVED_OBSERVATION_CSVS} )
           args=(
             python scripts/export_stimulus_onset_scan.py
-            --data-dir "${PYMEGDEC_ANALYSIS_DATA_DIR}"
-            --participants "${PARTICIPANTS}"
-            --train-window-center "${TRAIN_WINDOW_CENTER}"
-            "--scan-time-window=${SCAN_TIME_WINDOW}"
-            --window-step-s "${WINDOW_STEP_S}"
-            --window-size "${WINDOW_SIZE}"
+            --observation-csv "${observations[@]}"
             "--threshold-window=${THRESHOLD_WINDOW}"
             --threshold-quantile "${THRESHOLD_QUANTILE}"
             --threshold-method point
@@ -258,8 +197,8 @@ jobs:
             --max-false-alarm-rate 0.05
             --events-output outputs/stimulus_onset_events_max_run_sweep.csv
             --event-summary-output outputs/stimulus_onset_event_summary_max_run_sweep.csv
-            --summary-output outputs/stimulus_onset_operating_point_sweep_max_run.csv
-            --selected-output outputs/stimulus_onset_operating_point_selected_max_run.csv
+            --summary-output outputs/stimulus_onset_operating_point_max_run_sweep.csv
+            --selected-output outputs/stimulus_onset_operating_point_max_run_selected.csv
             --selected-events-output outputs/stimulus_onset_events_max_run_selected.csv
             --selected-event-summary-output outputs/stimulus_onset_event_summary_max_run_selected.csv
           )
@@ -268,160 +207,9 @@ jobs:
           fi
           "${args[@]}"
 
-      - name: Summarize onset quality
-        shell: bash
-        run: |
-          set -euo pipefail
-          python - <<'PY'
-          from pathlib import Path
-          import os
-          import numpy as np
-          import pandas as pd
-
-          rows = []
-
-          def _first_value(frame, column):
-              if column not in frame.columns:
-                  return np.nan
-              values = frame[column].dropna()
-              return values.iloc[0] if not values.empty else np.nan
-
-          def _conditional_correct(correct_rate, detected_rate):
-              try:
-                  correct_rate = float(correct_rate)
-                  detected_rate = float(detected_rate)
-              except (TypeError, ValueError):
-                  return np.nan
-              if not np.isfinite(correct_rate) or not np.isfinite(detected_rate) or detected_rate == 0:
-                  return np.nan
-              return correct_rate / detected_rate
-
-          def add_event_summary(label, path):
-              path = Path(path)
-              if not path.exists():
-                  return
-              frame = pd.read_csv(path)
-              false_alarm_rate = frame["false_alarm_rate"].mean()
-              post_detected_rate = frame["post_stimulus_detected_rate"].mean()
-              correct_rate = frame["correct_detection_rate"].mean()
-              rows.append({
-                  "setting": label,
-                  "threshold_quantile": _first_value(frame, "threshold_quantile"),
-                  "min_consecutive": _first_value(frame, "min_consecutive"),
-                  "min_duration_s": _first_value(frame, "min_duration_s"),
-                  "summary_rows": len(frame),
-                  "participants": frame["participant"].nunique() if "participant" in frame.columns else len(frame),
-                  "false_alarm_rate_mean": false_alarm_rate,
-                  "post_stimulus_detected_rate_mean": post_detected_rate,
-                  "correct_detection_rate_mean": correct_rate,
-                  "conditional_correct_detection_rate": _conditional_correct(correct_rate, post_detected_rate),
-                  "median_latency_s": frame["post_detection_latency_median_s"].median(),
-                  "mean_latency_s": frame["post_detection_latency_mean_s"].mean(),
-              })
-
-          def add_selected_operating_point(path):
-              path = Path(path)
-              if not path.exists():
-                  return
-              frame = pd.read_csv(path)
-              if frame.empty:
-                  return
-              selected = frame.iloc[0].to_dict()
-              rows.append({
-                  "setting": selected.get("setting", "selected_operating_point"),
-                  "threshold_quantile": selected.get("threshold_quantile", np.nan),
-                  "min_consecutive": selected.get("min_consecutive", np.nan),
-                  "min_duration_s": selected.get("min_duration_s", np.nan),
-                  "summary_rows": selected.get("summary_rows", np.nan),
-                  "participants": selected.get("participants", np.nan),
-                  "false_alarm_rate_mean": selected.get("false_alarm_rate_mean", np.nan),
-                  "post_stimulus_detected_rate_mean": selected.get("post_stimulus_detected_rate_mean", np.nan),
-                  "correct_detection_rate_mean": selected.get("correct_detection_rate_mean", np.nan),
-                  "conditional_correct_detection_rate": selected.get("conditional_correct_detection_rate", np.nan),
-                  "median_latency_s": selected.get("median_latency_s", np.nan),
-                  "mean_latency_s": selected.get("mean_latency_s", np.nan),
-                  "meets_false_alarm_constraint": selected.get("meets_false_alarm_constraint", np.nan),
-                  "selected_feasible": selected.get("selected_feasible", np.nan),
-              })
-
-          add_event_summary("robust_max_run", "outputs/stimulus_onset_event_summary_robust.csv")
-          add_event_summary("point_baseline", "outputs/stimulus_onset_event_summary_point.csv")
-          add_selected_operating_point("outputs/stimulus_onset_operating_point_selected.csv")
-          add_selected_operating_point("outputs/stimulus_onset_operating_point_selected_max_run.csv")
-
-          table = pd.DataFrame(rows)
-          table.to_csv("outputs/stimulus_onset_quality_summary.csv", index=False)
-          detection_start = os.environ.get("DETECTION_START_S", "")
-          if detection_start:
-              mode_line = f"Both benchmark settings use `--detection-start-s {detection_start}`, so earlier detections are excluded consistently."
-          else:
-              mode_line = "No `--detection-start-s` floor is applied, so pre-stimulus first detections contribute to the false-alarm rate."
-          if table.empty:
-              table_block = "No summary rows produced."
-          else:
-              plain_table = table.to_string(index=False, float_format=lambda value: f"{value:.4f}")
-              table_block = f"```\n{plain_table}\n```"
-
-          selected_line = ""
-          selected_lines = []
-          for selected_path in (
-              Path("outputs/stimulus_onset_operating_point_selected.csv"),
-              Path("outputs/stimulus_onset_operating_point_selected_max_run.csv"),
-          ):
-              if not selected_path.exists():
-                  continue
-              selected_frame = pd.read_csv(selected_path)
-              if selected_frame.empty:
-                  continue
-              selected = selected_frame.iloc[0]
-              selected_lines.append(
-                  f"Selected `{selected['setting']}` operating point: "
-                  f"`threshold_quantile={selected['threshold_quantile']}`, "
-                  f"`min_consecutive={selected['min_consecutive']}`, "
-                  f"`min_duration_s={selected['min_duration_s']}`, "
-                  f"`require_stable_prediction={selected['require_stable_prediction']}`."
-              )
-          if selected_lines:
-              selected_line = "\n".join(selected_lines)
-
-          text = "\n".join([
-              "# Stimulus onset benchmark",
-              "",
-              "Lower false-alarm rate is better. Post-stimulus detection and correct-at-detection should stay meaningfully above chance.",
-              mode_line,
-              "The point operating-point sweep reuses `outputs/stimulus_onset_scan_point.csv`; it does not rerun MEG decoding.",
-              "",
-              table_block,
-              "",
-              selected_line,
-              "",
-          ])
-          Path("outputs/README.md").write_text(text, encoding="utf-8")
-          print(text)
-          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as handle:
-              handle.write(text)
-          PY
-
-      - name: Build onset decision summary
-        shell: bash
-        run: |
-          set -euo pipefail
-          python scripts/export_stimulus_onset_decision_summary.py \
-            --artifact-dir outputs \
-            --output-csv outputs/stimulus_onset_decision_summary.csv \
-            --output-markdown outputs/stimulus_onset_decision_summary.md \
-            --output-json outputs/stimulus_onset_decision_summary.json
-
-      - name: Append onset decision summary
-        shell: bash
-        run: |
-          set -euo pipefail
-          cat outputs/stimulus_onset_decision_summary.md >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Upload onset benchmark outputs
-        uses: actions/upload-artifact@v7
-        if: always()
+      - name: Upload onset outputs
+        uses: actions/upload-artifact@v5
         with:
-          name: stimulus-onset-benchmark-outputs
-          path: outputs/
-          if-no-files-found: warn
+          name: stimulus-onset-outputs
+          path: outputs/stimulus_onset_*.csv
+          if-no-files-found: error

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -33,7 +33,7 @@ pymegdec stimulus cross-subject-nested --participants 1-4,6,8,9,10,13-27 --windo
 pymegdec stimulus predictions --participants 2 --output outputs/stimulus_predictions.csv
 pymegdec stimulus robustness --participants 2 --predictions-output outputs/stimulus_robustness_predictions.csv
 pymegdec stimulus temporal-generalization --participants 2 --output outputs/stimulus_temporal_generalization.csv
-pymegdec stimulus onset-scan --participants 2 --output outputs/stimulus_onset_scan.csv --events-output outputs/stimulus_onset_events.csv
+pymegdec stimulus onset-scan --observation-csv outputs/stimulus_probability_observations.csv --output outputs/stimulus_onset_scan.csv --events-output outputs/stimulus_onset_events.csv
 ```
 
 ### Legacy alpha workflows
@@ -212,14 +212,31 @@ pymegdec stimulus temporal-generalization \
 
 ## Stimulus onset scan
 
+The onset-scan entry point is now a compatibility wrapper around NeuRepTrace's
+onset detector. PyMEGDec no longer trains a raw BUSH-MEG scanner from
+`Part*Data.mat` / `Part*CueData.mat`; first export NeuRepTrace probability
+observation rows with `time`, `sequence_id` or `sample_index`, and `prob_class_*`
+columns, then run:
+
 ```bash
 pymegdec stimulus onset-scan \
-  --data-dir /path/to/MEG-Data \
-  --participants 2 \
-  --scan-time-window=-0.4,0.8 \
+  --observation-csv outputs/stimulus_probability_observations.csv \
   --threshold-window=-0.35,-0.05 \
+  --threshold-quantile 0.95 \
+  --score-column confidence \
   --output outputs/stimulus_onset_scan.csv \
   --events-output outputs/stimulus_onset_events.csv
+```
+
+For new scripts, prefer the NeuRepTrace command directly:
+
+```bash
+neureptrace onset-detect \
+  outputs/stimulus_probability_observations.csv \
+  --out-events outputs/stimulus_onset_events.csv \
+  --out-summary outputs/stimulus_onset_event_summary.csv \
+  --out-thresholded-observations outputs/stimulus_onset_scan.csv \
+  --out-threshold-summary outputs/stimulus_onset_scan_summary.csv
 ```
 
 ## Alpha movement result analysis

--- a/scripts/export_stimulus_onset_operating_point_sweep.py
+++ b/scripts/export_stimulus_onset_operating_point_sweep.py
@@ -1,4 +1,4 @@
-"""Sweep onset detector settings from an exported stimulus-onset scan."""
+"""Sweep NeuRepTrace onset detector settings from probability observations."""
 
 from __future__ import annotations
 
@@ -15,37 +15,8 @@ _SRC = _ROOT / "src"
 if _SRC.exists():
     sys.path.insert(0, str(_SRC))
 
+from neureptrace.onset_detection import detect_onsets, summarize_onset_events  # noqa: E402
 from pymegdec.alpha_metrics import write_alpha_metrics_csv  # noqa: E402
-from pymegdec.stimulus_decoding import (  # noqa: E402
-    _stimulus_onset_event_rows_from_reptrace,
-    summarize_stimulus_onset_events,
-)
-
-GROUP_FIELDS = (
-    "participant",
-    "variant",
-    "transfer_direction",
-    "train_window_center_s",
-    "threshold_method",
-    "min_consecutive",
-    "min_duration_s",
-    "require_stable_prediction",
-    "classifier",
-    "components_pca",
-    "frequency_low_hz",
-    "frequency_high_hz",
-)
-
-SCAN_GROUP_FIELDS = (
-    "participant",
-    "variant",
-    "transfer_direction",
-    "train_window_center_s",
-    "classifier",
-    "components_pca",
-    "frequency_low_hz",
-    "frequency_high_hz",
-)
 
 
 def _float_list(text: str) -> tuple[float, ...]:
@@ -84,137 +55,68 @@ def _bool_list(text: str) -> tuple[bool, ...]:
     return tuple(values)
 
 
-def _stable(value):
-    try:
-        if pd.isna(value):
-            return ""
-    except (TypeError, ValueError):
-        return value
-    return value
-
-
-def _stable_rows(rows: list[dict], fields: tuple[str, ...] = GROUP_FIELDS) -> list[dict]:
-    out = []
-    for row in rows:
-        item = dict(row)
-        for field in fields:
-            item[field] = _stable(item.get(field, ""))
-        out.append(item)
-    return out
-
-
-def _grouped_event_rows(
-    base_frame: pd.DataFrame,
-    *,
-    threshold_window: tuple[float, float],
-    threshold_quantile: float,
-    threshold_method: str,
-    min_consecutive: int,
-    min_duration: float,
-    require_stable_prediction: bool,
-    detection_start: float | None,
-) -> list[dict]:
-    grouped_events: list[dict] = []
-    for _, group in base_frame.groupby(list(SCAN_GROUP_FIELDS), sort=False, dropna=False):
-        grouped_events.extend(
-            _stimulus_onset_event_rows_from_reptrace(
-                group.to_dict(orient="records"),
-                threshold_window=threshold_window,
-                threshold_quantile=threshold_quantile,
-                threshold_method=threshold_method,
-                min_consecutive=min_consecutive,
-                min_duration=min_duration,
-                require_stable_prediction=require_stable_prediction,
-                detection_start_s=detection_start,
-            )
-        )
-    return _stable_rows(grouped_events)
-
-
 def _mean(frame: pd.DataFrame, column: str) -> float:
-    return float(pd.to_numeric(frame[column], errors="coerce").mean()) if column in frame else np.nan
+    return float(pd.to_numeric(frame[column], errors="coerce").mean()) if column in frame and not frame.empty else np.nan
 
 
 def _median(frame: pd.DataFrame, column: str) -> float:
-    return float(pd.to_numeric(frame[column], errors="coerce").median()) if column in frame else np.nan
+    return float(pd.to_numeric(frame[column], errors="coerce").median()) if column in frame and not frame.empty else np.nan
 
 
-def _aggregate(
-    rows: list[dict],
-    *,
-    threshold_method: str,
-    threshold_quantile: float,
-    min_consecutive: int,
-    min_duration: float,
-    require_stable_prediction: bool,
-    max_false_alarm_rate: float,
-) -> dict:
-    frame = pd.DataFrame(rows)
-    fa = _mean(frame, "false_alarm_rate")
-    post = _mean(frame, "post_stimulus_detected_rate")
-    correct = _mean(frame, "correct_detection_rate")
+def _aggregate(summary: pd.DataFrame, *, method: str, quantile: float, min_consecutive: int, min_duration: float, stable: bool, max_false_alarm_rate: float) -> dict:
+    false_alarm = _mean(summary, "false_alarm_rate")
+    post_rate = _mean(summary, "post_zero_detected_rate")
+    correct_rate = _mean(summary, "correct_detection_rate")
     return {
-        "setting": f"{threshold_method}_sweep",
-        "threshold_method": threshold_method,
-        "threshold_quantile": threshold_quantile,
+        "setting": f"{method}_sweep",
+        "threshold_method": method,
+        "threshold_quantile": quantile,
         "min_consecutive": min_consecutive,
         "min_duration_s": min_duration,
-        "require_stable_prediction": bool(require_stable_prediction),
-        "summary_rows": len(frame),
-        "participants": frame["participant"].nunique() if "participant" in frame else len(frame),
-        "false_alarm_rate_mean": fa,
-        "post_stimulus_detected_rate_mean": post,
-        "correct_detection_rate_mean": correct,
-        "conditional_correct_detection_rate": correct / post if np.isfinite(correct) and np.isfinite(post) and post else np.nan,
-        "median_latency_s": _median(frame, "post_detection_latency_median_s"),
-        "mean_latency_s": _mean(frame, "post_detection_latency_mean_s"),
-        "meets_false_alarm_constraint": bool(np.isfinite(fa) and fa <= max_false_alarm_rate),
+        "require_stable_prediction": bool(stable),
+        "summary_rows": len(summary),
+        "participants": summary["subject"].nunique() if "subject" in summary else len(summary),
+        "false_alarm_rate_mean": false_alarm,
+        "post_stimulus_detected_rate_mean": post_rate,
+        "correct_detection_rate_mean": correct_rate,
+        "conditional_correct_detection_rate": correct_rate / post_rate if np.isfinite(correct_rate) and np.isfinite(post_rate) and post_rate else np.nan,
+        "median_latency_s": _median(summary, "post_detection_latency_median"),
+        "mean_latency_s": _mean(summary, "post_detection_latency_mean"),
+        "meets_false_alarm_constraint": bool(np.isfinite(false_alarm) and false_alarm <= max_false_alarm_rate),
         "selection_max_false_alarm_rate": max_false_alarm_rate,
     }
 
 
 def _ranking(row: dict, feasible: bool) -> tuple:
-    fa = row.get("false_alarm_rate_mean", np.inf)
+    false_alarm = row.get("false_alarm_rate_mean", np.inf)
     post = row.get("post_stimulus_detected_rate_mean", -np.inf)
     correct = row.get("correct_detection_rate_mean", -np.inf)
     latency = row.get("median_latency_s", np.inf)
-    fa = fa if np.isfinite(fa) else np.inf
+    false_alarm = false_alarm if np.isfinite(false_alarm) else np.inf
     post = post if np.isfinite(post) else -np.inf
     correct = correct if np.isfinite(correct) else -np.inf
     latency = latency if np.isfinite(latency) else np.inf
-    tail = (
-        row["threshold_quantile"],
-        row["min_consecutive"],
-        row["min_duration_s"],
-        int(bool(row.get("require_stable_prediction", False))),
-    )
-    return (-post, -correct, latency, *tail) if feasible else (fa, -post, -correct, latency, *tail)
+    tail = (row["threshold_quantile"], row["min_consecutive"], row["min_duration_s"], int(bool(row.get("require_stable_prediction", False))))
+    return (-post, -correct, latency, *tail) if feasible else (false_alarm, -post, -correct, latency, *tail)
 
 
-def _select(rows: list[dict], *, threshold_method: str) -> dict:
+def _select(rows: list[dict], *, method: str) -> dict:
     feasible = [row for row in rows if row.get("meets_false_alarm_constraint")]
-    if feasible:
-        selected = min(feasible, key=lambda row: _ranking(row, True))
-        selected_feasible = True
-    else:
-        selected = min(rows, key=lambda row: _ranking(row, False))
-        selected_feasible = False
+    selected = min(feasible, key=lambda row: _ranking(row, True)) if feasible else min(rows, key=lambda row: _ranking(row, False))
     selected = dict(selected)
-    selected["setting"] = f"{threshold_method}_sweep_selected"
-    selected["selected_feasible"] = selected_feasible
-    selected["selection_rule"] = (
-        "false_alarm_rate_mean <= max_false_alarm_rate; then maximize post_stimulus_detected_rate_mean; "
-        "then maximize correct_detection_rate_mean; then minimize median_latency_s; then prefer lower settings"
-    )
+    selected["setting"] = f"{method}_sweep_selected"
+    selected["selected_feasible"] = bool(feasible)
+    selected["selection_rule"] = "constrain false alarms, maximize post-stimulus detections and correct detections, then minimize latency"
     return selected
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--scan-input", required=True)
+    parser.add_argument("--scan-input", required=True, help="Thresholded or raw NeuRepTrace probability-observation CSV.")
     parser.add_argument("--threshold-method", choices=("point", "max_run"), default="point")
     parser.add_argument("--threshold-window", type=_window, default=(-0.35, -0.05))
     parser.add_argument("--threshold-quantiles", type=_float_list, default=(0.95, 0.975, 0.99))
+    parser.add_argument("--score-column", default="confidence")
     parser.add_argument("--min-consecutives", type=_int_list, default=(1, 2, 3))
     parser.add_argument("--min-durations", type=_float_list, default=(0.025, 0.05, 0.075))
     parser.add_argument("--require-stable-prediction-values", type=_bool_list, default=(False,))
@@ -231,66 +133,40 @@ def _parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    frame = pd.read_csv(args.scan_input)
     detection_start = _optional_float(args.detection_start_s)
-    base_frame = pd.read_csv(args.scan_input)
-    all_events, all_summaries, aggregate_rows = [], [], []
+    all_events: list[dict] = []
+    all_summaries: list[dict] = []
+    aggregate_rows: list[dict] = []
     by_key = {}
-    for q, n, duration, require_stable_prediction in itertools.product(
-        args.threshold_quantiles,
-        args.min_consecutives,
-        args.min_durations,
-        args.require_stable_prediction_values,
-    ):
-        events = _grouped_event_rows(
-            base_frame,
+    for quantile, min_consecutive, min_duration, stable in itertools.product(args.threshold_quantiles, args.min_consecutives, args.min_durations, args.require_stable_prediction_values):
+        events = detect_onsets(
+            frame,
             threshold_window=args.threshold_window,
-            threshold_quantile=q,
+            threshold_quantile=quantile,
+            score_column=args.score_column,
             threshold_method=args.threshold_method,
-            min_consecutive=n,
-            min_duration=duration,
-            require_stable_prediction=require_stable_prediction,
+            min_consecutive=min_consecutive,
+            min_duration=min_duration,
+            require_stable_prediction=stable,
             detection_start=detection_start,
         )
-        summaries = _stable_rows(summarize_stimulus_onset_events(events))
-        row = _aggregate(
-            summaries,
-            threshold_method=args.threshold_method,
-            threshold_quantile=q,
-            min_consecutive=n,
-            min_duration=duration,
-            require_stable_prediction=require_stable_prediction,
-            max_false_alarm_rate=args.max_false_alarm_rate,
-        )
-        by_key[(q, n, duration, require_stable_prediction)] = (events, summaries)
-        all_events.extend(events)
-        all_summaries.extend(summaries)
-        aggregate_rows.append(row)
-    selected = _select(aggregate_rows, threshold_method=args.threshold_method)
-    selected_key = (
-        selected["threshold_quantile"],
-        selected["min_consecutive"],
-        selected["min_duration_s"],
-        bool(selected.get("require_stable_prediction", False)),
-    )
-    selected_events, selected_summaries = by_key[selected_key]
+        summary = summarize_onset_events(events)
+        aggregate_rows.append(_aggregate(summary, method=args.threshold_method, quantile=quantile, min_consecutive=min_consecutive, min_duration=min_duration, stable=stable, max_false_alarm_rate=args.max_false_alarm_rate))
+        by_key[(quantile, min_consecutive, min_duration, bool(stable))] = (events, summary)
+        all_events.extend(events.to_dict(orient="records"))
+        all_summaries.extend(summary.to_dict(orient="records"))
+    selected = _select(aggregate_rows, method=args.threshold_method)
+    selected_key = (selected["threshold_quantile"], selected["min_consecutive"], selected["min_duration_s"], bool(selected.get("require_stable_prediction", False)))
+    selected_events, selected_summary = by_key[selected_key]
     write_alpha_metrics_csv(all_events, args.events_output)
     write_alpha_metrics_csv(all_summaries, args.event_summary_output)
     write_alpha_metrics_csv(aggregate_rows, args.summary_output)
     write_alpha_metrics_csv([selected], args.selected_output)
-    write_alpha_metrics_csv(selected_events, args.selected_events_output)
-    write_alpha_metrics_csv(selected_summaries, args.selected_event_summary_output)
+    write_alpha_metrics_csv(selected_events.to_dict(orient="records"), args.selected_events_output)
+    write_alpha_metrics_csv(selected_summary.to_dict(orient="records"), args.selected_event_summary_output)
     print(f"Wrote {len(aggregate_rows)} operating-point rows to {args.summary_output}")
     print(f"Wrote selected operating point to {args.selected_output}")
-    print(
-        f"Selected {args.threshold_method} operating point: "
-        f"threshold_quantile={selected['threshold_quantile']}, "
-        f"min_consecutive={selected['min_consecutive']}, "
-        f"min_duration_s={selected['min_duration_s']}, "
-        f"require_stable_prediction={selected['require_stable_prediction']}, "
-        f"false_alarm_rate_mean={selected['false_alarm_rate_mean']:.4f}, "
-        f"post_stimulus_detected_rate_mean={selected['post_stimulus_detected_rate_mean']:.4f}, "
-        f"correct_detection_rate_mean={selected['correct_detection_rate_mean']:.4f}"
-    )
     return 0
 
 

--- a/scripts/export_stimulus_onset_scan.py
+++ b/scripts/export_stimulus_onset_scan.py
@@ -1,73 +1,16 @@
-"""Backward-compatible wrapper for the grouped stimulus onset-scan command."""
+"""Backward-compatible wrapper for the NeuRepTrace-backed onset-scan command."""
 
 from __future__ import annotations
 
 import sys
 from pathlib import Path
 
-import pandas as pd
-
 _ROOT = Path(__file__).resolve().parents[1]
 _SRC = _ROOT / "src"
 if _SRC.exists():
     sys.path.insert(0, str(_SRC))
 
-from pymegdec import stimulus_decoding as _stimulus_decoding  # noqa: E402
-
-
-def _stable_group_value(value):
-    """Canonicalize missing scalar values before grouping onset summaries."""
-
-    try:
-        if pd.isna(value):
-            return ""
-    except (TypeError, ValueError):
-        return value
-    return value
-
-
-def _canonicalize_group_fields(rows, group_fields):
-    stable_rows = []
-    for row in rows:
-        stable_row = dict(row)
-        for field in group_fields:
-            stable_row[field] = _stable_group_value(stable_row.get(field, ""))
-        stable_rows.append(stable_row)
-    return stable_rows
-
-
-_SUMMARY_GROUP_FIELDS = (
-    "participant",
-    "variant",
-    "transfer_direction",
-    "train_window_center_s",
-    "threshold_method",
-    "min_consecutive",
-    "min_duration_s",
-    "require_stable_prediction",
-    "classifier",
-    "components_pca",
-    "frequency_low_hz",
-    "frequency_high_hz",
-)
-_SCAN_GROUP_FIELDS = (*_SUMMARY_GROUP_FIELDS[:8], "scan_window_center_s", *_SUMMARY_GROUP_FIELDS[8:])
-
-_ORIGINAL_SUMMARIZE_STIMULUS_ONSET_EVENTS = _stimulus_decoding.summarize_stimulus_onset_events
-_ORIGINAL_SUMMARIZE_STIMULUS_ONSET_SCAN = _stimulus_decoding.summarize_stimulus_onset_scan
-
-
-def _summarize_stimulus_onset_events_stable(rows):
-    return _ORIGINAL_SUMMARIZE_STIMULUS_ONSET_EVENTS(_canonicalize_group_fields(rows, _SUMMARY_GROUP_FIELDS))
-
-
-def _summarize_stimulus_onset_scan_stable(rows):
-    return _ORIGINAL_SUMMARIZE_STIMULUS_ONSET_SCAN(_canonicalize_group_fields(rows, _SCAN_GROUP_FIELDS))
-
-
-_stimulus_decoding.summarize_stimulus_onset_events = _summarize_stimulus_onset_events_stable
-_stimulus_decoding.summarize_stimulus_onset_scan = _summarize_stimulus_onset_scan_stable
-
-from pymegdec.stimulus_cli import stimulus_onset_scan  # noqa: E402
+from pymegdec.stimulus_onset_neureptrace import stimulus_onset_scan  # noqa: E402
 
 
 def main() -> int:

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -18,6 +18,7 @@ from pymegdec import (
     stimulus_mcca,
 )
 from pymegdec.neureptrace_dataset_spec import write_neureptrace_dataset_spec
+from pymegdec.stimulus_onset_neureptrace import stimulus_onset_scan
 from pymegdec.synthetic_data_cli import make_synthetic_data
 
 CommandHandler = Callable[[Sequence[str] | None, str | None], int]
@@ -52,7 +53,7 @@ def _stimulus_handlers() -> dict[str, CommandHandler]:
         "predictions": stimulus_cli.stimulus_predictions,
         "robustness": stimulus_cli.stimulus_robustness,
         "temporal-generalization": stimulus_cli.stimulus_temporal_generalization,
-        "onset-scan": stimulus_cli.stimulus_onset_scan,
+        "onset-scan": stimulus_onset_scan,
     }
 
 
@@ -94,7 +95,7 @@ def _top_level_handlers() -> dict[str, CommandHandler]:
         "stimulus-predictions": stimulus_cli.stimulus_predictions,
         "stimulus-robustness": stimulus_cli.stimulus_robustness,
         "stimulus-temporal-generalization": stimulus_cli.stimulus_temporal_generalization,
-        "stimulus-onset-scan": stimulus_cli.stimulus_onset_scan,
+        "stimulus-onset-scan": stimulus_onset_scan,
         "alpha-metrics": alpha_cli.alpha_metrics,
         "alpha-movement": alpha_cli.alpha_movement,
         "alpha-movement-results": alpha_cli.alpha_movement_results,

--- a/src/pymegdec/stimulus_onset_neureptrace.py
+++ b/src/pymegdec/stimulus_onset_neureptrace.py
@@ -1,0 +1,131 @@
+"""NeuRepTrace-backed stimulus onset-scan compatibility helpers.
+
+PyMEGDec no longer owns the reusable onset detector.  This module keeps the
+historical PyMEGDec output slots while delegating thresholding and event
+extraction to :mod:`neureptrace.onset_detection` on probability-observation CSVs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from neureptrace.onset_detection import (
+    DEFAULT_DETECTION_WINDOW,
+    DEFAULT_THRESHOLD_QUANTILE,
+    DEFAULT_THRESHOLD_WINDOW,
+    THRESHOLD_METHODS,
+    detect_onsets_from_csvs,
+)
+
+DEFAULT_ONSET_SCORE_COLUMN = "confidence"
+
+
+def _paths(paths: Sequence[str | Path]) -> list[Path]:
+    if not paths:
+        raise ValueError("At least one NeuRepTrace probability-observation CSV is required.")
+    return [Path(path) for path in paths]
+
+
+def _read_records(path: str | Path | None) -> list[dict[str, Any]]:
+    if path is None or not Path(path).exists():
+        return []
+    return pd.read_csv(path).to_dict(orient="records")
+
+
+def _copy_column(frame: pd.DataFrame, target: str, source: str) -> None:
+    if target not in frame.columns and source in frame.columns:
+        frame[target] = frame[source]
+
+
+def _compat_thresholded_observations(path: str | Path | None) -> list[dict[str, Any]]:
+    if path is None or not Path(path).exists():
+        return []
+    frame = pd.read_csv(path)
+    _copy_column(frame, "scan_window_center_s", "time")
+    _copy_column(frame, "scan_window_start_s", "window_start")
+    _copy_column(frame, "scan_window_stop_s", "window_stop")
+    _copy_column(frame, "threshold_window_start_s", "threshold_window_start")
+    _copy_column(frame, "threshold_window_stop_s", "threshold_window_stop")
+    _copy_column(frame, "stimulus_score", "onset_score")
+    _copy_column(frame, "stimulus_score", "confidence")
+    _copy_column(frame, "correct", "is_correct")
+    frame.to_csv(path, index=False)
+    return frame.to_dict(orient="records")
+
+
+def _compat_events(path: str | Path | None) -> list[dict[str, Any]]:
+    if path is None or not Path(path).exists():
+        return []
+    frame = pd.read_csv(path)
+    _copy_column(frame, "detection_window_center_s", "detection_time")
+    _copy_column(frame, "detection_latency_s", "detection_latency")
+    _copy_column(frame, "detected_before_stimulus", "detected_before_zero")
+    _copy_column(frame, "stimulus_score_at_detection", "score_at_detection")
+    _copy_column(frame, "predicted_stimulus_id_at_detection", "predicted_class_at_detection")
+    _copy_column(frame, "correct_detected_stimulus", "is_correct_at_detection")
+    _copy_column(frame, "threshold_window_start_s", "threshold_window_start")
+    _copy_column(frame, "threshold_window_stop_s", "threshold_window_stop")
+    _copy_column(frame, "min_duration_s", "min_duration")
+    _copy_column(frame, "detection_run_duration_s", "detection_run_duration")
+    _copy_column(frame, "detection_run_stop_time_s", "detection_run_stop_time")
+    _copy_column(frame, "stimulus_score_peak_in_run", "score_peak_in_run")
+    frame.to_csv(path, index=False)
+    return frame.to_dict(orient="records")
+
+
+def run_neureptrace_onset_scan(
+    observation_csvs: Sequence[str | Path],
+    *,
+    output_path: str | Path,
+    events_output_path: str | Path,
+    summary_output_path: str | Path | None = None,
+    event_summary_output_path: str | Path | None = None,
+    threshold_window: tuple[float, float] = DEFAULT_THRESHOLD_WINDOW,
+    threshold_quantile: float = DEFAULT_THRESHOLD_QUANTILE,
+    score_column: str = DEFAULT_ONSET_SCORE_COLUMN,
+    threshold_method: str = "point",
+    detection_start_s: float | None = None,
+    detection_window: tuple[float, float] = DEFAULT_DETECTION_WINDOW,
+    min_consecutive: int = 1,
+    min_duration: float | None = None,
+    require_stable_prediction: bool = False,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Run NeuRepTrace onset detection and return PyMEGDec-style row lists."""
+
+    events, event_summary = detect_onsets_from_csvs(
+        _paths(observation_csvs),
+        threshold_window=threshold_window,
+        threshold_quantile=threshold_quantile,
+        score_column=score_column,
+        threshold_method=threshold_method,
+        detection_start=detection_start_s,
+        detection_window=detection_window,
+        min_consecutive=min_consecutive,
+        min_duration=min_duration,
+        require_stable_prediction=require_stable_prediction,
+        out_events=Path(events_output_path),
+        out_summary=Path(event_summary_output_path) if event_summary_output_path else None,
+        out_thresholded_observations=Path(output_path),
+        out_threshold_summary=Path(summary_output_path) if summary_output_path else None,
+    )
+    scan_rows = _compat_thresholded_observations(output_path)
+    event_rows = _compat_events(events_output_path)
+    summary_rows = _read_records(summary_output_path)
+    event_summary_rows = event_summary.to_dict(orient="records")
+    if event_summary_output_path and not Path(event_summary_output_path).exists():
+        Path(event_summary_output_path).parent.mkdir(parents=True, exist_ok=True)
+        event_summary.to_csv(event_summary_output_path, index=False)
+    if not event_rows:
+        event_rows = events.to_dict(orient="records")
+    return scan_rows, event_rows, summary_rows, event_summary_rows
+
+
+__all__ = [
+    "DEFAULT_ONSET_SCORE_COLUMN",
+    "THRESHOLD_METHODS",
+    "run_neureptrace_onset_scan",
+]

--- a/src/pymegdec/stimulus_onset_neureptrace.py
+++ b/src/pymegdec/stimulus_onset_neureptrace.py
@@ -7,6 +7,7 @@ extraction to :mod:`neureptrace.onset_detection` on probability-observation CSVs
 
 from __future__ import annotations
 
+import argparse
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -21,7 +22,12 @@ from neureptrace.onset_detection import (
     detect_onsets_from_csvs,
 )
 
+from pymegdec.cli import normalize_argv, parse_float_or_inf
+
 DEFAULT_ONSET_SCORE_COLUMN = "confidence"
+DEFAULT_ONSET_MIN_CONSECUTIVE = 1
+DEFAULT_ONSET_MIN_DURATION = None
+DEFAULT_ONSET_REQUIRE_STABLE_PREDICTION = False
 
 
 def _paths(paths: Sequence[str | Path]) -> list[Path]:
@@ -77,6 +83,28 @@ def _compat_events(path: str | Path | None) -> list[dict[str, Any]]:
     return frame.to_dict(orient="records")
 
 
+def _time_window(value: str | Sequence[float]) -> tuple[float, float]:
+    if isinstance(value, str):
+        normalized = value.replace(":", ",")
+        parts = tuple(float(token.strip()) for token in normalized.split(",", maxsplit=1))
+    else:
+        parts = tuple(float(token) for token in value)
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError("Window must have the form start,stop or start:stop.")
+    if parts[0] > parts[1]:
+        raise argparse.ArgumentTypeError("Window start must be before stop.")
+    return parts
+
+
+def _optional_float(value: str | float | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip().lower() in {"", "none", "null", "nan"}:
+        return None
+    parsed = float(value)
+    return None if pd.isna(parsed) else parsed
+
+
 def run_neureptrace_onset_scan(
     observation_csvs: Sequence[str | Path],
     *,
@@ -90,9 +118,9 @@ def run_neureptrace_onset_scan(
     threshold_method: str = "point",
     detection_start_s: float | None = None,
     detection_window: tuple[float, float] = DEFAULT_DETECTION_WINDOW,
-    min_consecutive: int = 1,
-    min_duration: float | None = None,
-    require_stable_prediction: bool = False,
+    min_consecutive: int = DEFAULT_ONSET_MIN_CONSECUTIVE,
+    min_duration: float | None = DEFAULT_ONSET_MIN_DURATION,
+    require_stable_prediction: bool = DEFAULT_ONSET_REQUIRE_STABLE_PREDICTION,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """Run NeuRepTrace onset detection and return PyMEGDec-style row lists."""
 
@@ -124,8 +152,96 @@ def run_neureptrace_onset_scan(
     return scan_rows, event_rows, summary_rows, event_summary_rows
 
 
+def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description="Detect stimulus onsets from NeuRepTrace probability-observation CSVs.",
+    )
+    parser.add_argument("--observation-csv", "--observations", nargs="+", dest="observation_csvs", help="NeuRepTrace probability-observation CSVs or glob patterns.")
+    parser.add_argument("--threshold-window", type=_time_window, default=DEFAULT_THRESHOLD_WINDOW, help="Baseline threshold window as start,stop or start:stop in seconds.")
+    parser.add_argument("--threshold-quantile", type=float, default=DEFAULT_THRESHOLD_QUANTILE, help="Detection threshold quantile.")
+    parser.add_argument("--threshold-method", choices=THRESHOLD_METHODS, default="point")
+    parser.add_argument("--score-column", default=DEFAULT_ONSET_SCORE_COLUMN, help="Score column to threshold; confidence and probability_true_class can be inferred.")
+    parser.add_argument("--detection-start-s", type=parse_float_or_inf, default=None, help="Optional earliest scan center considered for first detection.")
+    parser.add_argument("--detection-window", type=_time_window, default=DEFAULT_DETECTION_WINDOW, help="Detection scan window as start,stop or start:stop.")
+    parser.add_argument("--min-consecutive", type=int, default=DEFAULT_ONSET_MIN_CONSECUTIVE)
+    parser.add_argument("--min-duration", type=float, default=DEFAULT_ONSET_MIN_DURATION)
+    parser.add_argument("--require-stable-prediction", action="store_true", default=DEFAULT_ONSET_REQUIRE_STABLE_PREDICTION)
+    parser.add_argument("--output", default="outputs/stimulus_onset_scan.csv", help="Thresholded observation output CSV.")
+    parser.add_argument("--events-output", default="outputs/stimulus_onset_events.csv", help="Onset-event output CSV.")
+    parser.add_argument("--summary-output", default="outputs/stimulus_onset_scan_summary.csv", help="Threshold-crossing summary CSV.")
+    parser.add_argument("--event-summary-output", default="outputs/stimulus_onset_event_summary.csv", help="Onset-event summary CSV.")
+
+    # Legacy raw BUSH-MEG scan options are accepted only to produce one clear
+    # migration error when old scripts are run unchanged.
+    parser.add_argument("--data-dir", dest="data_folder", help=argparse.SUPPRESS)
+    parser.add_argument("--participants", help=argparse.SUPPRESS)
+    parser.add_argument("--train-window-center", help=argparse.SUPPRESS)
+    parser.add_argument("--scan-time-window", help=argparse.SUPPRESS)
+    parser.add_argument("--window-step-s", help=argparse.SUPPRESS)
+    parser.add_argument("--window-size", help=argparse.SUPPRESS)
+    parser.add_argument("--null-window-center", help=argparse.SUPPRESS)
+    parser.add_argument("--transfer-direction", help=argparse.SUPPRESS)
+    parser.add_argument("--new-framerate", help=argparse.SUPPRESS)
+    parser.add_argument("--classifier", help=argparse.SUPPRESS)
+    parser.add_argument("--classifier-param", help=argparse.SUPPRESS)
+    parser.add_argument("--components-pca", help=argparse.SUPPRESS)
+    parser.add_argument("--frequency-range", nargs=2, help=argparse.SUPPRESS)
+    parser.add_argument("--chance-classes", help=argparse.SUPPRESS)
+    return parser
+
+
+def stimulus_onset_scan(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    """Compatibility CLI for NeuRepTrace onset detection."""
+
+    parser = _build_parser(prog=prog)
+    args = parser.parse_args(normalize_argv(argv))
+    if not args.observation_csvs:
+        parser.error(
+            "PyMEGDec no longer performs raw BUSH-MEG onset scans from Part*Data.mat files. "
+            "Generate NeuRepTrace probability observations first, then pass them with --observation-csv. "
+            "You can also call `neureptrace onset-detect` directly."
+        )
+    if not 0.0 <= args.threshold_quantile <= 1.0:
+        parser.error("--threshold-quantile must be between 0 and 1.")
+    if args.min_consecutive < 1:
+        parser.error("--min-consecutive must be at least 1.")
+    if args.min_duration is not None and args.min_duration < 0:
+        parser.error("--min-duration must be non-negative.")
+
+    scan_rows, event_rows, summary_rows, event_summary_rows = run_neureptrace_onset_scan(
+        args.observation_csvs,
+        output_path=args.output,
+        events_output_path=args.events_output,
+        summary_output_path=args.summary_output,
+        event_summary_output_path=args.event_summary_output,
+        threshold_window=args.threshold_window,
+        threshold_quantile=args.threshold_quantile,
+        score_column=args.score_column,
+        threshold_method=args.threshold_method,
+        detection_start_s=_optional_float(args.detection_start_s),
+        detection_window=args.detection_window,
+        min_consecutive=args.min_consecutive,
+        min_duration=args.min_duration,
+        require_stable_prediction=args.require_stable_prediction,
+    )
+    print(f"Wrote {len(scan_rows)} thresholded observation rows to {args.output}")
+    print(f"Wrote {len(event_rows)} onset event rows to {args.events_output}")
+    print(f"Wrote {len(summary_rows)} threshold summary rows to {args.summary_output}")
+    print(f"Wrote {len(event_summary_rows)} event summary rows to {args.event_summary_output}")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return stimulus_onset_scan(argv)
+
+
 __all__ = [
+    "DEFAULT_ONSET_MIN_CONSECUTIVE",
+    "DEFAULT_ONSET_MIN_DURATION",
+    "DEFAULT_ONSET_REQUIRE_STABLE_PREDICTION",
     "DEFAULT_ONSET_SCORE_COLUMN",
     "THRESHOLD_METHODS",
     "run_neureptrace_onset_scan",
+    "stimulus_onset_scan",
 ]

--- a/src/pymegdec/stimulus_onset_neureptrace.py
+++ b/src/pymegdec/stimulus_onset_neureptrace.py
@@ -8,6 +8,7 @@ extraction to :mod:`neureptrace.onset_detection` on probability-observation CSVs
 from __future__ import annotations
 
 import argparse
+import glob
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -33,7 +34,19 @@ DEFAULT_ONSET_REQUIRE_STABLE_PREDICTION = False
 def _paths(paths: Sequence[str | Path]) -> list[Path]:
     if not paths:
         raise ValueError("At least one NeuRepTrace probability-observation CSV is required.")
-    return [Path(path) for path in paths]
+    resolved: list[Path] = []
+    for item in paths:
+        text = str(item)
+        matches = sorted(glob.glob(text))
+        if matches:
+            resolved.extend(Path(match) for match in matches)
+        elif Path(text).exists():
+            resolved.append(Path(text))
+        else:
+            raise FileNotFoundError(f"Observation CSV input does not exist or match any file: {text}")
+    if not resolved:
+        raise ValueError("No NeuRepTrace probability-observation CSVs were resolved.")
+    return resolved
 
 
 def _read_records(path: str | Path | None) -> list[dict[str, Any]]:

--- a/tests/test_stimulus_onset_neureptrace.py
+++ b/tests/test_stimulus_onset_neureptrace.py
@@ -1,0 +1,125 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from pymegdec import stimulus_onset_neureptrace as onset
+
+
+def _observation_rows() -> pd.DataFrame:
+    rows = []
+    for sequence_id, label in [("trial0", 0), ("trial1", 1)]:
+        for time, confidence in [(-0.10, 0.20), (-0.05, 0.25), (0.00, 0.95), (0.05, 0.90)]:
+            p_true = confidence
+            p_other = 1.0 - confidence
+            if label == 0:
+                probs = (p_true, p_other)
+                predicted = 0 if p_true >= p_other else 1
+            else:
+                probs = (p_other, p_true)
+                predicted = 1 if p_true >= p_other else 0
+            rows.append(
+                {
+                    "subject": "s1",
+                    "decoder": "demo",
+                    "emission_mode": "calibrated",
+                    "sequence_id": sequence_id,
+                    "sample_index": sequence_id,
+                    "time": time,
+                    "window_start": time - 0.0125,
+                    "window_stop": time + 0.0125,
+                    "true_label": label,
+                    "true_class": f"class_{label}",
+                    "class_0": "class_0",
+                    "class_1": "class_1",
+                    "predicted_label": predicted,
+                    "predicted_class": f"class_{predicted}",
+                    "prob_class_0": probs[0],
+                    "prob_class_1": probs[1],
+                    "confidence": max(probs),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+class TestStimulusOnsetNeuRepTrace(unittest.TestCase):
+    def test_run_neureptrace_onset_scan_writes_pymegdec_compat_outputs(self):
+        with tempfile.TemporaryDirectory(prefix="pymegdec-onset-test-") as tmp:
+            root = Path(tmp)
+            observations = root / "observations.csv"
+            scan = root / "scan.csv"
+            events = root / "events.csv"
+            summary = root / "summary.csv"
+            event_summary = root / "event_summary.csv"
+            _observation_rows().to_csv(observations, index=False)
+
+            scan_rows, event_rows, summary_rows, event_summary_rows = onset.run_neureptrace_onset_scan(
+                [observations],
+                output_path=scan,
+                events_output_path=events,
+                summary_output_path=summary,
+                event_summary_output_path=event_summary,
+                threshold_window=(-0.10, -0.05),
+                threshold_quantile=1.0,
+                threshold_method="point",
+                detection_start_s=0.0,
+            )
+
+            self.assertTrue(scan.exists())
+            self.assertTrue(events.exists())
+            self.assertTrue(summary.exists())
+            self.assertTrue(event_summary.exists())
+            self.assertEqual(len(scan_rows), 8)
+            self.assertEqual(len(event_rows), 2)
+            self.assertTrue(all(row["detected"] for row in event_rows))
+            self.assertIn("scan_window_center_s", pd.read_csv(scan).columns)
+            self.assertIn("detection_window_center_s", pd.read_csv(events).columns)
+            self.assertTrue(summary_rows)
+            self.assertTrue(event_summary_rows)
+
+    def test_cli_requires_observation_csvs(self):
+        with self.assertRaises(SystemExit) as caught:
+            onset.stimulus_onset_scan(["--participants", "1-2"])
+        self.assertNotEqual(caught.exception.code, 0)
+
+    def test_cli_delegates_to_neureptrace_observation_csvs(self):
+        with tempfile.TemporaryDirectory(prefix="pymegdec-onset-cli-test-") as tmp:
+            root = Path(tmp)
+            observations = root / "observations.csv"
+            scan = root / "scan.csv"
+            events = root / "events.csv"
+            summary = root / "summary.csv"
+            event_summary = root / "event_summary.csv"
+            _observation_rows().to_csv(observations, index=False)
+
+            status = onset.stimulus_onset_scan(
+                [
+                    "--observation-csv",
+                    str(observations),
+                    "--threshold-window",
+                    "-0.10,-0.05",
+                    "--threshold-quantile",
+                    "1.0",
+                    "--detection-start-s",
+                    "0.0",
+                    "--output",
+                    str(scan),
+                    "--events-output",
+                    str(events),
+                    "--summary-output",
+                    str(summary),
+                    "--event-summary-output",
+                    str(event_summary),
+                ]
+            )
+
+            self.assertEqual(status, 0)
+            self.assertTrue(scan.exists())
+            self.assertTrue(events.exists())
+            self.assertTrue(summary.exists())
+            self.assertTrue(event_summary.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `pymegdec.stimulus_onset_neureptrace`, a compatibility wrapper around `neureptrace.onset_detection.detect_onsets_from_csvs`
- route grouped/top-level PyMEGDec onset-scan commands through NeuRepTrace probability-observation CSVs via `--observation-csv`
- replace the legacy onset-scan script wrapper with the NeuRepTrace-backed entry point
- update the manual onset benchmark workflow to consume NeuRepTrace probability observation CSVs instead of private raw MEG MAT files
- update the operating-point sweep script to use NeuRepTrace's public `detect_onsets` and `summarize_onset_events` APIs
- document the new migration boundary and add focused tests for the NeuRepTrace-backed onset path

## Migration note

The reusable onset detector and threshold/event logic now live in NeuRepTrace. PyMEGDec keeps only compatibility entry points and output-file naming conventions. New workflows should produce NeuRepTrace probability observation tables and call `neureptrace onset-detect` directly.

## Validation

- Inspected the branch diff via the GitHub connector.
- Tests were not run locally in this environment; CI should run the added focused tests.
- `main` advanced while preparing this branch, so the PR may need an update branch step before merge.