### PR TITLE
Add sharded nested stimulus matrix workflow

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -1,0 +1,421 @@
+name: Manual stimulus cross-subject nested matrix
+#checkov:skip=CKV_GHA_7:Manual workflow inputs are constrained to benchmark sharding parameters.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_type:
+        description: Runner backend used for shard jobs.
+        required: true
+        default: self-hosted
+        type: choice
+        options: [github-hosted, self-hosted]
+      self_hosted_runner_label:
+        description: Self-hosted runner label.
+        required: true
+        default: self-hosted
+        type: string
+      use_nextcloud_data:
+        description: Restore/download/cache the MEG data before running shards.
+        required: true
+        default: true
+        type: boolean
+      config_bundle:
+        description: Named candidate bundle to shard. Use all only for a broader screening pass.
+        required: true
+        default: windowed_logreg_lean
+        type: choice
+        options:
+          - windowed_logreg_lean
+          - windowed_logreg_core
+          - feature_check
+          - lda_svm_check
+          - all
+      benchmark_preset:
+        description: Screening keeps the trial cap; final-all-trials ignores it and can exceed 2h per shard.
+        required: true
+        default: screening
+        type: choice
+        options: [screening, final-all-trials]
+      participants:
+        description: Participant ids used for training and held-out shards.
+        required: true
+        default: "1-4,6,8,9,10,13-27"
+        type: string
+      participants_per_job:
+        description: Number of held-out participants per matrix job. Use 1 for the safest <2h target.
+        required: true
+        default: "1"
+        type: choice
+        options: ["1", "2", "4"]
+      max_parallel:
+        description: Maximum matrix shard jobs to run concurrently.
+        required: true
+        default: "4"
+        type: choice
+        options: ["1", "2", "4", "8"]
+      per_job_timeout_minutes:
+        description: Timeout for each shard job.
+        required: true
+        default: "120"
+        type: choice
+        options: ["60", "90", "120", "180"]
+      max_trials_per_class_per_participant:
+        description: Screening trial cap per stimulus class and participant.
+        required: false
+        default: "10"
+        type: string
+      label_shuffle_control:
+        description: Shuffle training labels within each participant as a nested null control.
+        required: true
+        default: false
+        type: boolean
+      label_shuffle_seed:
+        description: Seed for the nested label-shuffle control.
+        required: true
+        default: "0"
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  prepare-matrix:
+    name: Prepare nested matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      shard_count: ${{ steps.matrix.outputs.shard_count }}
+    steps:
+      - name: Build matrix
+        id: matrix
+        shell: python
+        env:
+          CONFIG_BUNDLE: ${{ inputs.config_bundle }}
+          PARTICIPANTS: ${{ inputs.participants }}
+          PARTICIPANTS_PER_JOB: ${{ inputs.participants_per_job }}
+        run: |
+          import json
+          import os
+
+          bundles = {
+              "windowed_logreg_lean": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_classifier",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_core": {
+                  "window_centers": "0.150,0.175,0.200,0.225",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_classifier",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "feature_check": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat,sensor_mean_slope_std",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic-weighted",
+                  "classifier_params": "1",
+                  "components_pca_values": "64",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_classifier",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "lda_svm_check": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "shrinkage-lda,multiclass-svm",
+                  "classifier_params": "default",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_classifier",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+          }
+
+          def parse_participants(spec):
+              values = []
+              for token in spec.split(","):
+                  token = token.strip()
+                  if not token:
+                      continue
+                  if "-" in token:
+                      start, stop = token.split("-", 1)
+                      values.extend(range(int(start), int(stop) + 1))
+                  else:
+                      values.append(int(token))
+              return sorted(dict.fromkeys(values))
+
+          def chunks(values, size):
+              for index in range(0, len(values), size):
+                  yield values[index:index + size]
+
+          requested = os.environ["CONFIG_BUNDLE"]
+          selected_ids = tuple(bundles) if requested == "all" else (requested,)
+          participants = parse_participants(os.environ["PARTICIPANTS"])
+          participants_per_job = int(os.environ["PARTICIPANTS_PER_JOB"])
+          include = []
+          for bundle_id in selected_ids:
+              for participant_chunk in chunks(participants, participants_per_job):
+                  outer_participants = ",".join(str(participant) for participant in participant_chunk)
+                  outer_label = "p" + "-p".join(f"{participant:02d}" for participant in participant_chunk)
+                  include.append({
+                      "config_id": bundle_id,
+                      "outer_participants": outer_participants,
+                      "outer_label": outer_label,
+                      **bundles[bundle_id],
+                  })
+
+          matrix = json.dumps({"include": include}, separators=(",", ":"))
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"matrix={matrix}\n")
+              output.write(f"shard_count={len(include)}\n")
+
+  nested-matrix:
+    name: Nested ${{ matrix.config_id }} ${{ matrix.outer_label }}
+    needs: prepare-matrix
+    runs-on: ${{ inputs.runner_type == 'github-hosted' && 'ubuntu-latest' || inputs.self_hosted_runner_label }}
+    timeout-minutes: ${{ fromJSON(inputs.per_job_timeout_minutes) }}
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ fromJSON(inputs.max_parallel) }}
+      matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
+    env:
+      DATA_DIR: .cache/meg-data-main
+      DATA_CACHE_VERSION: v2
+      USE_NEXTCLOUD_DATA: ${{ inputs.use_nextcloud_data }}
+      BENCHMARK_PRESET: ${{ inputs.benchmark_preset }}
+      OUTPUT_STEM: matrix_${{ matrix.config_id }}_${{ matrix.outer_label }}
+      PARTICIPANTS: ${{ inputs.participants }}
+      OUTER_PARTICIPANTS: ${{ matrix.outer_participants }}
+      WINDOW_CENTERS: ${{ matrix.window_centers }}
+      WINDOW_SIZE: "0.1"
+      BASELINE_WINDOW: "-0.35,-0.05"
+      FEATURE_MODES: ${{ matrix.feature_modes }}
+      NORMALIZATIONS: ${{ matrix.normalizations }}
+      ALIGNMENTS: ${{ matrix.alignments }}
+      CLASSIFIERS: ${{ matrix.classifiers }}
+      CLASSIFIER_PARAMS: ${{ matrix.classifier_params }}
+      COMPONENTS_PCA_VALUES: ${{ matrix.components_pca_values }}
+      SELECTION_ENSEMBLE_SIZE: ${{ matrix.selection_ensemble_size }}
+      SELECTION_ENSEMBLE_DIVERSITY: ${{ matrix.selection_ensemble_diversity }}
+      SELECTION_ENSEMBLE_SCORE_NORMALIZATION: ${{ matrix.selection_ensemble_score_normalization }}
+      SELECTION_ENSEMBLE_WEIGHTING: ${{ matrix.selection_ensemble_weighting }}
+      SELECTION_ENSEMBLE_TEMPERATURE: ${{ matrix.selection_ensemble_temperature }}
+      MAX_TRIALS_PER_CLASS_PER_PARTICIPANT: ${{ inputs.max_trials_per_class_per_participant }}
+      LABEL_SHUFFLE_CONTROL: ${{ inputs.label_shuffle_control }}
+      LABEL_SHUFFLE_SEED: ${{ inputs.label_shuffle_seed }}
+      MAIN_FILE_NAMES: >-
+        Part1Data.mat,Part2Data.mat,Part3Data.mat,Part4Data.mat,Part6Data.mat,
+        Part8Data.mat,Part9Data.mat,Part10Data.mat,Part13Data.mat,Part14Data.mat,
+        Part15Data.mat,Part16Data.mat,Part17Data.mat,Part18Data.mat,Part19Data.mat,
+        Part20Data.mat,Part21Data.mat,Part22Data.mat,Part23Data.mat,Part24Data.mat,
+        Part25Data.mat,Part26Data.mat,Part27Data.mat
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Prepare main MEG data
+        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
+        timeout-minutes: 90
+        uses: ./.github/actions/prepare-meg-data
+        with:
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          cache-key: meg-data-main-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+          file-names: ${{ env.MAIN_FILE_NAMES }}
+          require-cue-files: "false"
+          expected-main-files: "23"
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Validate main data files
+        shell: bash
+        run: |
+          set -euo pipefail
+          main_count="$(find -L "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+          echo "Main files: ${main_count}"
+          test "${main_count}" -ge 23
+
+      - name: Run nested shard
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs
+          output_prefix="outputs/${OUTPUT_STEM}"
+          effective_trial_cap="${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}"
+          if [[ "${BENCHMARK_PRESET}" == "final-all-trials" ]]; then
+            effective_trial_cap=""
+          fi
+          echo "Config bundle: ${{ matrix.config_id }}"
+          echo "Outer participant shard: ${OUTER_PARTICIPANTS}"
+          echo "Output prefix: ${output_prefix}"
+          args=(
+            python scripts/export_stimulus_cross_subject_nested.py
+            --data-dir "${DATA_DIR}"
+            --participants "${PARTICIPANTS}"
+            --outer-participants "${OUTER_PARTICIPANTS}"
+            --window-centers "${WINDOW_CENTERS}"
+            --window-size "${WINDOW_SIZE}"
+            --baseline-window "${BASELINE_WINDOW}"
+            --feature-modes "${FEATURE_MODES}"
+            --normalizations "${NORMALIZATIONS}"
+            --alignments "${ALIGNMENTS}"
+            --classifiers "${CLASSIFIERS}"
+            --classifier-params "${CLASSIFIER_PARAMS}"
+            --components-pca-values "${COMPONENTS_PCA_VALUES}"
+            --selection-ensemble-size "${SELECTION_ENSEMBLE_SIZE}"
+            --selection-ensemble-diversity "${SELECTION_ENSEMBLE_DIVERSITY}"
+            --selection-ensemble-score-normalization "${SELECTION_ENSEMBLE_SCORE_NORMALIZATION}"
+            --selection-ensemble-weighting "${SELECTION_ENSEMBLE_WEIGHTING}"
+            --selection-ensemble-temperature "${SELECTION_ENSEMBLE_TEMPERATURE}"
+            --outer-output "${output_prefix}_outer.csv"
+            --summary-output "${output_prefix}_group_summary.csv"
+            --inner-validation-output "${output_prefix}_inner_validation.csv"
+            --selected-output "${output_prefix}_selected.csv"
+            --predictions-output "${output_prefix}_predictions.csv"
+            --confusion-output "${output_prefix}_confusion.csv"
+            --per-stimulus-output "${output_prefix}_per_stimulus.csv"
+            --confusion-pairs-output "${output_prefix}_confusion_pairs.csv"
+            --write-incremental
+          )
+          if [[ -n "${effective_trial_cap}" ]]; then
+            args+=(--max-trials-per-class-per-participant "${effective_trial_cap}")
+          fi
+          if [[ "${LABEL_SHUFFLE_CONTROL}" == "true" ]]; then
+            args+=(--label-shuffle-control --label-shuffle-seed "${LABEL_SHUFFLE_SEED}")
+          fi
+          "${args[@]}"
+
+      - name: Upload nested shard outputs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: nested-matrix-${{ matrix.config_id }}-${{ matrix.outer_label }}
+          path: outputs/*.csv
+          if-no-files-found: warn
+
+  aggregate-matrix:
+    name: Aggregate nested matrix
+    needs: [prepare-matrix, nested-matrix]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Download shard artifacts
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          pattern: nested-matrix-*
+          path: shard-artifacts
+          merge-multiple: false
+
+      - name: Aggregate completed shards
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pymegdec.stimulus_nested_matrix \
+            --input-dir shard-artifacts \
+            --output-dir outputs \
+            --output-stem nested_matrix
+
+      - name: Append aggregate summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import csv
+          import os
+          from pathlib import Path
+
+          path = Path("outputs/nested_matrix_group_summary.csv")
+          if not path.exists():
+              Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("# Nested matrix\n\nNo aggregate summary was produced.\n", encoding="utf-8")
+              raise SystemExit(0)
+
+          rows = list(csv.DictReader(path.open(newline="", encoding="utf-8")))
+          lines = [
+              "# Nested matrix",
+              "",
+              f"Aggregated {len(rows)} completed config bundle(s).",
+              "",
+              "| config bundle | outer folds | candidates | balanced accuracy | top-2 | top-3 | selected classifiers | selected windows |",
+              "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+          ]
+          for row in rows:
+              lines.append(
+                  "| {bundle} | {folds} | {candidates} | {balanced:.2f}% | {top2:.2f}% | {top3:.2f}% | {classifiers} | {windows} |".format(
+                      bundle=row.get("matrix_config_bundle", ""),
+                      folds=row.get("n_outer_folds", ""),
+                      candidates=row.get("n_candidates", ""),
+                      balanced=float(row.get("balanced_percent_mean", "nan")),
+                      top2=float(row.get("top2_percent_mean", "nan")),
+                      top3=float(row.get("top3_percent_mean", "nan")),
+                      classifiers=row.get("selected_classifier_counts", ""),
+                      windows=row.get("selected_window_center_counts", ""),
+                  )
+              )
+          Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload aggregate outputs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: nested-matrix-aggregate
+          path: outputs/*.csv
+          if-no-files-found: warn

--- a/src/pymegdec/stimulus_nested_matrix.py
+++ b/src/pymegdec/stimulus_nested_matrix.py
@@ -1,0 +1,166 @@
+"""Aggregate sharded nested cross-subject stimulus benchmark outputs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+from pymegdec.stimulus_cross_subject import (
+    summarize_cross_subject_confusion_pairs,
+    summarize_cross_subject_predictions,
+    summarize_nested_cross_subject_stimulus,
+)
+
+SHARD_OUTER_RE = re.compile(r"^matrix_(?P<bundle>.+)_p\d+(?:-p\d+)*_outer\.csv$")
+SHARD_SUFFIXES = {
+    "outer": "_outer.csv",
+    "inner_validation": "_inner_validation.csv",
+    "selected": "_selected.csv",
+    "predictions": "_predictions.csv",
+}
+
+
+def _read_rows(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _with_bundle(rows: Iterable[dict[str, str]], bundle: str) -> list[dict[str, str]]:
+    return [{**row, "matrix_config_bundle": bundle} for row in rows]
+
+
+def _write_rows(path: Path, rows: list[dict]) -> None:
+    if rows:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_alpha_metrics_csv(_rows_with_consistent_fields(rows), path)
+
+
+def _rows_with_consistent_fields(rows: list[dict]) -> list[dict]:
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    return [{key: row.get(key, "") for key in fieldnames} for row in rows]
+
+
+def _shard_path(outer_path: Path, kind: str) -> Path:
+    return outer_path.with_name(outer_path.name.removesuffix(SHARD_SUFFIXES["outer"]) + SHARD_SUFFIXES[kind])
+
+
+def discover_nested_matrix_shards(input_dir: Path) -> dict[str, list[Path]]:
+    """Return outer shard CSVs grouped by matrix configuration bundle."""
+
+    shards: dict[str, list[Path]] = defaultdict(list)
+    for path in sorted(input_dir.rglob("matrix_*_p*_outer.csv")):
+        match = SHARD_OUTER_RE.match(path.name)
+        if match:
+            shards[match.group("bundle")].append(path)
+    return dict(shards)
+
+
+def aggregate_nested_matrix_outputs(
+    input_dir: Path,
+    output_dir: Path,
+    *,
+    output_stem: str = "nested_matrix",
+    signflip_permutations: int = 10_000,
+    signflip_seed: int = 0,
+) -> dict[str, list[dict]]:
+    """Combine completed nested matrix shards and recompute bundle summaries."""
+
+    shards_by_bundle = discover_nested_matrix_shards(input_dir)
+    if not shards_by_bundle:
+        raise ValueError(f"No nested matrix outer shard CSVs found below {input_dir}.")
+
+    all_outer: list[dict] = []
+    all_inner: list[dict] = []
+    all_selected: list[dict] = []
+    all_predictions: list[dict] = []
+    all_summaries: list[dict] = []
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for bundle, outer_paths in sorted(shards_by_bundle.items()):
+        outer_rows: list[dict] = []
+        inner_rows: list[dict] = []
+        selected_rows: list[dict] = []
+        prediction_rows: list[dict] = []
+        for outer_path in outer_paths:
+            outer_rows.extend(_with_bundle(_read_rows(outer_path), bundle))
+            inner_rows.extend(_with_bundle(_read_rows(_shard_path(outer_path, "inner_validation")), bundle))
+            selected_rows.extend(_with_bundle(_read_rows(_shard_path(outer_path, "selected")), bundle))
+            prediction_rows.extend(_with_bundle(_read_rows(_shard_path(outer_path, "predictions")), bundle))
+
+        summary_rows = summarize_nested_cross_subject_stimulus(
+            outer_rows,
+            signflip_permutations=signflip_permutations,
+            signflip_seed=signflip_seed,
+        )
+        summary_rows = [{**row, "matrix_config_bundle": bundle} for row in summary_rows]
+        confusion_rows, per_stimulus_rows = summarize_cross_subject_predictions(prediction_rows)
+        confusion_pair_rows = summarize_cross_subject_confusion_pairs(prediction_rows)
+
+        bundle_stem = f"{output_stem}_{bundle}"
+        _write_rows(output_dir / f"{bundle_stem}_outer.csv", outer_rows)
+        _write_rows(output_dir / f"{bundle_stem}_inner_validation.csv", inner_rows)
+        _write_rows(output_dir / f"{bundle_stem}_selected.csv", selected_rows)
+        _write_rows(output_dir / f"{bundle_stem}_predictions.csv", prediction_rows)
+        _write_rows(output_dir / f"{bundle_stem}_group_summary.csv", summary_rows)
+        _write_rows(output_dir / f"{bundle_stem}_confusion.csv", _with_bundle(confusion_rows, bundle))
+        _write_rows(output_dir / f"{bundle_stem}_per_stimulus.csv", _with_bundle(per_stimulus_rows, bundle))
+        _write_rows(output_dir / f"{bundle_stem}_confusion_pairs.csv", _with_bundle(confusion_pair_rows, bundle))
+
+        all_outer.extend(outer_rows)
+        all_inner.extend(inner_rows)
+        all_selected.extend(selected_rows)
+        all_predictions.extend(prediction_rows)
+        all_summaries.extend(summary_rows)
+
+    _write_rows(output_dir / f"{output_stem}_outer.csv", all_outer)
+    _write_rows(output_dir / f"{output_stem}_inner_validation.csv", all_inner)
+    _write_rows(output_dir / f"{output_stem}_selected.csv", all_selected)
+    _write_rows(output_dir / f"{output_stem}_predictions.csv", all_predictions)
+    _write_rows(output_dir / f"{output_stem}_group_summary.csv", all_summaries)
+    return {
+        "outer": all_outer,
+        "inner_validation": all_inner,
+        "selected": all_selected,
+        "predictions": all_predictions,
+        "group_summary": all_summaries,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", type=Path, required=True, help="Directory containing downloaded nested matrix shard artifacts.")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Directory for aggregated CSV outputs.")
+    parser.add_argument("--output-stem", default="nested_matrix", help="Stem for aggregate output CSVs.")
+    parser.add_argument("--signflip-permutations", type=int, default=10_000)
+    parser.add_argument("--signflip-seed", type=int, default=0)
+    args = parser.parse_args(argv)
+
+    artifacts = aggregate_nested_matrix_outputs(
+        args.input_dir,
+        args.output_dir,
+        output_stem=args.output_stem,
+        signflip_permutations=args.signflip_permutations,
+        signflip_seed=args.signflip_seed,
+    )
+    print(
+        "Aggregated "
+        f"{len(artifacts['outer'])} outer row(s), "
+        f"{len(artifacts['selected'])} selected row(s), "
+        f"and {len(artifacts['group_summary'])} bundle summary row(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stimulus_nested_matrix.py
+++ b/tests/test_stimulus_nested_matrix.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import csv
+import tempfile
+import unittest
 from pathlib import Path
-
-import pytest
 
 from pymegdec.stimulus_nested_matrix import aggregate_nested_matrix_outputs, discover_nested_matrix_shards
 
@@ -63,45 +63,67 @@ def _selected_row(participant: int) -> dict:
     }
 
 
-def test_discovers_nested_matrix_shards_by_bundle(tmp_path: Path):
-    _write_csv(tmp_path / "nested-matrix-logreg-p1" / "matrix_logreg_p1_outer.csv", [_outer_row(1, balanced=0.1)])
-    _write_csv(tmp_path / "nested-matrix-feature-p2" / "matrix_feature_p2_outer.csv", [_outer_row(2, balanced=0.2)])
+class TestStimulusNestedMatrix(unittest.TestCase):
+    def test_discovers_nested_matrix_shards_by_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            _write_csv(tmp_path / "nested-matrix-logreg-p1" / "matrix_logreg_p1_outer.csv", [_outer_row(1, balanced=0.1)])
+            _write_csv(tmp_path / "nested-matrix-feature-p2" / "matrix_feature_p2_outer.csv", [_outer_row(2, balanced=0.2)])
 
-    shards = discover_nested_matrix_shards(tmp_path)
+            shards = discover_nested_matrix_shards(tmp_path)
 
-    assert sorted(shards) == ["feature", "logreg"]
-    assert [path.name for path in shards["logreg"]] == ["matrix_logreg_p1_outer.csv"]
+            self.assertEqual(sorted(shards), ["feature", "logreg"])
+            self.assertEqual([path.name for path in shards["logreg"]], ["matrix_logreg_p1_outer.csv"])
+
+    def test_aggregates_nested_matrix_shards_and_recomputes_bundle_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            for participant, balanced in [(1, 0.10), (2, 0.20)]:
+                stem = tmp_path / f"nested-matrix-logreg-p{participant}" / f"matrix_logreg_p{participant}"
+                _write_csv(stem.with_name(f"{stem.name}_outer.csv"), [_outer_row(participant, balanced=balanced)])
+                _write_csv(stem.with_name(f"{stem.name}_selected.csv"), [_selected_row(participant)])
+                _write_csv(
+                    stem.with_name(f"{stem.name}_inner_validation.csv"),
+                    [{"test_participant": participant, "candidate_index": participant, "balanced_accuracy": balanced}],
+                )
+
+            artifacts = aggregate_nested_matrix_outputs(
+                tmp_path,
+                tmp_path / "out",
+                output_stem="nested_matrix",
+                signflip_permutations=0,
+            )
+            summary = list(csv.DictReader((tmp_path / "out" / "nested_matrix_group_summary.csv").open(newline="", encoding="utf-8")))
+            selected = list(csv.DictReader((tmp_path / "out" / "nested_matrix_selected.csv").open(newline="", encoding="utf-8")))
+
+            self.assertEqual(len(artifacts["outer"]), 2)
+            self.assertEqual(len(summary), 1)
+            self.assertEqual(summary[0]["matrix_config_bundle"], "logreg")
+            self.assertAlmostEqual(float(summary[0]["balanced_accuracy_mean"]), 0.15)
+            self.assertEqual(summary[0]["participants_total"], "2")
+            self.assertEqual({row["matrix_config_bundle"] for row in selected}, {"logreg"})
+
+    def test_aggregates_multiple_config_bundles_separately(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            _write_csv(tmp_path / "nested-matrix-logreg-p1" / "matrix_logreg_p1_outer.csv", [_outer_row(1, balanced=0.10)])
+            _write_csv(
+                tmp_path / "nested-matrix-feature-p1" / "matrix_feature_p1_outer.csv",
+                [_outer_row(1, balanced=0.30, bundle_classifier="shrinkage-lda")],
+            )
+
+            aggregate_nested_matrix_outputs(
+                tmp_path,
+                tmp_path / "out",
+                output_stem="nested_matrix",
+                signflip_permutations=0,
+            )
+            summary = list(csv.DictReader((tmp_path / "out" / "nested_matrix_group_summary.csv").open(newline="", encoding="utf-8")))
+
+            self.assertEqual([row["matrix_config_bundle"] for row in summary], ["feature", "logreg"])
+            self.assertTrue((tmp_path / "out" / "nested_matrix_feature_group_summary.csv").exists())
+            self.assertTrue((tmp_path / "out" / "nested_matrix_logreg_group_summary.csv").exists())
 
 
-def test_aggregates_nested_matrix_shards_and_recomputes_bundle_summary(tmp_path: Path):
-    for participant, balanced in [(1, 0.10), (2, 0.20)]:
-        stem = tmp_path / f"nested-matrix-logreg-p{participant}" / f"matrix_logreg_p{participant}"
-        _write_csv(stem.with_name(f"{stem.name}_outer.csv"), [_outer_row(participant, balanced=balanced)])
-        _write_csv(stem.with_name(f"{stem.name}_selected.csv"), [_selected_row(participant)])
-        _write_csv(
-            stem.with_name(f"{stem.name}_inner_validation.csv"),
-            [{"test_participant": participant, "candidate_index": participant, "balanced_accuracy": balanced}],
-        )
-
-    artifacts = aggregate_nested_matrix_outputs(tmp_path, tmp_path / "out", output_stem="nested_matrix", signflip_permutations=0)
-    summary = list(csv.DictReader((tmp_path / "out" / "nested_matrix_group_summary.csv").open(newline="", encoding="utf-8")))
-    selected = list(csv.DictReader((tmp_path / "out" / "nested_matrix_selected.csv").open(newline="", encoding="utf-8")))
-
-    assert len(artifacts["outer"]) == 2
-    assert len(summary) == 1
-    assert summary[0]["matrix_config_bundle"] == "logreg"
-    assert float(summary[0]["balanced_accuracy_mean"]) == pytest.approx(0.15)
-    assert summary[0]["participants_total"] == "2"
-    assert {row["matrix_config_bundle"] for row in selected} == {"logreg"}
-
-
-def test_aggregates_multiple_config_bundles_separately(tmp_path: Path):
-    _write_csv(tmp_path / "nested-matrix-logreg-p1" / "matrix_logreg_p1_outer.csv", [_outer_row(1, balanced=0.10)])
-    _write_csv(tmp_path / "nested-matrix-feature-p1" / "matrix_feature_p1_outer.csv", [_outer_row(1, balanced=0.30, bundle_classifier="shrinkage-lda")])
-
-    aggregate_nested_matrix_outputs(tmp_path, tmp_path / "out", output_stem="nested_matrix", signflip_permutations=0)
-    summary = list(csv.DictReader((tmp_path / "out" / "nested_matrix_group_summary.csv").open(newline="", encoding="utf-8")))
-
-    assert [row["matrix_config_bundle"] for row in summary] == ["feature", "logreg"]
-    assert (tmp_path / "out" / "nested_matrix_feature_group_summary.csv").exists()
-    assert (tmp_path / "out" / "nested_matrix_logreg_group_summary.csv").exists()
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stimulus_nested_matrix.py
+++ b/tests/test_stimulus_nested_matrix.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from pymegdec.stimulus_nested_matrix import aggregate_nested_matrix_outputs, discover_nested_matrix_shards
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _outer_row(participant: int, *, balanced: float, bundle_classifier: str = "multinomial-logistic") -> dict:
+    return {
+        "test_participant": participant,
+        "accuracy": balanced,
+        "balanced_accuracy": balanced,
+        "chance_accuracy": 0.0625,
+        "top2_accuracy": min(1.0, balanced + 0.1),
+        "top3_accuracy": min(1.0, balanced + 0.2),
+        "mean_true_label_rank": 4.0,
+        "selected_candidate_index": participant,
+        "selected_candidate_indices": str(participant),
+        "selected_classifier": bundle_classifier,
+        "selected_window_center_s": 0.175,
+        "selected_feature_mode": "sensor_flat",
+        "selected_normalization": "subject_baseline_whiten",
+        "selected_alignment": "none",
+        "selected_components_pca": 64,
+        "selected_inner_winner_margin": 0.01,
+        "max_trials_per_class_per_participant": 10,
+        "n_candidates": 2,
+        "label_shuffle_control": False,
+        "label_shuffle_seed": 0,
+        "outer_evaluation_mode": "topk_score_ensemble",
+        "selection_ensemble_size": 2,
+        "selection_ensemble_diversity": "window_classifier",
+        "selection_ensemble_score_normalization": "rank_softmax",
+        "selection_ensemble_weighting": "inner_lcb_softmax",
+        "selection_ensemble_temperature": 0.02,
+    }
+
+
+def _selected_row(participant: int) -> dict:
+    return {
+        "test_participant": participant,
+        "selected_candidate_index": participant,
+        "selected_classifier": "multinomial-logistic",
+        "selected_window_center_s": 0.175,
+        "selected_inner_balanced_accuracy_mean": 0.2,
+        "selected_inner_winner_margin": 0.01,
+    }
+
+
+def test_discovers_nested_matrix_shards_by_bundle(tmp_path: Path):
+    _write_csv(tmp_path / "nested-matrix-logreg-p1" / "matrix_logreg_p1_outer.csv", [_outer_row(1, balanced=0.1)])
+    _write_csv(tmp_path / "nested-matrix-feature-p2" / "matrix_feature_p2_outer.csv", [_outer_row(2, balanced=0.2)])
+
+    shards = discover_nested_matrix_shards(tmp_path)
+
+    assert sorted(shards) == ["feature", "logreg"]
+    assert [path.name for path in shards["logreg"]] == ["matrix_logreg_p1_outer.csv"]
+
+
+def test_aggregates_nested_matrix_shards_and_recomputes_bundle_summary(tmp_path: Path):
+    for participant, balanced in [(1, 0.10), (2, 0.20)]:
+        stem = tmp_path / f"nested-matrix-logreg-p{participant}" / f"matrix_logreg_p{participant}"
+        _write_csv(stem.with_name(f"{stem.name}_outer.csv"), [_outer_row(participant, balanced=balanced)])
+        _write_csv(stem.with_name(f"{stem.name}_selected.csv"), [_selected_row(participant)])
+        _write_csv(
+            stem.with_name(f"{stem.name}_inner_validation.csv"),
+            [{"test_participant": participant, "candidate_index": participant, "balanced_accuracy": balanced}],
+        )
+
+    artifacts = aggregate_nested_matrix_outputs(tmp_path, tmp_path / "out", output_stem="nested_matrix", signflip_permutations=0)
+    summary = list(csv.DictReader((tmp_path / "out" / "nested_matrix_group_summary.csv").open(newline="", encoding="utf-8")))
+    selected = list(csv.DictReader((tmp_path / "out" / "nested_matrix_selected.csv").open(newline="", encoding="utf-8")))
+
+    assert len(artifacts["outer"]) == 2
+    assert len(summary) == 1
+    assert summary[0]["matrix_config_bundle"] == "logreg"
+    assert float(summary[0]["balanced_accuracy_mean"]) == pytest.approx(0.15)
+    assert summary[0]["participants_total"] == "2"
+    assert {row["matrix_config_bundle"] for row in selected} == {"logreg"}
+
+
+def test_aggregates_multiple_config_bundles_separately(tmp_path: Path):
+    _write_csv(tmp_path / "nested-matrix-logreg-p1" / "matrix_logreg_p1_outer.csv", [_outer_row(1, balanced=0.10)])
+    _write_csv(tmp_path / "nested-matrix-feature-p1" / "matrix_feature_p1_outer.csv", [_outer_row(1, balanced=0.30, bundle_classifier="shrinkage-lda")])
+
+    aggregate_nested_matrix_outputs(tmp_path, tmp_path / "out", output_stem="nested_matrix", signflip_permutations=0)
+    summary = list(csv.DictReader((tmp_path / "out" / "nested_matrix_group_summary.csv").open(newline="", encoding="utf-8")))
+
+    assert [row["matrix_config_bundle"] for row in summary] == ["feature", "logreg"]
+    assert (tmp_path / "out" / "nested_matrix_feature_group_summary.csv").exists()
+    assert (tmp_path / "out" / "nested_matrix_logreg_group_summary.csv").exists()


### PR DESCRIPTION
## Summary
- Add a manual nested stimulus matrix workflow that shards by held-out participant and named config bundle.
- Add bundle-level aggregation for completed shard artifacts into coherent group summary CSVs.
- Cover shard discovery and aggregate recomputation with focused unittest-compatible tests.

## Verification
- `python -m unittest tests.test_stimulus_nested_matrix`
- `python -m unittest discover -v`
- `python -m ruff check src\\pymegdec\\stimulus_nested_matrix.py tests\\test_stimulus_nested_matrix.py`
- `python -m py_compile src\\pymegdec\\stimulus_nested_matrix.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text(encoding='utf-8')); print('yaml ok')"`

## Notes
- The workflow is designed for self-hosted runs by default and can shard by participant chunks to keep individual jobs around the requested runtime budget.
- Local untracked artifact directories were left untouched.
- Follow-up fix: converted the new tests away from pytest so the repository's `python -m unittest discover` CI can import and execute them without optional test dependencies.