### PR TITLE
Bind hyperalignment workflow to NeuRepTrace kernels

### DIFF
--- a/docs/hyperalignment-neureptrace-boundary.md
+++ b/docs/hyperalignment-neureptrace-boundary.md
@@ -1,0 +1,25 @@
+# NeuRepTrace boundary for hyperalignment
+
+PyMEGDec keeps the BUSH-MEG-specific cross-subject hyperalignment workflow: MAT-file loading, feature extraction, LOSO fold orchestration, output naming, and compatibility CLI arguments.
+
+The reusable alignment kernels are bound to NeuRepTrace:
+
+- `neureptrace.decoding.hyperalignment.class_alignment_matrices`
+- `neureptrace.decoding.hyperalignment.fit_class_hyperalignment`
+- `neureptrace.decoding.hyperalignment.fit_projection_to_hyperalignment`
+- `neureptrace.decoding.hyperalignment_initialization`
+- `neureptrace.decoding.windowed` for the fitted shared-space decoder helpers
+
+This means new generic improvements to Procrustes hyperalignment should be made in NeuRepTrace. PyMEGDec should only adapt BUSH-MEG data and preserve old command names such as:
+
+```bash
+pymegdec stimulus cross-subject-hyperalignment \
+  --participants 1-4,6,8,9,10,13-27 \
+  --window-center 0.175 \
+  --window-size 0.1 \
+  --feature-mode sensor_flat \
+  --normalization subject_baseline_z \
+  --classifier multiclass-svm \
+  --components-pca 64 \
+  --hyper-components 64
+```

--- a/src/pymegdec/stimulus_hyperalignment.py
+++ b/src/pymegdec/stimulus_hyperalignment.py
@@ -1,11 +1,11 @@
-"""Public facade for Procrustes hyperalignment stimulus decoding."""
+"""Public facade for NeuRepTrace-backed Procrustes hyperalignment stimulus decoding."""
 
 from __future__ import annotations
 
 from dataclasses import replace
 import sys
 
-from reptrace.decoding.hyperalignment_initialization import (
+from neureptrace.decoding.hyperalignment_initialization import (
     HYPERALIGNMENT_INITIALIZATION_MODES,
     fit_class_hyperalignment as _fit_initialized_class_hyperalignment,
     normalize_hyperalignment_initialization,

--- a/src/pymegdec/stimulus_hyperalignment.py
+++ b/src/pymegdec/stimulus_hyperalignment.py
@@ -5,10 +5,21 @@ from __future__ import annotations
 from dataclasses import replace
 import sys
 
+from neureptrace.decoding.hyperalignment import (
+    CLASS_ALIGNMENT_SAMPLE_MODES,
+    class_alignment_matrices as _nrt_class_alignment_matrices,
+    fit_class_hyperalignment as _nrt_fit_class_hyperalignment,
+    fit_projection_to_hyperalignment as _nrt_fit_projection_to_hyperalignment,
+)
 from neureptrace.decoding.hyperalignment_initialization import (
     HYPERALIGNMENT_INITIALIZATION_MODES,
     fit_class_hyperalignment as _fit_initialized_class_hyperalignment,
     normalize_hyperalignment_initialization,
+)
+from neureptrace.decoding.windowed import (
+    fit_window_model as _nrt_fit_window_model,
+    predict_window_model as _nrt_predict_window_model,
+    transform_window_features as _nrt_transform_window_features,
 )
 
 from pymegdec import _stimulus_hyperalignment_legacy as _impl
@@ -43,6 +54,14 @@ def _evaluate_hyperalignment_outer_fold(*args, **kwargs):
         _impl.fit_class_hyperalignment = original_fit_class_hyperalignment
 
 
+# Bind the legacy BUSH-MEG orchestration to NeuRepTrace-owned reusable kernels.
+_impl.CLASS_ALIGNMENT_SAMPLE_MODES = CLASS_ALIGNMENT_SAMPLE_MODES
+_impl.class_alignment_matrices = _nrt_class_alignment_matrices
+_impl.fit_class_hyperalignment = _nrt_fit_class_hyperalignment
+_impl.fit_projection_to_hyperalignment = _nrt_fit_projection_to_hyperalignment
+_impl.fit_window_model = _nrt_fit_window_model
+_impl.predict_window_model = _nrt_predict_window_model
+_impl.transform_window_features = _nrt_transform_window_features
 _impl.HYPERALIGNMENT_INITIALIZATION_MODES = HYPERALIGNMENT_INITIALIZATION_MODES
 _impl._normalize_hyperalignment_initialization = normalize_hyperalignment_initialization
 _impl._normalized_hyperalignment_config = _normalized_hyperalignment_config

--- a/tests/test_stimulus_hyperalignment_neureptrace_boundary.py
+++ b/tests/test_stimulus_hyperalignment_neureptrace_boundary.py
@@ -1,0 +1,21 @@
+import neureptrace.decoding.hyperalignment as nrt_hyperalignment
+import neureptrace.decoding.windowed as nrt_windowed
+
+from pymegdec import stimulus_hyperalignment as hyperalignment
+
+
+def test_hyperalignment_facade_binds_reusable_kernels_to_neureptrace():
+    assert hyperalignment.class_alignment_matrices is nrt_hyperalignment.class_alignment_matrices
+    assert hyperalignment.fit_class_hyperalignment is nrt_hyperalignment.fit_class_hyperalignment
+    assert hyperalignment.fit_projection_to_hyperalignment is nrt_hyperalignment.fit_projection_to_hyperalignment
+    assert hyperalignment.fit_window_model is nrt_windowed.fit_window_model
+    assert hyperalignment.predict_window_model is nrt_windowed.predict_window_model
+    assert hyperalignment.transform_window_features is nrt_windowed.transform_window_features
+
+
+def test_hyperalignment_config_normalization_uses_neureptrace_initialization_modes():
+    config = hyperalignment.CrossSubjectHyperalignmentConfig(hyperalignment_initialization="mean")
+    normalized = hyperalignment._normalized_hyperalignment_config(config)  # pylint: disable=protected-access
+    assert normalized.hyperalignment_initialization == "mean"
+    assert "pca" in hyperalignment.HYPERALIGNMENT_INITIALIZATION_MODES
+    assert "mean" in hyperalignment.HYPERALIGNMENT_INITIALIZATION_MODES


### PR DESCRIPTION
## Summary

- update the PyMEGDec hyperalignment facade to import NeuRepTrace hyperalignment initialization, class-alignment, projection, and windowed-decoding kernels directly
- bind the legacy BUSH-MEG orchestration module to those NeuRepTrace-owned reusable functions at the public facade boundary
- add a focused boundary test that asserts the public PyMEGDec hyperalignment module resolves reusable kernels from `neureptrace.decoding.hyperalignment` and `neureptrace.decoding.windowed`
- document the ownership boundary in `docs/hyperalignment-neureptrace-boundary.md`

## Migration note

This does not attempt a full rewrite of the BUSH-MEG LOSO workflow. PyMEGDec still owns MAT loading, feature extraction, LOSO orchestration, and compatibility CLI/output naming. NeuRepTrace owns the reusable Procrustes hyperalignment, initialization, projection, and shared-space windowed-decoding kernels.

## Validation

- Inspected the branch diff via the GitHub connector.
- Tests were not run locally in this environment; CI should run the added boundary test.
- `main` advanced while preparing this branch, so the PR may need an update-branch step before merge.