### PR TITLE
Validate nested matrix participant chunk completeness

### DIFF
--- a/src/pymegdec/stimulus_nested_matrix.py
+++ b/src/pymegdec/stimulus_nested_matrix.py
@@ -16,7 +16,7 @@ from pymegdec.stimulus_cross_subject import (
     summarize_nested_cross_subject_stimulus,
 )
 
-SHARD_OUTER_RE = re.compile(r"^matrix_(?P<bundle>.+)_p\d+(?:-p\d+)*_outer\.csv$")
+SHARD_OUTER_RE = re.compile(r"^matrix_(?P<bundle>.+)_(?P<outer_label>p\d+(?:-p\d+)*)_outer\.csv$")
 SHARD_SUFFIXES = {
     "outer": "_outer.csv",
     "inner_validation": "_inner_validation.csv",
@@ -60,6 +60,28 @@ def _shard_path(outer_path: Path, kind: str) -> Path:
     return outer_path.with_name(outer_path.name.removesuffix(SHARD_SUFFIXES["outer"]) + SHARD_SUFFIXES[kind])
 
 
+def _expected_outer_participants(outer_path: Path) -> set[int]:
+    match = SHARD_OUTER_RE.match(outer_path.name)
+    if not match:
+        return set()
+    return {int(token.removeprefix("p")) for token in match.group("outer_label").split("-")}
+
+
+def _row_outer_participants(path: Path, rows: list[dict[str, str]]) -> set[int]:
+    participants: set[int] = set()
+    for row_number, row in enumerate(rows, start=2):
+        raw_participant = row.get("test_participant")
+        if raw_participant is None or str(raw_participant).strip() == "":
+            raise NestedMatrixShardError(f"{path.name} row {row_number} is missing test_participant.")
+        try:
+            participants.add(int(raw_participant))
+        except ValueError as exc:
+            raise NestedMatrixShardError(
+                f"{path.name} row {row_number} has non-integer test_participant={raw_participant!r}."
+            ) from exc
+    return participants
+
+
 def discover_nested_matrix_shards(input_dir: Path) -> dict[str, list[Path]]:
     """Return outer shard CSVs grouped by matrix configuration bundle."""
 
@@ -76,6 +98,7 @@ def validate_nested_matrix_shards(
     *,
     expected_shard_count: int | None = None,
     required_kinds: Iterable[str] = REQUIRED_STRICT_SHARD_KINDS,
+    require_complete_outer_participants: bool = False,
 ) -> None:
     """Validate that discovered nested-matrix shards are complete enough to aggregate."""
 
@@ -90,10 +113,27 @@ def validate_nested_matrix_shards(
     required_kinds = tuple(required_kinds)
     for bundle, outer_paths in sorted(shards_by_bundle.items()):
         for outer_path in outer_paths:
+            participant_row_sets: list[tuple[str, Path, set[int]]] = []
+            if require_complete_outer_participants:
+                participant_row_sets.append(("outer", outer_path, _row_outer_participants(outer_path, _read_rows(outer_path))))
             for kind in required_kinds:
                 sidecar_path = _shard_path(outer_path, kind)
                 if not sidecar_path.exists():
                     missing.append(f"bundle={bundle} outer={outer_path.name} missing={sidecar_path.name}")
+                elif require_complete_outer_participants:
+                    participant_row_sets.append((kind, sidecar_path, _row_outer_participants(sidecar_path, _read_rows(sidecar_path))))
+            if require_complete_outer_participants:
+                expected_participants = _expected_outer_participants(outer_path)
+                for kind, path, actual_participants in participant_row_sets:
+                    missing_participants = sorted(expected_participants - actual_participants)
+                    unexpected_participants = sorted(actual_participants - expected_participants)
+                    details = []
+                    if missing_participants:
+                        details.append("missing_outer_participants=" + ",".join(str(value) for value in missing_participants))
+                    if unexpected_participants:
+                        details.append("unexpected_outer_participants=" + ",".join(str(value) for value in unexpected_participants))
+                    if details:
+                        missing.append(f"bundle={bundle} {kind}={path.name} {' '.join(details)}")
     if missing:
         details = "\n".join(f"- {item}" for item in missing)
         raise NestedMatrixShardError(f"Incomplete nested matrix shard artifact set:\n{details}")
@@ -118,6 +158,7 @@ def aggregate_nested_matrix_outputs(
         shards_by_bundle,
         expected_shard_count=expected_shard_count,
         required_kinds=REQUIRED_STRICT_SHARD_KINDS if strict_shards else (),
+        require_complete_outer_participants=strict_shards,
     )
 
     all_outer: list[dict] = []
@@ -202,7 +243,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--strict-shards",
         action="store_true",
-        help="Require every discovered outer shard to have inner-validation, selected, and prediction sidecars.",
+        help="Require every discovered outer shard to have sidecars and rows for every participant in its shard label.",
     )
     parser.add_argument(
         "--expected-shard-count",

--- a/tests/test_stimulus_nested_matrix.py
+++ b/tests/test_stimulus_nested_matrix.py
@@ -127,6 +127,37 @@ class TestStimulusNestedMatrix(unittest.TestCase):
             with self.assertRaisesRegex(NestedMatrixShardError, "Expected 2 nested matrix outer shard"):
                 validate_nested_matrix_shards(shards, expected_shard_count=2, required_kinds=())
 
+    def test_strict_validation_rejects_incomplete_participant_chunks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            stem = tmp_path / "nested-matrix-logreg-p1-p2" / "matrix_logreg_p1-p2"
+            _write_csv(stem.with_name(f"{stem.name}_outer.csv"), [_outer_row(1, balanced=0.1)])
+            _write_csv(stem.with_name(f"{stem.name}_selected.csv"), [_selected_row(1)])
+            _write_csv(
+                stem.with_name(f"{stem.name}_inner_validation.csv"),
+                [{"test_participant": 1, "candidate_index": 1, "balanced_accuracy": 0.1}],
+            )
+            _write_csv(stem.with_name(f"{stem.name}_predictions.csv"), _prediction_rows(1))
+
+            shards = discover_nested_matrix_shards(tmp_path)
+
+            with self.assertRaisesRegex(NestedMatrixShardError, "missing_outer_participants=2"):
+                validate_nested_matrix_shards(
+                    shards,
+                    expected_shard_count=1,
+                    required_kinds=("inner_validation", "selected", "predictions"),
+                    require_complete_outer_participants=True,
+                )
+            with self.assertRaisesRegex(NestedMatrixShardError, "missing_outer_participants=2"):
+                aggregate_nested_matrix_outputs(
+                    tmp_path,
+                    tmp_path / "out",
+                    output_stem="nested_matrix",
+                    signflip_permutations=0,
+                    strict_shards=True,
+                    expected_shard_count=1,
+                )
+
     def test_aggregates_nested_matrix_shards_and_recomputes_bundle_summary(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)


### PR DESCRIPTION
## Summary
- validate that strict nested-matrix aggregation has an outer row for every participant encoded in each shard filename
- check selected, inner-validation, and prediction sidecars for the same participant coverage when strict mode is enabled
- add a regression test for a multi-participant shard whose files exist but only contain rows for one participant

## Context
PR #155 added the sharded nested matrix workflow. Follow-ups already fixed the unittest import issue, aggregate output coverage, strict sidecar validation, and cached-data preparation. This final hardening closes an edge case for `participants_per_job=2` or `4`: a shard artifact could contain the expected files while silently missing one of the participant folds inside the chunk.

## Validation
- `python -m py_compile src/pymegdec/stimulus_nested_matrix.py`
- `python -m py_compile tests/test_stimulus_nested_matrix.py`
- Ran the focused unittest file against local lightweight stubs for imported repository helpers because this environment cannot clone/install the repository from GitHub.