### PR TITLE
Use rank-normalized source ensemble scores

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -64,7 +64,7 @@ jobs:
             --selection-ensemble-size 6 \
             --selection-ensemble-diversity window_classifier \
             --selection-metric balanced_top2 \
-            --selection-ensemble-score-normalization row_z_softmax \
+            --selection-ensemble-score-normalization rank_softmax \
             --selection-ensemble-weighting inner_selection_lcb_softmax \
             --write-incremental \
             --resume \


### PR DESCRIPTION
## Summary

Switches the source-only-next nested benchmark from `row_z_softmax` to `rank_softmax` for selected ensemble score normalization.

The current source-only-next grid already ranks candidates with `balanced_top2` and weights them with `inner_selection_lcb_softmax`. This change makes the probability aggregation less sensitive to raw score scale differences between classifiers/windows by using the existing rank-based score normalization path.

This is a low-risk benchmark improvement: the implementation already exists and is covered by a scale-invariance test; this PR only opts the promising source-only-next workflow into it.

## Validation

Ran with local NeuRepTrace on `PYTHONPATH`:

```bash
python -m pytest tests/test_stimulus_cross_subject.py
git diff --check
```

Result: 32 passed, diff check clean.