### PR TITLE
Use NeuRepTrace for stimulus temporal-generalization summaries

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -200,6 +200,11 @@ pymegdec stimulus robustness \
 
 ## Stimulus temporal generalization
 
+The grouped command remains BUSH-MEG-specific for MAT loading and feature-window
+construction, but the command-facing matrix/summary boundary is NeuRepTrace-backed:
+PyMEGDec builds temporal feature windows and uses NeuRepTrace's temporal-generalization
+summary API for the output table.
+
 ```bash
 pymegdec stimulus temporal-generalization \
   --data-dir /path/to/MEG-Data \

--- a/scripts/export_stimulus_temporal_generalization.py
+++ b/scripts/export_stimulus_temporal_generalization.py
@@ -1,4 +1,4 @@
-"""Backward-compatible wrapper for the grouped stimulus temporal-generalization command."""
+"""Backward-compatible wrapper for the NeuRepTrace-backed temporal-generalization command."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ _SRC = _ROOT / "src"
 if _SRC.exists():
     sys.path.insert(0, str(_SRC))
 
-from pymegdec.stimulus_cli import stimulus_temporal_generalization  # noqa: E402
+from pymegdec.stimulus_temporal_generalization_neureptrace import stimulus_temporal_generalization  # noqa: E402
 
 
 def main() -> int:

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -19,6 +19,7 @@ from pymegdec import (
 )
 from pymegdec.neureptrace_dataset_spec import write_neureptrace_dataset_spec
 from pymegdec.stimulus_onset_neureptrace import stimulus_onset_scan
+from pymegdec.stimulus_temporal_generalization_neureptrace import stimulus_temporal_generalization
 from pymegdec.synthetic_data_cli import make_synthetic_data
 
 CommandHandler = Callable[[Sequence[str] | None, str | None], int]
@@ -52,7 +53,7 @@ def _stimulus_handlers() -> dict[str, CommandHandler]:
         "decoding": legacy_cli.stimulus_decoding,
         "predictions": stimulus_cli.stimulus_predictions,
         "robustness": stimulus_cli.stimulus_robustness,
-        "temporal-generalization": stimulus_cli.stimulus_temporal_generalization,
+        "temporal-generalization": stimulus_temporal_generalization,
         "onset-scan": stimulus_onset_scan,
     }
 
@@ -94,7 +95,7 @@ def _top_level_handlers() -> dict[str, CommandHandler]:
         "stimulus-cross-subject-smoke": stimulus_cli.stimulus_cross_subject_smoke,
         "stimulus-predictions": stimulus_cli.stimulus_predictions,
         "stimulus-robustness": stimulus_cli.stimulus_robustness,
-        "stimulus-temporal-generalization": stimulus_cli.stimulus_temporal_generalization,
+        "stimulus-temporal-generalization": stimulus_temporal_generalization,
         "stimulus-onset-scan": stimulus_onset_scan,
         "alpha-metrics": alpha_cli.alpha_metrics,
         "alpha-movement": alpha_cli.alpha_movement,

--- a/src/pymegdec/stimulus_temporal_generalization_neureptrace.py
+++ b/src/pymegdec/stimulus_temporal_generalization_neureptrace.py
@@ -1,0 +1,106 @@
+"""NeuRepTrace-backed temporal-generalization compatibility workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import pandas as pd
+
+from neureptrace.decoding.temporal_generalization import summarize_temporal_generalization_matrix
+
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+from pymegdec.cli import normalize_argv
+from pymegdec.data_config import resolve_data_folder
+from pymegdec.stimulus_decoding import (
+    TEMPORAL_GENERALIZATION_SUMMARY_GROUP_FIELDS,
+    StimulusDecodingConfig,
+    evaluate_participant_stimulus_temporal_generalization,
+    window_centers_from_range,
+)
+
+
+def _present_group_fields(rows: Sequence[dict[str, Any]], preferred_fields: Sequence[str]) -> tuple[str, ...]:
+    return tuple(field for field in preferred_fields if any(field in row for row in rows))
+
+
+def summarize_stimulus_temporal_generalization_with_neureptrace(rows: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Summarize PyMEGDec temporal-generalization rows via NeuRepTrace."""
+
+    if not rows:
+        return []
+    frame = pd.DataFrame(list(rows))
+    group_fields = _present_group_fields(list(rows), TEMPORAL_GENERALIZATION_SUMMARY_GROUP_FIELDS)
+    summary = summarize_temporal_generalization_matrix(
+        frame,
+        group_columns=group_fields,
+        accuracy_column="accuracy",
+        chance_column="chance_accuracy",
+    )
+    if "n_rows" in summary.columns and "n_participants" not in summary.columns:
+        summary.insert(len(group_fields), "n_participants", summary["n_rows"].astype(int))
+    if "n_rows" in summary.columns:
+        summary = summary.drop(columns=["n_rows"])
+    return summary.to_dict(orient="records")
+
+
+def export_stimulus_temporal_generalization(
+    data_folder,
+    participants,
+    output_path,
+    *,
+    summary_output_path=None,
+    config=None,
+    progress=None,
+):
+    """Run BUSH-MEG temporal generalization and summarize with NeuRepTrace."""
+
+    config = config or StimulusDecodingConfig()
+    data_folder = resolve_data_folder(data_folder)
+    rows: list[dict[str, Any]] = []
+    for participant in participants:
+        if progress is not None:
+            progress(f"START participant={participant}")
+        rows.extend(evaluate_participant_stimulus_temporal_generalization(data_folder, participant, config=config))
+        if progress is not None:
+            progress(f"DONE participant={participant}")
+    write_alpha_metrics_csv(rows, output_path)
+    summary_rows = summarize_stimulus_temporal_generalization_with_neureptrace(rows)
+    if summary_output_path:
+        write_alpha_metrics_csv(summary_rows, summary_output_path)
+    return rows, summary_rows
+
+
+def stimulus_temporal_generalization(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    from pymegdec import stimulus_cli as _legacy_stimulus_cli
+
+    parser = _legacy_stimulus_cli._build_temporal_generalization_parser(prog=prog)  # pylint: disable=protected-access
+    args = parser.parse_args(normalize_argv(argv))
+    data_folder = resolve_data_folder(args.data_folder)
+    participants = _legacy_stimulus_cli._participants_or_error(parser, args.participants, data_folder)  # pylint: disable=protected-access
+    config = _legacy_stimulus_cli._base_config(  # pylint: disable=protected-access
+        args,
+        window_centers=window_centers_from_range(args.time_window, args.window_step_s),
+    )
+    rows, summary_rows = export_stimulus_temporal_generalization(
+        data_folder,
+        participants,
+        args.output,
+        summary_output_path=args.summary_output,
+        config=config,
+        progress=lambda message: print(message, flush=True),
+    )
+    print(f"Wrote {len(rows)} participant/train/test rows to {args.output}")
+    print(f"Wrote {len(summary_rows)} train/test summary rows to {args.summary_output}")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
+    return stimulus_temporal_generalization(argv, prog)
+
+
+__all__ = [
+    "export_stimulus_temporal_generalization",
+    "stimulus_temporal_generalization",
+    "summarize_stimulus_temporal_generalization_with_neureptrace",
+]

--- a/tests/test_stimulus_temporal_generalization_neureptrace.py
+++ b/tests/test_stimulus_temporal_generalization_neureptrace.py
@@ -1,0 +1,70 @@
+import unittest
+
+from pymegdec.stimulus_temporal_generalization_neureptrace import summarize_stimulus_temporal_generalization_with_neureptrace
+
+
+class TestStimulusTemporalGeneralizationNeuRepTrace(unittest.TestCase):
+    def test_summary_delegates_to_neureptrace_shape_with_pymegdec_compatibility(self):
+        rows = [
+            {
+                "participant": 1,
+                "variant": "without_null",
+                "transfer_direction": "main-to-cue",
+                "train_window_center_s": 0.0,
+                "test_window_center_s": 0.0,
+                "is_diagonal": True,
+                "accuracy": 0.25,
+                "chance_accuracy": 0.0625,
+                "classifier": "multiclass-svm",
+                "components_pca": 100,
+                "frequency_low_hz": 0.0,
+                "frequency_high_hz": float("inf"),
+            },
+            {
+                "participant": 2,
+                "variant": "without_null",
+                "transfer_direction": "main-to-cue",
+                "train_window_center_s": 0.0,
+                "test_window_center_s": 0.0,
+                "is_diagonal": True,
+                "accuracy": 0.50,
+                "chance_accuracy": 0.0625,
+                "classifier": "multiclass-svm",
+                "components_pca": 100,
+                "frequency_low_hz": 0.0,
+                "frequency_high_hz": float("inf"),
+            },
+            {
+                "participant": 1,
+                "variant": "without_null",
+                "transfer_direction": "main-to-cue",
+                "train_window_center_s": 0.0,
+                "test_window_center_s": 0.1,
+                "is_diagonal": False,
+                "accuracy": 0.10,
+                "chance_accuracy": 0.0625,
+                "classifier": "multiclass-svm",
+                "components_pca": 100,
+                "frequency_low_hz": 0.0,
+                "frequency_high_hz": float("inf"),
+            },
+        ]
+
+        summary = summarize_stimulus_temporal_generalization_with_neureptrace(rows)
+
+        self.assertEqual(len(summary), 2)
+        diagonal = [row for row in summary if row["is_diagonal"]][0]
+        off_diagonal = [row for row in summary if not row["is_diagonal"]][0]
+        self.assertEqual(diagonal["n_participants"], 2)
+        self.assertAlmostEqual(diagonal["accuracy_mean"], 0.375)
+        self.assertAlmostEqual(diagonal["percent_mean"], 37.5)
+        self.assertEqual(diagonal["above_chance_count"], 2)
+        self.assertEqual(off_diagonal["n_participants"], 1)
+        self.assertAlmostEqual(off_diagonal["accuracy_mean"], 0.10)
+
+    def test_empty_summary_is_empty_list(self):
+        self.assertEqual(summarize_stimulus_temporal_generalization_with_neureptrace([]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `pymegdec.stimulus_temporal_generalization_neureptrace`, a compatibility wrapper that keeps BUSH-MEG MAT loading/window construction in PyMEGDec but uses NeuRepTrace's public temporal-generalization summary API
- route grouped/top-level PyMEGDec temporal-generalization commands through the new wrapper
- point the legacy script wrapper at the NeuRepTrace-backed command path
- document the new ownership boundary in the CLI docs
- add focused tests for the NeuRepTrace-backed summary shape and PyMEGDec `n_participants` compatibility field

## Migration note

This is intentionally narrower than a full raw-data port: PyMEGDec still adapts BUSH-MEG MAT files into temporal feature windows, while NeuRepTrace owns the dataset-independent temporal-generalization matrix/summary semantics exposed by the command.

## Validation

- Inspected the branch diff via the GitHub connector.
- Tests were not run locally in this environment; CI should run the added focused tests.