### PR TITLE
Add top-k composite nested selection

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -63,7 +63,7 @@ jobs:
             --score-calibrations none \
             --selection-ensemble-size 6 \
             --selection-ensemble-diversity window_classifier \
-            --selection-metric balanced_top2 \
+            --selection-metric balanced_top2_top3 \
             --selection-ensemble-score-normalization rank_softmax \
             --selection-ensemble-weighting inner_selection_lcb_softmax \
             --write-incremental \

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -54,6 +54,7 @@ CROSS_SUBJECT_SELECTION_METRIC_CHOICES = (
     "top3_accuracy",
     "mean_true_label_rank",
     "balanced_top2",
+    "balanced_top2_top3",
     "balanced_rank",
 )
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE = 1
@@ -2542,6 +2543,12 @@ def _nested_row_selection_score(row, selection_metric):
         return -_row_float(row, "mean_true_label_rank")
     if selection_metric == "balanced_top2":
         return 0.5 * _row_float(row, "balanced_accuracy") + 0.5 * _row_float(row, "top2_accuracy")
+    if selection_metric == "balanced_top2_top3":
+        return (
+            _row_float(row, "balanced_accuracy")
+            + _row_float(row, "top2_accuracy")
+            + _row_float(row, "top3_accuracy")
+        ) / 3.0
     if selection_metric == "balanced_rank":
         chance_mean_rank = float(row.get("chance_mean_rank", 0.5 * (row.get("chance_classes", DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES) + 1)))
         rank_score = _inner_rank_score(_row_float(row, "mean_true_label_rank"), chance_mean_rank=chance_mean_rank)
@@ -2565,6 +2572,11 @@ def _nested_selection_score(summary, selection_metric):
         balanced = float(summary["selected_inner_balanced_accuracy_mean"])
         top2 = float(summary["selected_inner_top2_accuracy_mean"])
         return 0.5 * balanced + 0.5 * top2
+    if selection_metric == "balanced_top2_top3":
+        balanced = float(summary["selected_inner_balanced_accuracy_mean"])
+        top2 = float(summary["selected_inner_top2_accuracy_mean"])
+        top3 = float(summary["selected_inner_top3_accuracy_mean"])
+        return (balanced + top2 + top3) / 3.0
     if selection_metric == "balanced_rank":
         balanced = float(summary["selected_inner_balanced_accuracy_mean"])
         rank_score = float(summary["selected_inner_rank_score_mean"])

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -784,20 +784,20 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(diverse["selection_ensemble_diversity"], "window")
         self.assertEqual(diverse["selected_ensemble_window_center_counts"], "0.1:1;0.2:1")
 
-    def test_nested_selection_metric_can_use_top2_signal(self):
+    def test_nested_selection_metric_can_use_topk_signal(self):
         configs = (
             CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),
             CrossSubjectStimulusConfig(window_center=0.20, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),
         )
 
-        def inner_row(candidate_index, balanced_accuracy, top2_accuracy, mean_true_label_rank):
+        def inner_row(candidate_index, balanced_accuracy, top2_accuracy, top3_accuracy, mean_true_label_rank):
             return {
                 "outer_test_participant": 4,
                 "candidate_index": candidate_index,
                 "balanced_accuracy": balanced_accuracy,
                 "accuracy": balanced_accuracy,
                 "top2_accuracy": top2_accuracy,
-                "top3_accuracy": top2_accuracy,
+                "top3_accuracy": top3_accuracy,
                 "mean_true_label_rank": mean_true_label_rank,
                 "chance_mean_rank": 1.5,
                 "train_participants": "1,2,3",
@@ -816,8 +816,8 @@ class TestStimulusCrossSubject(unittest.TestCase):
             }
 
         inner_rows = [
-            inner_row(1, 0.70, 0.72, 1.30),
-            inner_row(2, 0.64, 0.95, 1.05),
+            inner_row(1, 0.70, 0.72, 0.74, 1.30),
+            inner_row(2, 0.64, 0.95, 0.99, 1.05),
         ]
 
         balanced, _balanced_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
@@ -840,6 +840,16 @@ class TestStimulusCrossSubject(unittest.TestCase):
             selection_metric="balanced_top2",
             candidate_configs=configs,
         )
+        topk_aware, _topk_aware_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=1,
+            selection_ensemble_diversity="none",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            selection_metric="balanced_top2_top3",
+            candidate_configs=configs,
+        )
 
         self.assertEqual(balanced["selected_candidate_index"], 1)
         self.assertEqual(rank_aware["selected_candidate_index"], 2)
@@ -847,6 +857,9 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertIn("2:", rank_aware["selected_ensemble_inner_selection_score_means"])
         self.assertGreater(rank_aware["selected_inner_selection_score_mean"], rank_aware["selected_inner_balanced_accuracy_mean"])
         self.assertEqual(rank_aware["selected_inner_selection_score_sem"], 0.0)
+        self.assertEqual(topk_aware["selected_candidate_index"], 2)
+        self.assertEqual(topk_aware["selection_metric"], "balanced_top2_top3")
+        self.assertGreater(topk_aware["selected_inner_selection_score_mean"], rank_aware["selected_inner_selection_score_mean"])
 
     def test_rank_softmax_score_normalization_ignores_score_scale(self):
         small_scale = cross_subject._class_score_probabilities(  # pylint: disable=protected-access


### PR DESCRIPTION
## Summary

Adds a `balanced_top2_top3` nested selection metric for source-only stimulus decoding.

The BUSH-MEG results repeatedly show stronger top-2/top-3 signal than top-1 accuracy. The existing `balanced_top2` selector uses top-2 information, but ignores top-3. This PR adds a source-fold composite score:

```text
(balanced_accuracy + top2_accuracy + top3_accuracy) / 3
```

and switches the source-only-next workflow to use `--selection-metric balanced_top2_top3` with the existing rank-normalized, metric-aligned ensemble settings.

The held-out target subject remains excluded from nested selection and weighting.

## Validation

Ran with local NeuRepTrace on `PYTHONPATH`:

```bash
python -m pytest tests/test_stimulus_cross_subject.py
python -m ruff check src/pymegdec/_stimulus_cross_subject_legacy.py tests/test_stimulus_cross_subject.py
git diff --check
```

Result: 32 passed, Ruff clean, diff check clean.