### PR TITLE
Use rank-aware top-k source selection

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -63,7 +63,7 @@ jobs:
             --score-calibrations none \
             --selection-ensemble-size 6 \
             --selection-ensemble-diversity window_feature_classifier \
-            --selection-metric balanced_top2_top3 \
+            --selection-metric balanced_top2_top3_rank \
             --selection-ensemble-score-normalization rank_softmax \
             --selection-ensemble-weighting inner_selection_lcb_softmax \
             --write-incremental \

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -55,6 +55,7 @@ CROSS_SUBJECT_SELECTION_METRIC_CHOICES = (
     "mean_true_label_rank",
     "balanced_top2",
     "balanced_top2_top3",
+    "balanced_top2_top3_rank",
     "balanced_rank",
 )
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE = 1
@@ -2554,6 +2555,15 @@ def _nested_row_selection_score(row, selection_metric):
             + _row_float(row, "top2_accuracy")
             + _row_float(row, "top3_accuracy")
         ) / 3.0
+    if selection_metric == "balanced_top2_top3_rank":
+        chance_mean_rank = float(row.get("chance_mean_rank", 0.5 * (row.get("chance_classes", DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES) + 1)))
+        rank_score = _inner_rank_score(_row_float(row, "mean_true_label_rank"), chance_mean_rank=chance_mean_rank)
+        return (
+            _row_float(row, "balanced_accuracy")
+            + _row_float(row, "top2_accuracy")
+            + _row_float(row, "top3_accuracy")
+            + rank_score
+        ) / 4.0
     if selection_metric == "balanced_rank":
         chance_mean_rank = float(row.get("chance_mean_rank", 0.5 * (row.get("chance_classes", DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES) + 1)))
         rank_score = _inner_rank_score(_row_float(row, "mean_true_label_rank"), chance_mean_rank=chance_mean_rank)
@@ -2582,6 +2592,12 @@ def _nested_selection_score(summary, selection_metric):
         top2 = float(summary["selected_inner_top2_accuracy_mean"])
         top3 = float(summary["selected_inner_top3_accuracy_mean"])
         return (balanced + top2 + top3) / 3.0
+    if selection_metric == "balanced_top2_top3_rank":
+        balanced = float(summary["selected_inner_balanced_accuracy_mean"])
+        top2 = float(summary["selected_inner_top2_accuracy_mean"])
+        top3 = float(summary["selected_inner_top3_accuracy_mean"])
+        rank_score = float(summary["selected_inner_rank_score_mean"])
+        return (balanced + top2 + top3 + rank_score) / 4.0
     if selection_metric == "balanced_rank":
         balanced = float(summary["selected_inner_balanced_accuracy_mean"])
         rank_score = float(summary["selected_inner_rank_score_mean"])

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -909,6 +909,68 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(topk_aware["selection_metric"], "balanced_top2_top3")
         self.assertGreater(topk_aware["selected_inner_selection_score_mean"], rank_aware["selected_inner_selection_score_mean"])
 
+    def test_nested_selection_metric_can_use_topk_and_rank_signal(self):
+        configs = (
+            CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),
+            CrossSubjectStimulusConfig(window_center=0.20, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),
+        )
+
+        def inner_row(candidate_index, balanced_accuracy, top2_accuracy, top3_accuracy, mean_true_label_rank):
+            return {
+                "outer_test_participant": 4,
+                "candidate_index": candidate_index,
+                "balanced_accuracy": balanced_accuracy,
+                "accuracy": balanced_accuracy,
+                "top2_accuracy": top2_accuracy,
+                "top3_accuracy": top3_accuracy,
+                "mean_true_label_rank": mean_true_label_rank,
+                "chance_mean_rank": 8.5,
+                "train_participants": "1,2,3",
+                "n_train_participants": 3,
+                "window_center_s": 0.10 * candidate_index,
+                "window_size_s": 0.1,
+                "window_start_s": 0.10 * candidate_index - 0.05,
+                "window_stop_s": 0.10 * candidate_index + 0.05,
+                "feature_mode": "sensor_mean",
+                "normalization": "none",
+                "alignment": "none",
+                "classifier": "multiclass-svm",
+                "classifier_param": 0.5,
+                "components_pca": float("inf"),
+                "max_trials_per_class_per_participant": "",
+            }
+
+        inner_rows = [
+            inner_row(1, 0.75, 0.80, 0.90, 5.5),
+            inner_row(2, 0.70, 0.74, 0.78, 2.0),
+        ]
+
+        topk_aware, _topk_aware_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=1,
+            selection_ensemble_diversity="none",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            selection_metric="balanced_top2_top3",
+            candidate_configs=configs,
+        )
+        rank_composite, _rank_composite_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=1,
+            selection_ensemble_diversity="none",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            selection_metric="balanced_top2_top3_rank",
+            candidate_configs=configs,
+        )
+
+        self.assertEqual(topk_aware["selected_candidate_index"], 1)
+        self.assertEqual(rank_composite["selected_candidate_index"], 2)
+        self.assertEqual(rank_composite["selection_metric"], "balanced_top2_top3_rank")
+        self.assertGreater(rank_composite["selected_inner_rank_score_mean"], 0.8)
+
     def test_rank_softmax_score_normalization_ignores_score_scale(self):
         small_scale = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
             np.asarray([[0.30, 0.10, 0.20]], dtype=float),


### PR DESCRIPTION
## Summary

Adds a `balanced_top2_top3_rank` nested selection metric and switches the default `stimulus-source-only-next` workflow to use it.

The existing default selection metric used balanced accuracy, top-2, and top-3 accuracy. This PR also folds in the source-fold mean true-label rank, normalized against chance rank, so candidate selection can prefer models that rank the true class consistently well even when top-1 remains noisy.

This keeps the held-out target subject untouched: the rank signal is computed only in the inner source-subject validation folds.

## Validation

Ran with local NeuRepTrace on `PYTHONPATH`:

```bash
python -m pytest tests/test_stimulus_cross_subject.py tests/test_stimulus_cross_subject_next.py tests/test_classifiers.py tests/test_classifier_registry.py
python -m ruff check src/pymegdec/_stimulus_cross_subject_legacy.py tests/test_stimulus_cross_subject.py
git diff --check
```

Result: 61 passed, ruff passed, diff check clean.