### PR TITLE
Blend rank and margin source ensemble scores

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -64,7 +64,7 @@ jobs:
             --selection-ensemble-size 6 \
             --selection-ensemble-diversity window_feature_classifier \
             --selection-metric balanced_top2_top3_rank \
-            --selection-ensemble-score-normalization rank_softmax \
+            --selection-ensemble-score-normalization rank_z_blend \
             --selection-ensemble-weighting inner_selection_lcb_softmax \
             --write-incremental \
             --resume \

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -70,7 +70,7 @@ SELECTION_ENSEMBLE_WEIGHTING_MODES = (
     "inner_selection_softmax",
     "inner_selection_lcb_softmax",
 )
-ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax")
+ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax", "rank_z_blend")
 SELECTION_ENSEMBLE_DIVERSITY_MODES = ("none", "window", "classifier", "window_classifier", "window_feature_classifier", "full_config")
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
 NESTED_SCORE_ENSEMBLE_NORMALIZATION = DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
@@ -1818,6 +1818,8 @@ def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJ
         return _row_softmax_probabilities(scores)
     if score_normalization == "rank_softmax":
         return _rank_softmax_probabilities(scores)
+    if score_normalization == "rank_z_blend":
+        return _rank_z_blend_probabilities(scores)
     raise ValueError(f"Unsupported ensemble score normalization: {score_normalization}")
 
 
@@ -1840,6 +1842,19 @@ def _rank_softmax_probabilities(scores):
         exp_logits = np.exp(logits - np.max(logits))
         probabilities[row_index] = exp_logits / np.sum(exp_logits)
     return probabilities
+
+
+def _rank_z_blend_probabilities(scores):
+    rank_probabilities = _rank_softmax_probabilities(scores)
+    row_z_probabilities = _row_softmax_probabilities(scores)
+    blended = 0.5 * rank_probabilities + 0.5 * row_z_probabilities
+    row_sums = np.sum(blended, axis=1, keepdims=True)
+    return np.divide(
+        blended,
+        row_sums,
+        out=np.full_like(blended, 1.0 / blended.shape[1]),
+        where=row_sums > 0.0,
+    )
 
 
 def _align_score_columns(probabilities, score_classes, class_order):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -991,6 +991,31 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertGreater(large_scale[0, 0], large_scale[0, 2])
         self.assertGreater(large_scale[0, 2], large_scale[0, 1])
 
+    def test_rank_z_blend_score_normalization_keeps_rank_and_margin_signal(self):
+        scores = np.asarray([[1.00, 0.99, -3.00], [10.0, -1.0, 0.0]], dtype=float)
+
+        rank_only = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax",
+        )
+        row_z = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="row_z_softmax",
+        )
+        blended = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank-z-blend",
+        )
+
+        np.testing.assert_allclose(np.sum(blended, axis=1), np.ones(2))
+        self.assertEqual(int(np.argmax(blended[0])), 0)
+        self.assertEqual(int(np.argmax(blended[1])), 0)
+        self.assertGreater(blended[0, 1], blended[0, 2])
+        self.assertGreater(blended[1, 2], blended[1, 1])
+        self.assertLess(blended[0, 0] - blended[0, 1], rank_only[0, 0] - rank_only[0, 1])
+        self.assertGreater(blended[1, 0] - blended[1, 2], rank_only[1, 0] - rank_only[1, 2])
+        np.testing.assert_allclose(blended, 0.5 * rank_only + 0.5 * row_z)
+
     def test_nested_cross_subject_can_evaluate_outer_subset(self):
         data_by_participant = {
             1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),


### PR DESCRIPTION
## Summary

Adds `rank_z_blend` ensemble score normalization and switches the default `stimulus-source-only-next` workflow to use it.

`rank_softmax` is robust across candidate models because it ignores score scale, but it also discards margin information that may help convert top-k signal into top-1 accuracy. The new normalizer averages rank-softmax probabilities with row-wise z-softmax probabilities, keeping rank robustness while allowing strong within-row margins to sharpen the selected score ensemble.

The held-out target subject remains untouched; this only changes how already-selected source-fold candidates combine their held-out target scores.

## Validation

Ran with local NeuRepTrace on `PYTHONPATH`:

```bash
python -m pytest tests/test_stimulus_cross_subject.py tests/test_stimulus_cross_subject_next.py tests/test_classifiers.py tests/test_classifier_registry.py
python -m ruff check src/pymegdec/_stimulus_cross_subject_legacy.py tests/test_stimulus_cross_subject.py
git diff --check
```

Result: 63 passed, ruff passed, diff check clean.