### PR TITLE
Finalize PyMEGDec archive closeout

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: New reusable M/EEG decoding work
+    url: https://github.com/IPS-Stuttgart/NeuRepTrace/issues/new
+    about: Please open new datasets, decoding methods, benchmarks, diagnostics, and reporting requests in NeuRepTrace.
+  - name: PyMEGDec archive policy
+    url: https://github.com/IPS-Stuttgart/PyMEGDec/blob/main/ARCHIVE.md
+    about: Read the archive policy before opening PyMEGDec compatibility or reproducibility issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Archive-scope checklist
+
+PyMEGDec is deprecated and kept only as a historical compatibility archive. Before merging, confirm that this PR is archive-scoped.
+
+- [ ] This change is required for historical PyMEGDec/BUSH-MEG reproducibility, archive hygiene, or a temporary NeuRepTrace compatibility shim.
+- [ ] No new reusable dataset loader, decoder, benchmark, calibration metric, report helper, or analysis workflow is being added here.
+- [ ] Any reusable functionality has been implemented in or redirected to NeuRepTrace.
+- [ ] Fast tests pass without private MEG files, or the reason they were not run is documented below.
+- [ ] Private-data-dependent behavior is skipped gracefully when the historical MAT files are unavailable.
+
+## Summary
+
+
+## Validation
+

--- a/ARCHIVE.md
+++ b/ARCHIVE.md
@@ -1,0 +1,61 @@
+# PyMEGDec archive policy
+
+PyMEGDec is a legacy compatibility and reproducibility archive for the historical
+BUSH-MEG decoding work. NeuRepTrace is the maintained successor for reusable
+M/EEG decoding, dataset specifications, probability-observation diagnostics,
+onset/state inference, calibration-aware metrics, and report aggregation.
+
+## Maintained successor
+
+Use [NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace) for all new work.
+New reusable code should not be added to PyMEGDec unless it is a temporary shim
+that preserves an old command surface while delegating to NeuRepTrace.
+
+## Supported residual changes
+
+Accept changes here only when they are required for at least one of these cases:
+
+- reproducing historical PyMEGDec/BUSH-MEG results;
+- preserving old command names while routing users to NeuRepTrace;
+- documenting the migration or archive boundary;
+- keeping package metadata, tests, security notes, and CI usable for the archive;
+- fixing a narrowly scoped regression in a historical workflow.
+
+Do not add new datasets, new reusable decoders, new benchmark infrastructure,
+new calibration metrics, or new report aggregation helpers here. Implement those
+in NeuRepTrace and keep PyMEGDec as a caller or dataset-specific wrapper only
+when backward compatibility requires it.
+
+## Residual PyMEGDec ownership
+
+The only code that should remain project-owned here is code that is tightly tied
+to the historical repository context:
+
+- `Part*Data.mat` and `Part*CueData.mat` naming conventions;
+- BUSH-MEG metadata defaults and private result-layout compatibility;
+- CTF geometry handling used by the legacy alpha analyses;
+- alpha-band, alpha-movement, and alpha/reaction-time paper exports;
+- exact historical CSV schemas required to reproduce old outputs;
+- thin compatibility entry points for old scripts and notebooks.
+
+## Final closeout checklist
+
+Before archiving the GitHub repository, verify the following manually:
+
+1. The README and documentation point users to NeuRepTrace.
+2. `pyproject.toml` marks the package as inactive/deprecated.
+3. Public imports and command-line entry points are kept only for compatibility.
+4. Fast tests pass without private MEG files.
+5. Any remaining private-data-dependent commands document their required input
+   files and are skipped gracefully when those files are absent.
+6. Open issues and pull requests are either closed, migrated to NeuRepTrace, or
+   explicitly labelled as archive-only.
+7. Repository settings are changed to archived/read-only after the final closeout
+   PR is merged.
+
+## Security and support
+
+This archive is not actively maintained for feature development. Security fixes
+should be limited to dependency metadata or compatibility changes needed to keep
+historical reproduction environments installable. General usage questions and
+new feature requests should be opened in NeuRepTrace instead.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@
 > [!WARNING]
 > **PyMEGDec is deprecated. Use [NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace) for all new work from now on.** This repository is kept only as a compatibility and reproducibility archive for the historical MEG decoding workflows. Do not add new reusable dataset-loading, decoding, evaluation, diagnostics, or reporting functionality here; implement it in NeuRepTrace instead.
 
