### PR TITLE
Focus source-only next on early windows

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -13,7 +13,7 @@ on:
         required: false
       window_centers:
         description: Candidate window centers in seconds
-        default: "0.125,0.175,0.250,0.400,0.550"
+        default: "0.150,0.175,0.200,0.225"
         required: true
       max_trials_per_class:
         description: Optional cap per subject/class; empty for all trials


### PR DESCRIPTION
## Summary

Updates the default `stimulus-source-only-next` workflow window grid from:

```text
0.125,0.175,0.250,0.400,0.550
```

to:

```text
0.150,0.175,0.200,0.225
```

This keeps the benchmark budget concentrated around the early post-stimulus window range where the strongest source-only BUSH-MEG signal has shown up in prior smoke/nested screens. It also removes late-window defaults that have not been competitive in the current evidence table.

The workflow input remains editable, so broader windows can still be dispatched explicitly.

## Validation

Workflow-only change:

```bash
git diff --check
```

Result: diff check clean.