### PR TITLE
Add class-bias calibration to source-only next

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -60,7 +60,7 @@ jobs:
             --classifier-params 0.1,1.0 \
             --components-pca-values 64,128 \
             --sample-weightings none,subject_class_balanced \
-            --score-calibrations none \
+            --score-calibrations none,inner_class_bias \
             --selection-ensemble-size 6 \
             --selection-ensemble-diversity window_feature_classifier \
             --selection-metric balanced_top2_top3_rank \

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -110,6 +110,37 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual({config.score_calibration for config in configs}, {"none", "inner_class_bias"})
         self.assertEqual({config.alignment_alpha for config in configs}, {0.25, 1.0})
 
+    def test_inner_class_bias_score_calibration_fits_source_fold_metadata(self):
+        time = np.asarray([-0.1, 0.0, 0.1, 0.2], dtype=float)
+        labels = [1, 2, 1, 2]
+        data_by_participant = {
+            1: mat_data_from_trials(labels, [[[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]], [[-0.9, -0.9, -0.9, -0.9]], [[0.9, 0.9, 0.9, 0.9]]], time),
+            2: mat_data_from_trials(labels, [[[-1.1, -1.1, -1.1, -1.1]], [[1.1, 1.1, 1.1, 1.1]], [[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]]], time),
+            3: mat_data_from_trials(labels, [[[-1.2, -1.2, -1.2, -1.2]], [[1.2, 1.2, 1.2, 1.2]], [[-1.1, -1.1, -1.1, -1.1]], [[1.1, 1.1, 1.1, 1.1]]], time),
+        }
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean",
+            normalization="none",
+            classifier="multinomial-logistic",
+            classifier_param=1.0,
+            components_pca=float("inf"),
+            score_calibration="inner_class_bias",
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            train_sets = [load_participant_stimulus_features("unused", participant, config=config) for participant in (1, 2, 3)]
+
+        fitted_model = cross_subject._fit_outer_fold_model(train_sets, config, 1.0)  # pylint: disable=protected-access
+        metadata = fitted_model["score_calibration_metadata"]
+
+        self.assertEqual(metadata["mode"], "inner_class_bias")
+        np.testing.assert_array_equal(metadata["classes"], np.asarray([0, 1]))
+        self.assertEqual(metadata["bias"].shape, (2,))
+        self.assertTrue(np.isfinite(metadata["inner_balanced_accuracy"]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds `inner_class_bias` as a candidate score-calibration mode in the default `stimulus-source-only-next` nested grid.

The workflow already ran a separate fixed class-bias smoke, but the main nested source-only grid only searched `score_calibrations none`. This PR lets source-fold model selection choose between uncalibrated scores and inner-source class-bias corrected scores while keeping the held-out target subject untouched.

The class-bias correction is fitted only from inner source-subject validation folds, so the target subject still remains label-unseen during model selection.

## Validation

Ran with local NeuRepTrace on `PYTHONPATH`:

```bash
python -m pytest tests/test_stimulus_cross_subject_next.py tests/test_stimulus_cross_subject.py
python -m ruff check tests/test_stimulus_cross_subject_next.py
git diff --check
```

Result: 41 passed, ruff passed, diff check clean.