### PR TITLE
Add weighted logistic to source-only next

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -56,7 +56,7 @@ jobs:
             --normalizations subject_baseline_whiten \
             --alignments none \
             --alignment-alphas 1.0 \
-            --classifiers multinomial-logistic,multiclass-svm \
+            --classifiers multinomial-logistic,multinomial-logistic-weighted,multiclass-svm \
             --classifier-params 0.1,1.0 \
             --components-pca-values 64,128 \
             --sample-weightings none,subject_class_balanced \


### PR DESCRIPTION
## Summary

Adds `multinomial-logistic-weighted` to the default `stimulus-source-only-next` nested classifier grid.

The capped matrix screens already tested weighted logistic as a plausible source-only classifier. The current source-only-next workflow had regular multinomial logistic and multiclass SVM, but omitted the weighted logistic variant. This PR lets the source-fold nested selector choose it when the held-out-source folds support it, while keeping the held-out target subject untouched.

The early-window default grid from PR #173 keeps the added classifier from expanding the default search as much as the older late-window grid did.

## Validation

Ran with local NeuRepTrace on `PYTHONPATH`:

```bash
python -m pytest tests/test_classifiers.py tests/test_classifier_registry.py
git diff --check
```

Result: 22 passed, diff check clean.