### PR TITLE
Add feature-aware source ensemble diversity

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -62,7 +62,7 @@ jobs:
             --sample-weightings none,subject_class_balanced \
             --score-calibrations none \
             --selection-ensemble-size 6 \
-            --selection-ensemble-diversity window_classifier \
+            --selection-ensemble-diversity window_feature_classifier \
             --selection-metric balanced_top2_top3 \
             --selection-ensemble-score-normalization rank_softmax \
             --selection-ensemble-weighting inner_selection_lcb_softmax \

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -70,7 +70,7 @@ SELECTION_ENSEMBLE_WEIGHTING_MODES = (
     "inner_selection_lcb_softmax",
 )
 ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax")
-SELECTION_ENSEMBLE_DIVERSITY_MODES = ("none", "window", "classifier", "window_classifier", "full_config")
+SELECTION_ENSEMBLE_DIVERSITY_MODES = ("none", "window", "classifier", "window_classifier", "window_feature_classifier", "full_config")
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
 NESTED_SCORE_ENSEMBLE_NORMALIZATION = DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
 FEATURE_MODES = (
@@ -1357,6 +1357,11 @@ def _ensemble_diversity_key(config, diversity):
         return f"classifier={config.classifier}"
     if diversity == "window_classifier":
         return f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},classifier={config.classifier}"
+    if diversity == "window_feature_classifier":
+        return (
+            f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
+            f"feature={config.feature_mode},classifier={config.classifier}"
+        )
     return (
         f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
         f"feature={config.feature_mode},norm={config.normalization},alignment={config.alignment},"

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -784,6 +784,54 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(diverse["selection_ensemble_diversity"], "window")
         self.assertEqual(diverse["selected_ensemble_window_center_counts"], "0.1:1;0.2:1")
 
+    def test_nested_ensemble_can_diversify_by_window_feature_and_classifier(self):
+        configs = (
+            CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, feature_mode="sensor_flat", normalization="none", classifier="multiclass-svm", classifier_param=0.5),
+            CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, feature_mode="sensor_flat", normalization="none", classifier="multiclass-svm", classifier_param=1.0),
+            CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, feature_mode="sensor_mean_logpower", normalization="none", classifier="multiclass-svm", classifier_param=0.5),
+        )
+
+        def inner_row(candidate_index, balanced_accuracy, feature_mode, classifier_param):
+            return {
+                "outer_test_participant": 4,
+                "candidate_index": candidate_index,
+                "balanced_accuracy": balanced_accuracy,
+                "accuracy": balanced_accuracy,
+                "train_participants": "1,2,3",
+                "n_train_participants": 3,
+                "window_center_s": 0.10,
+                "window_size_s": 0.1,
+                "window_start_s": 0.05,
+                "window_stop_s": 0.15,
+                "feature_mode": feature_mode,
+                "normalization": "none",
+                "alignment": "none",
+                "classifier": "multiclass-svm",
+                "classifier_param": classifier_param,
+                "components_pca": float("inf"),
+                "max_trials_per_class_per_participant": "",
+            }
+
+        inner_rows = [
+            inner_row(1, 0.90, "sensor_flat", 0.5),
+            inner_row(2, 0.85, "sensor_flat", 1.0),
+            inner_row(3, 0.80, "sensor_mean_logpower", 0.5),
+        ]
+
+        feature_diverse, _feature_diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window_feature_classifier",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+
+        self.assertEqual(feature_diverse["selected_candidate_indices"], "1;3")
+        self.assertEqual(feature_diverse["selection_ensemble_diversity"], "window_feature_classifier")
+        self.assertEqual(feature_diverse["selected_ensemble_feature_mode_counts"], "sensor_flat:1;sensor_mean_logpower:1")
+
     def test_nested_selection_metric_can_use_topk_signal(self):
         configs = (
             CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),


### PR DESCRIPTION
## Summary

Adds a `window_feature_classifier` nested source-ensemble diversity mode and uses it in the default `stimulus-source-only-next` workflow.

The current source-only-next grid already searches several feature modes, but the ensemble diversity key only separated candidates by window and classifier. That could discard a complementary feature representation at the same window/classifier before outer-subject evaluation. The new diversity mode keeps the same fitted candidate grid while allowing the nested selector to retain one candidate per `(window, feature, classifier)` combination.

## Validation

Ran with local NeuRepTrace on `PYTHONPATH`:

```bash
python -m pytest tests/test_stimulus_cross_subject.py tests/test_stimulus_cross_subject_next.py tests/test_classifiers.py tests/test_classifier_registry.py
python -m ruff check src/pymegdec/_stimulus_cross_subject_legacy.py tests/test_stimulus_cross_subject.py
git diff --check
```

Result: 60 passed, ruff passed, diff check clean.