### PR TITLE
Fix nested matrix aggregate output coverage

### DIFF
--- a/src/pymegdec/stimulus_nested_matrix.py
+++ b/src/pymegdec/stimulus_nested_matrix.py
@@ -32,7 +32,7 @@ def _read_rows(path: Path) -> list[dict[str, str]]:
         return list(csv.DictReader(handle))
 
 
-def _with_bundle(rows: Iterable[dict[str, str]], bundle: str) -> list[dict[str, str]]:
+def _with_bundle(rows: Iterable[dict], bundle: str) -> list[dict]:
     return [{**row, "matrix_config_bundle": bundle} for row in rows]
 
 
@@ -85,6 +85,9 @@ def aggregate_nested_matrix_outputs(
     all_selected: list[dict] = []
     all_predictions: list[dict] = []
     all_summaries: list[dict] = []
+    all_confusion: list[dict] = []
+    all_per_stimulus: list[dict] = []
+    all_confusion_pairs: list[dict] = []
 
     output_dir.mkdir(parents=True, exist_ok=True)
     for bundle, outer_paths in sorted(shards_by_bundle.items()):
@@ -106,6 +109,9 @@ def aggregate_nested_matrix_outputs(
         summary_rows = [{**row, "matrix_config_bundle": bundle} for row in summary_rows]
         confusion_rows, per_stimulus_rows = summarize_cross_subject_predictions(prediction_rows)
         confusion_pair_rows = summarize_cross_subject_confusion_pairs(prediction_rows)
+        bundle_confusion_rows = _with_bundle(confusion_rows, bundle)
+        bundle_per_stimulus_rows = _with_bundle(per_stimulus_rows, bundle)
+        bundle_confusion_pair_rows = _with_bundle(confusion_pair_rows, bundle)
 
         bundle_stem = f"{output_stem}_{bundle}"
         _write_rows(output_dir / f"{bundle_stem}_outer.csv", outer_rows)
@@ -113,27 +119,36 @@ def aggregate_nested_matrix_outputs(
         _write_rows(output_dir / f"{bundle_stem}_selected.csv", selected_rows)
         _write_rows(output_dir / f"{bundle_stem}_predictions.csv", prediction_rows)
         _write_rows(output_dir / f"{bundle_stem}_group_summary.csv", summary_rows)
-        _write_rows(output_dir / f"{bundle_stem}_confusion.csv", _with_bundle(confusion_rows, bundle))
-        _write_rows(output_dir / f"{bundle_stem}_per_stimulus.csv", _with_bundle(per_stimulus_rows, bundle))
-        _write_rows(output_dir / f"{bundle_stem}_confusion_pairs.csv", _with_bundle(confusion_pair_rows, bundle))
+        _write_rows(output_dir / f"{bundle_stem}_confusion.csv", bundle_confusion_rows)
+        _write_rows(output_dir / f"{bundle_stem}_per_stimulus.csv", bundle_per_stimulus_rows)
+        _write_rows(output_dir / f"{bundle_stem}_confusion_pairs.csv", bundle_confusion_pair_rows)
 
         all_outer.extend(outer_rows)
         all_inner.extend(inner_rows)
         all_selected.extend(selected_rows)
         all_predictions.extend(prediction_rows)
         all_summaries.extend(summary_rows)
+        all_confusion.extend(bundle_confusion_rows)
+        all_per_stimulus.extend(bundle_per_stimulus_rows)
+        all_confusion_pairs.extend(bundle_confusion_pair_rows)
 
     _write_rows(output_dir / f"{output_stem}_outer.csv", all_outer)
     _write_rows(output_dir / f"{output_stem}_inner_validation.csv", all_inner)
     _write_rows(output_dir / f"{output_stem}_selected.csv", all_selected)
     _write_rows(output_dir / f"{output_stem}_predictions.csv", all_predictions)
     _write_rows(output_dir / f"{output_stem}_group_summary.csv", all_summaries)
+    _write_rows(output_dir / f"{output_stem}_confusion.csv", all_confusion)
+    _write_rows(output_dir / f"{output_stem}_per_stimulus.csv", all_per_stimulus)
+    _write_rows(output_dir / f"{output_stem}_confusion_pairs.csv", all_confusion_pairs)
     return {
         "outer": all_outer,
         "inner_validation": all_inner,
         "selected": all_selected,
         "predictions": all_predictions,
         "group_summary": all_summaries,
+        "confusion": all_confusion,
+        "per_stimulus": all_per_stimulus,
+        "confusion_pairs": all_confusion_pairs,
     }
 
 

--- a/tests/test_stimulus_nested_matrix.py
+++ b/tests/test_stimulus_nested_matrix.py
@@ -63,6 +63,41 @@ def _selected_row(participant: int) -> dict:
     }
 
 
+def _prediction_rows(participant: int) -> list[dict]:
+    return [
+        {
+            "test_participant": participant,
+            "true_stimulus": 1,
+            "predicted_stimulus": 1,
+            "correct": True,
+            "window_center_s": 0.175,
+            "feature_mode": "sensor_flat",
+            "normalization": "subject_baseline_whiten",
+            "alignment": "none",
+            "classifier": "multinomial-logistic",
+            "components_pca": 64,
+            "max_trials_per_class_per_participant": 10,
+            "label_shuffle_control": False,
+            "label_shuffle_seed": 0,
+        },
+        {
+            "test_participant": participant,
+            "true_stimulus": 2,
+            "predicted_stimulus": 1,
+            "correct": False,
+            "window_center_s": 0.175,
+            "feature_mode": "sensor_flat",
+            "normalization": "subject_baseline_whiten",
+            "alignment": "none",
+            "classifier": "multinomial-logistic",
+            "components_pca": 64,
+            "max_trials_per_class_per_participant": 10,
+            "label_shuffle_control": False,
+            "label_shuffle_seed": 0,
+        },
+    ]
+
+
 class TestStimulusNestedMatrix(unittest.TestCase):
     def test_discovers_nested_matrix_shards_by_bundle(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -86,6 +121,7 @@ class TestStimulusNestedMatrix(unittest.TestCase):
                     stem.with_name(f"{stem.name}_inner_validation.csv"),
                     [{"test_participant": participant, "candidate_index": participant, "balanced_accuracy": balanced}],
                 )
+                _write_csv(stem.with_name(f"{stem.name}_predictions.csv"), _prediction_rows(participant))
 
             artifacts = aggregate_nested_matrix_outputs(
                 tmp_path,
@@ -95,6 +131,9 @@ class TestStimulusNestedMatrix(unittest.TestCase):
             )
             summary = list(csv.DictReader((tmp_path / "out" / "nested_matrix_group_summary.csv").open(newline="", encoding="utf-8")))
             selected = list(csv.DictReader((tmp_path / "out" / "nested_matrix_selected.csv").open(newline="", encoding="utf-8")))
+            confusion = list(csv.DictReader((tmp_path / "out" / "nested_matrix_confusion.csv").open(newline="", encoding="utf-8")))
+            per_stimulus = list(csv.DictReader((tmp_path / "out" / "nested_matrix_per_stimulus.csv").open(newline="", encoding="utf-8")))
+            confusion_pairs = list(csv.DictReader((tmp_path / "out" / "nested_matrix_confusion_pairs.csv").open(newline="", encoding="utf-8")))
 
             self.assertEqual(len(artifacts["outer"]), 2)
             self.assertEqual(len(summary), 1)
@@ -102,27 +141,40 @@ class TestStimulusNestedMatrix(unittest.TestCase):
             self.assertAlmostEqual(float(summary[0]["balanced_accuracy_mean"]), 0.15)
             self.assertEqual(summary[0]["participants_total"], "2")
             self.assertEqual({row["matrix_config_bundle"] for row in selected}, {"logreg"})
+            self.assertEqual({row["matrix_config_bundle"] for row in confusion}, {"logreg"})
+            self.assertEqual({row["matrix_config_bundle"] for row in per_stimulus}, {"logreg"})
+            self.assertEqual({row["matrix_config_bundle"] for row in confusion_pairs}, {"logreg"})
+            self.assertEqual(len(artifacts["confusion"]), len(confusion))
+            self.assertEqual(len(artifacts["per_stimulus"]), len(per_stimulus))
+            self.assertEqual(len(artifacts["confusion_pairs"]), len(confusion_pairs))
 
     def test_aggregates_multiple_config_bundles_separately(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             _write_csv(tmp_path / "nested-matrix-logreg-p1" / "matrix_logreg_p1_outer.csv", [_outer_row(1, balanced=0.10)])
+            _write_csv(tmp_path / "nested-matrix-logreg-p1" / "matrix_logreg_p1_predictions.csv", _prediction_rows(1))
             _write_csv(
                 tmp_path / "nested-matrix-feature-p1" / "matrix_feature_p1_outer.csv",
                 [_outer_row(1, balanced=0.30, bundle_classifier="shrinkage-lda")],
             )
+            _write_csv(tmp_path / "nested-matrix-feature-p1" / "matrix_feature_p1_predictions.csv", _prediction_rows(1))
 
-            aggregate_nested_matrix_outputs(
+            artifacts = aggregate_nested_matrix_outputs(
                 tmp_path,
                 tmp_path / "out",
                 output_stem="nested_matrix",
                 signflip_permutations=0,
             )
             summary = list(csv.DictReader((tmp_path / "out" / "nested_matrix_group_summary.csv").open(newline="", encoding="utf-8")))
+            confusion = list(csv.DictReader((tmp_path / "out" / "nested_matrix_confusion.csv").open(newline="", encoding="utf-8")))
 
             self.assertEqual([row["matrix_config_bundle"] for row in summary], ["feature", "logreg"])
+            self.assertEqual({row["matrix_config_bundle"] for row in confusion}, {"feature", "logreg"})
+            self.assertEqual({row["matrix_config_bundle"] for row in artifacts["confusion"]}, {"feature", "logreg"})
             self.assertTrue((tmp_path / "out" / "nested_matrix_feature_group_summary.csv").exists())
+            self.assertTrue((tmp_path / "out" / "nested_matrix_feature_confusion.csv").exists())
             self.assertTrue((tmp_path / "out" / "nested_matrix_logreg_group_summary.csv").exists())
+            self.assertTrue((tmp_path / "out" / "nested_matrix_logreg_confusion.csv").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- write combined nested-matrix confusion, per-stimulus, and confusion-pair aggregate CSVs, not only bundle-specific versions
- return the combined aggregate diagnostic tables from `aggregate_nested_matrix_outputs`
- extend nested-matrix tests with prediction shards so aggregate diagnostic outputs are covered

## Context
PR #155 added the sharded nested matrix workflow and bundle-level aggregation. The post-merge omission was that the workflow uploaded `outputs/*.csv`, but the aggregator only wrote combined outer/inner/selected/predictions/group-summary CSVs. Diagnostic tables were produced only as bundle-specific files. This follow-up makes the aggregate artifact set coherent.

## Validation
- Tests not run locally in this environment; CI should run `tests/test_stimulus_nested_matrix.py` and repository test discovery.