### PR TITLE
Fix nested matrix mypy variable shadowing

### DIFF
--- a/src/pymegdec/stimulus_nested_matrix.py
+++ b/src/pymegdec/stimulus_nested_matrix.py
@@ -135,8 +135,8 @@ def validate_nested_matrix_shards(
                     if details:
                         missing.append(f"bundle={bundle} {kind}={path.name} {' '.join(details)}")
     if missing:
-        details = "\n".join(f"- {item}" for item in missing)
-        raise NestedMatrixShardError(f"Incomplete nested matrix shard artifact set:\n{details}")
+        missing_details = "\n".join(f"- {item}" for item in missing)
+        raise NestedMatrixShardError(f"Incomplete nested matrix shard artifact set:\n{missing_details}")
 
 
 def aggregate_nested_matrix_outputs(


### PR DESCRIPTION
## Summary
- rename the strict-shard error detail accumulator from `details` to `missing_details`
- avoid reusing a `list[str]` local as a string, which broke `mypy src`

## Context
The merged follow-up to PR #155 left Static checks failing on PR #162's merge commit:

```text
src/pymegdec/stimulus_nested_matrix.py:138: error: Incompatible types in assignment (expression has type "str", variable has type "list[str]")  [assignment]
```

This is a minimal type-check-only fix; runtime behavior is unchanged.

## Validation
- Inspected the failing GitHub Actions log for Static checks run `26408857248`.
- The patch is a one-line local rename. Full CI should validate `ruff`, `mypy`, and tests on the PR.