### PR TITLE
Fix nested matrix cached data preparation

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -16,7 +16,7 @@ on:
         default: self-hosted
         type: string
       use_nextcloud_data:
-        description: Restore/download/cache the MEG data before running shards.
+        description: Allow WebDAV download on cache miss; cached/self-hosted data are still exposed when false.
         required: true
         default: true
         type: boolean
@@ -208,7 +208,6 @@ jobs:
     env:
       DATA_DIR: .cache/meg-data-main
       DATA_CACHE_VERSION: v2
-      USE_NEXTCLOUD_DATA: ${{ inputs.use_nextcloud_data }}
       BENCHMARK_PRESET: ${{ inputs.benchmark_preset }}
       OUTPUT_STEM: matrix_${{ matrix.config_id }}_${{ matrix.outer_label }}
       PARTICIPANTS: ${{ inputs.participants }}
@@ -242,13 +241,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Prepare main MEG data
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
         timeout-minutes: 90
         uses: ./.github/actions/prepare-meg-data
         with:
           data-dir: ${{ env.DATA_DIR }}
           cache-version: ${{ env.DATA_CACHE_VERSION }}
           cache-key: meg-data-main-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+          download-on-miss: ${{ inputs.use_nextcloud_data }}
           file-names: ${{ env.MAIN_FILE_NAMES }}
           require-cue-files: "false"
           expected-main-files: "23"


### PR DESCRIPTION
## Summary
- keep the nested-matrix data preparation action active even when `use_nextcloud_data=false`
- reinterpret `use_nextcloud_data` as controlling only WebDAV download-on-cache-miss behavior
- remove the stale `USE_NEXTCLOUD_DATA` env gate so self-hosted/local cache data are still exposed at `DATA_DIR`

## Rationale
PR #155 added the sharded nested-matrix workflow. The manual input `use_nextcloud_data=false` was intended to avoid fresh Nextcloud/WebDAV downloads, but the workflow skipped the entire `prepare-meg-data` composite action. On self-hosted runners this also skipped exposing the local cache via the workflow `DATA_DIR`, so the subsequent validation and shard run could fail even when cached data were already available.

## Validation
- Inspected the workflow through the GitHub connector.
- Did not run the manual benchmark workflow here because it requires private MEG data/secrets or a populated self-hosted cache.