### PR TITLE
Add one-vs-one SVM to source-only next

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -56,7 +56,7 @@ jobs:
             --normalizations subject_baseline_whiten \
             --alignments none \
             --alignment-alphas 1.0 \
-            --classifiers multinomial-logistic,multinomial-logistic-weighted,multiclass-svm \
+            --classifiers multinomial-logistic,multinomial-logistic-weighted,multiclass-svm,one-vs-one-linear-svm \
             --classifier-params 0.1,1.0 \
             --components-pca-values 64,128 \
             --sample-weightings none,subject_class_balanced \

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -15,7 +15,7 @@ import reptrace.decoding.classifiers as reptrace_classifiers
 from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import LinearSVC
-from sklearn.multiclass import OneVsOneClassifier, OneVsRestClassifier
+from sklearn.multiclass import OneVsRestClassifier
 from sklearn.naive_bayes import GaussianNB
 from sklearn.pipeline import Pipeline
 
@@ -141,12 +141,73 @@ def _linear_svc(classifier_param, random_state):
     return LinearSVC(C=float(classifier_param), max_iter=5000, random_state=random_state)
 
 
-def _build_one_vs_one_linear_svm(_features, _labels, classifier_param, random_state):
-    return OneVsOneClassifier(_linear_svc(classifier_param, random_state))
-
-
 def _build_one_vs_rest_linear_svm(_features, _labels, classifier_param, random_state):
     return OneVsRestClassifier(_linear_svc(classifier_param, random_state))
+
+
+class SampleWeightedOneVsOneLinearSVM:
+    """One-vs-one LinearSVC adapter that propagates per-trial weights."""
+
+    def __init__(self, *, C: float = 1.0, random_state: int | None = 0):
+        self.C = float(C)
+        self.random_state = random_state
+        self.classes_: np.ndarray | None = None
+        self.models_: list[tuple[int, int, LinearSVC]] | None = None
+
+    def fit(self, features, labels, sample_weight=None):
+        features = np.asarray(features, dtype=float)
+        labels = np.asarray(labels).ravel()
+        if features.ndim != 2:
+            raise ValueError("features must be a two-dimensional matrix.")
+        if labels.shape[0] != features.shape[0]:
+            raise ValueError("labels must have the same length as features.")
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight, dtype=float).ravel()
+            if sample_weight.shape[0] != labels.shape[0]:
+                raise ValueError("sample_weight must contain one value per training row.")
+
+        self.classes_ = np.unique(labels)
+        if self.classes_.size < 2:
+            raise ValueError("One-vs-one linear SVM requires at least two classes.")
+
+        class_to_index = {label: index for index, label in enumerate(self.classes_.tolist())}
+        self.models_ = []
+        pair_index = 0
+        for left_class_index, left_class in enumerate(self.classes_[:-1]):
+            for right_class in self.classes_[left_class_index + 1 :]:
+                right_class_index = class_to_index[right_class]
+                pair_mask = np.isin(labels, (left_class, right_class))
+                pair_labels = (labels[pair_mask] == right_class).astype(int)
+                pair_weights = None if sample_weight is None else sample_weight[pair_mask]
+                seed = None if self.random_state is None else int(self.random_state) + pair_index
+                model = LinearSVC(C=self.C, max_iter=5000, random_state=seed)
+                if pair_weights is None:
+                    model.fit(features[pair_mask], pair_labels)
+                else:
+                    model.fit(features[pair_mask], pair_labels, sample_weight=pair_weights)
+                self.models_.append((left_class_index, right_class_index, model))
+                pair_index += 1
+        return self
+
+    def decision_function(self, features):
+        if self.models_ is None or self.classes_ is None:
+            raise RuntimeError("SampleWeightedOneVsOneLinearSVM must be fitted before scoring.")
+        features = np.asarray(features, dtype=float)
+        scores = np.zeros((features.shape[0], self.classes_.size), dtype=float)
+        for left_class_index, right_class_index, model in self.models_:
+            margin = np.asarray(model.decision_function(features), dtype=float)
+            scores[:, left_class_index] -= margin
+            scores[:, right_class_index] += margin
+        return scores / max(self.classes_.size - 1, 1)
+
+    def predict(self, features):
+        if self.classes_ is None:
+            raise RuntimeError("SampleWeightedOneVsOneLinearSVM must be fitted before prediction.")
+        return self.classes_[np.argmax(self.decision_function(features), axis=1)]
+
+
+def _build_one_vs_one_linear_svm(_features, _labels, classifier_param, random_state):
+    return SampleWeightedOneVsOneLinearSVM(C=float(classifier_param), random_state=random_state)
 
 
 class SampleWeightedECOCLinearSVM:
@@ -254,6 +315,7 @@ __all__ = [
     "DecodedLabelClassifier",
     "ShrinkagePrototypeClassifier",
     "SampleWeightedECOCLinearSVM",
+    "SampleWeightedOneVsOneLinearSVM",
     "_build_pytorch_data_loaders",
     "get_default_classifier_param",
     "positive_class_score",

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -72,6 +72,7 @@ class TestClassifiers(unittest.TestCase):
         self.assertIs(classifiers.train_multiclass_classifier, train_multiclass_classifier)
         self.assertIn("gaussian-naive-bayes", classifiers.CLASSIFIER_REGISTRY)
         self.assertIn("multinomial-logistic-weighted", classifiers.CLASSIFIER_REGISTRY)
+        self.assertIn("one-vs-one-linear-svm", classifiers.CLASSIFIER_REGISTRY)
         self.assertIn("regularized-qda", classifiers.CLASSIFIER_REGISTRY)
         self.assertIn("shrinkage-prototype", classifiers.CLASSIFIER_REGISTRY)
 
@@ -80,6 +81,7 @@ class TestClassifiers(unittest.TestCase):
         self.assertEqual(get_default_classifier_param("gaussian-naive-bayes"), 1e-9)
         self.assertEqual(get_default_classifier_param("multinomial-logistic"), 1.0)
         self.assertEqual(get_default_classifier_param("multinomial-logistic-weighted"), 1.0)
+        self.assertEqual(get_default_classifier_param("one-vs-one-linear-svm"), 1.0)
         self.assertEqual(get_default_classifier_param("regularized-qda"), 0.5)
         self.assertEqual(get_default_classifier_param("shrinkage-prototype"), 0.25)
         self.assertIsNone(get_default_classifier_param("shrinkage-lda"))
@@ -146,6 +148,33 @@ class TestClassifiers(unittest.TestCase):
 
         self.assertIn("multinomial-logistic-weighted", CLASSIFIER_REGISTRY)
         self.assertEqual(model.model.class_weight, "balanced")
+        self.assertEqual(len(model.predict(features)), len(labels))
+
+    def test_one_vs_one_linear_svm_accepts_sample_weight(self):
+        rng = np.random.default_rng(41)
+        features = np.vstack(
+            [
+                rng.normal(loc=(-1.0, -1.0), scale=0.2, size=(6, 2)),
+                rng.normal(loc=(1.0, 0.5), scale=0.2, size=(6, 2)),
+                rng.normal(loc=(0.0, 1.5), scale=0.2, size=(6, 2)),
+            ]
+        )
+        labels = np.repeat(np.arange(3, dtype=int), 6)
+        sample_weight = np.linspace(0.5, 2.0, labels.size)
+
+        model = train_multiclass_classifier(
+            features,
+            labels,
+            "one-vs-one-linear-svm",
+            1.0,
+            random_state=13,
+            sample_weight=sample_weight,
+        )
+        scores = model.decision_function(features[:4])
+
+        self.assertIn("one-vs-one-linear-svm", CLASSIFIER_REGISTRY)
+        self.assertEqual(len(model.model.models_), 3)
+        self.assertEqual(scores.shape, (4, 3))
         self.assertEqual(len(model.predict(features)), len(labels))
 
     def test_shrinkage_prototype_classifier_trains_and_scores(self):


### PR DESCRIPTION
## Summary

Adds a sample-weight-aware `one-vs-one-linear-svm` adapter and includes it in the default `stimulus-source-only-next` nested classifier grid.

The classifier was already exposed in the PyMEGDec registry, but the previous adapter used scikit-learn's `OneVsOneClassifier`, which rejects `sample_weight` in the local sklearn version unless metadata routing is enabled. Since the source-only-next grid evaluates both unweighted and `subject_class_balanced` candidates, this PR replaces the adapter with a small pairwise LinearSVC implementation that propagates per-trial weights to every binary pair.

This gives nested source-fold selection a pairwise SVM decomposition for the 16-way image problem without touching the held-out target subject.

## Validation

Ran with local NeuRepTrace on `PYTHONPATH`:

```bash
python -m pytest tests/test_classifiers.py tests/test_classifier_registry.py tests/test_stimulus_cross_subject.py tests/test_stimulus_cross_subject_next.py
python -m ruff check src/pymegdec/classifiers.py tests/test_classifiers.py
git diff --check
```

Result: 62 passed, ruff passed, diff check clean.