+## Archive status
+
+PyMEGDec is in final archive mode. The maintained successor is
+[NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace), which owns reusable
+M/EEG decoding, dataset-spec validation, probability-observation diagnostics,
+onset/state inference, calibration-aware metrics, and report aggregation.
+
+This repository should receive only narrowly scoped closeout changes:
+
+- fixes that keep historical PyMEGDec/BUSH-MEG reproduction commands runnable;
+- documentation, security, packaging, or CI changes needed for archive hygiene;
+- temporary compatibility shims that route users to NeuRepTrace.
+
+New reusable methods, dataset loaders, benchmarks, or analysis workflows belong
+in NeuRepTrace. See [`ARCHIVE.md`](ARCHIVE.md) for the archive policy and the
+final maintainer checklist.
+
 PyMEGDec contains the MEG-specific analysis layer for historical decoding
 experiments. It loads participant MATLAB files, prepares MEG windows, runs
 model-transfer and cross-validation workflows, and exports stimulus analysis
@@ -28,7 +45,7 @@ explicitly legacy-only. They remain callable for reproducibility and to regenera
 existing Bush/MEG CSV exports, but new reusable decoding or dataset-loading work
 must be implemented in NeuRepTrace instead.
 
-## Quick start
+## Legacy reproduction quick start
 
 ```bash
 python -m pip install --upgrade pip
@@ -74,6 +91,7 @@ default windows, and output locations in the dataset spec.
 
 The longer workflow documentation lives in `docs/`:
 
+- `docs/archive.md` — archive policy, supported residual changes, and closeout checklist.
 - `docs/getting-started.md` — installation, optional extras, and tests.
 - `docs/data.md` — data-directory resolution and participant-file conventions.
 - `docs/cli.md` — grouped CLI commands and compatibility entry points.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security policy
+
+PyMEGDec is deprecated and kept only as a compatibility and reproducibility
+archive for historical BUSH-MEG analyses. NeuRepTrace is the maintained successor
+for reusable M/EEG decoding functionality.
+
+## Supported versions
+
+Only the archived `main` branch is considered for narrow compatibility and
+reproducibility fixes. Feature work, new datasets, new decoders, and reusable
+workflow improvements should be made in NeuRepTrace instead.
+
+## Reporting a vulnerability
+
+If a vulnerability affects reusable decoding, dataset loading, metrics,
+probability-observation processing, or reporting code that now belongs in
+NeuRepTrace, report it in NeuRepTrace.
+
+Open a PyMEGDec issue only when the vulnerability is specific to this archive,
+for example package metadata, historical compatibility wrappers, or a legacy
+script that must remain usable for reproducibility. Avoid including private MEG
+data or credentials in public reports.
+
+## Expected response
+
+Because this repository is an archive, fixes will normally be limited to:
+
+- dependency or packaging metadata needed for safe historical installation;
+- documentation updates that prevent unsafe use;
+- compatibility changes that route affected functionality to NeuRepTrace;
+- minimal changes that keep historical reproduction commands runnable.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -1,0 +1,61 @@
+# Archive policy
+
+PyMEGDec is a legacy compatibility and reproducibility archive for the historical
+BUSH-MEG decoding work. NeuRepTrace is the maintained successor for reusable
+M/EEG decoding, dataset specifications, probability-observation diagnostics,
+onset/state inference, calibration-aware metrics, and report aggregation.
+
+## Maintained successor
+
+Use [NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace) for all new work.
+New reusable code should not be added to PyMEGDec unless it is a temporary shim
+that preserves an old command surface while delegating to NeuRepTrace.
+
+## Supported residual changes
+
+Accept changes here only when they are required for at least one of these cases:
+
+- reproducing historical PyMEGDec/BUSH-MEG results;
+- preserving old command names while routing users to NeuRepTrace;
+- documenting the migration or archive boundary;
+- keeping package metadata, tests, security notes, and CI usable for the archive;
+- fixing a narrowly scoped regression in a historical workflow.
+
+Do not add new datasets, new reusable decoders, new benchmark infrastructure,
+new calibration metrics, or new report aggregation helpers here. Implement those
+in NeuRepTrace and keep PyMEGDec as a caller or dataset-specific wrapper only
+when backward compatibility requires it.
+
+## Residual PyMEGDec ownership
+
+The only code that should remain project-owned here is code that is tightly tied
+to the historical repository context:
+
+- `Part*Data.mat` and `Part*CueData.mat` naming conventions;
+- BUSH-MEG metadata defaults and private result-layout compatibility;
+- CTF geometry handling used by the legacy alpha analyses;
+- alpha-band, alpha-movement, and alpha/reaction-time paper exports;
+- exact historical CSV schemas required to reproduce old outputs;
+- thin compatibility entry points for old scripts and notebooks.
+
+## Final closeout checklist
+
+Before archiving the GitHub repository, verify the following manually:
+
+1. The README and documentation point users to NeuRepTrace.
+2. `pyproject.toml` marks the package as inactive/deprecated.
+3. Public imports and command-line entry points are kept only for compatibility.
+4. Fast tests pass without private MEG files.
+5. Any remaining private-data-dependent commands document their required input
+   files and are skipped gracefully when those files are absent.
+6. Open issues and pull requests are either closed, migrated to NeuRepTrace, or
+   explicitly labelled as archive-only.
+7. Repository settings are changed to archived/read-only after the final closeout
+   PR is merged.
+
+## Security and support
+
+This archive is not actively maintained for feature development. Security fixes
+should be limited to dependency metadata or compatibility changes needed to keep
+historical reproduction environments installable. General usage questions and
+new feature requests should be opened in NeuRepTrace instead.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # PyMEGDec documentation
 
-!!! warning "Deprecated"
+!!! warning "Deprecated archive"
     **PyMEGDec is deprecated. Use [NeuRepTrace](https://github.com/IPS-Stuttgart/NeuRepTrace) for all new work from now on.** This repository is kept only as a compatibility and reproducibility archive for the historical MEG decoding workflows. Do not add new reusable dataset-loading, decoding, evaluation, diagnostics, or reporting functionality here; implement it in NeuRepTrace instead.
 
 PyMEGDec provides project-specific utilities for historical MEG decoding
@@ -8,12 +8,16 @@ experiments. The package focuses on workflows that need the repository's
 participant-file naming conventions, MATLAB `.mat` loading, CTF sensor geometry,
 MEG preprocessing, and paper-facing exports.
 
-The usual legacy workflow is:
+The repository is now in final archive mode. See the [archive policy](archive.md)
+for the residual scope and closeout checklist.
+
+The usual legacy reproduction workflow is:
 
 1. Configure the local MEG data directory.
 2. Choose a participant or participant range.
-3. Run cross-validation, model transfer, stimulus decoding, alpha-metric export,
-   sensor-level alpha-movement export, or alpha/reaction-time analysis.
+3. Run only the historical cross-validation, model-transfer, stimulus-decoding,
+   alpha-metric export, sensor-level alpha-movement export, or
+   alpha/reaction-time analysis needed to reproduce an old result.
 4. Analyze the exported CSV tables and plots.
 
 ## Boundary with NeuRepTrace

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ theme:
 
 nav:
   - Overview: index.md
+  - Archive policy: archive.md
   - Getting started: getting-started.md
   - Data configuration: data.md
   - CLI reference: cli.md

--- a/src/pymegdec/__init__.py
+++ b/src/pymegdec/__init__.py
@@ -68,7 +68,7 @@ from pymegdec.stimulus_hyperalignment import (
     summarize_cross_subject_hyperalignment,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## Summary

Final archive-hardening changes for sunsetting PyMEGDec:

- adds `ARCHIVE.md` with the archive policy, residual ownership boundary, and final closeout checklist;
- adds a docs-site archive page and links it from `mkdocs.yml`;
- updates the README and docs overview to make final archive mode explicit;
- adds a PR template requiring archive-scope justification;
- adds an issue-template config routing new reusable M/EEG work to NeuRepTrace;
- adds `SECURITY.md` for archive-scoped vulnerability/support expectations;
- fixes `pymegdec.__version__` from `0.1.0` to `0.1.1` to match `pyproject.toml`.

## Validation

- Compared `archive/final-closeout-v2` against current `main`; branch is ahead by 9 commits and behind by 0.
- Changes are documentation/templates/metadata only, except the package version string sync.
- I could not run the test suite locally because the execution environment cannot clone from GitHub, but these changes should not affect runtime behavior beyond `__version__`.

## Archive note

After merging this PR, the remaining manual repository action is to archive the GitHub repository in settings once any open issues/PRs are migrated or closed.