### PR TITLE
Fix nested matrix cached data preparation

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -16,7 +16,7 @@ on:
         default: self-hosted
         type: string
       use_nextcloud_data:
-        description: Restore/download/cache the MEG data before running shards.
+        description: Allow WebDAV download on cache miss; cached/self-hosted data are still exposed when false.
         required: true
         default: true
         type: boolean
@@ -208,7 +208,6 @@ jobs:
     env:
       DATA_DIR: .cache/meg-data-main
       DATA_CACHE_VERSION: v2
-      USE_NEXTCLOUD_DATA: ${{ inputs.use_nextcloud_data }}
       BENCHMARK_PRESET: ${{ inputs.benchmark_preset }}
       OUTPUT_STEM: matrix_${{ matrix.config_id }}_${{ matrix.outer_label }}
       PARTICIPANTS: ${{ inputs.participants }}
@@ -242,13 +241,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Prepare main MEG data
-        if: ${{ env.USE_NEXTCLOUD_DATA == 'true' }}
         timeout-minutes: 90
         uses: ./.github/actions/prepare-meg-data
         with:
           data-dir: ${{ env.DATA_DIR }}
           cache-version: ${{ env.DATA_CACHE_VERSION }}
           cache-key: meg-data-main-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+          download-on-miss: ${{ inputs.use_nextcloud_data }}
           file-names: ${{ env.MAIN_FILE_NAMES }}
           require-cue-files: "false"
           expected-main-files: "23"


### PR DESCRIPTION
## Summary
- keep the nested-matrix MEG data preparation action active even when `use_nextcloud_data=false`
- interpret `use_nextcloud_data` as permission to download from WebDAV on cache miss, not as permission to skip cached/self-hosted data exposure
- remove the unused `USE_NEXTCLOUD_DATA` job environment variable and pass the workflow input to `download-on-miss`

## Context
PR #155 added the manual sharded nested stimulus matrix workflow. In the merged workflow, setting `use_nextcloud_data=false` skipped `.github/actions/prepare-meg-data` entirely. That also skipped exposing an existing self-hosted/local cache at `.cache/meg-data-main`, so the later `Validate main data files` step would fail even when the data were already present in the runner cache.

## Validation
- Inspected the workflow through the GitHub connector.
- Compared the branch against `main`; only this workflow file changed (+2/-3).
- Local workflow execution was not possible in this environment because it cannot resolve `github.com` for a clone/install.