### PR TITLE
Use LCB rank-topk source selection

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -63,7 +63,7 @@ jobs:
             --score-calibrations none,inner_class_bias \
             --selection-ensemble-size 6 \
             --selection-ensemble-diversity window_feature_classifier \
-            --selection-metric balanced_top2_top3_rank \
+            --selection-metric balanced_top2_top3_rank_lcb \
             --selection-ensemble-score-normalization rank_z_blend \
             --selection-ensemble-weighting inner_selection_lcb_softmax \
             --write-incremental \

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -56,6 +56,7 @@ CROSS_SUBJECT_SELECTION_METRIC_CHOICES = (
     "balanced_top2",
     "balanced_top2_top3",
     "balanced_top2_top3_rank",
+    "balanced_top2_top3_rank_lcb",
     "balanced_rank",
 )
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE = 1
@@ -1477,6 +1478,7 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=DEFAULT_CROSS_SUBJEC
             summary["selected_inner_mean_true_label_rank_mean"],
             chance_mean_rank=chance_mean_rank,
         )
+        summary["selected_inner_selection_ranking_score"] = _nested_selection_score(summary, selection_metric)
         summaries.append(
             summary
         )
@@ -1486,10 +1488,10 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=DEFAULT_CROSS_SUBJEC
         reverse=True,
     )
     selected = ranked[0]
-    selected_score = float(selected["selected_inner_selection_score_mean"])
+    selected_score = float(selected.get("selected_inner_selection_ranking_score", selected["selected_inner_selection_score_mean"]))
     if len(ranked) > 1:
         second_best_balanced_mean = float(ranked[1]["selected_inner_balanced_accuracy_mean"])
-        second_best_score = float(ranked[1]["selected_inner_selection_score_mean"])
+        second_best_score = float(ranked[1].get("selected_inner_selection_ranking_score", ranked[1]["selected_inner_selection_score_mean"]))
         winner_margin = selected_score - second_best_score
     else:
         second_best_balanced_mean = np.nan
@@ -1499,7 +1501,8 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=DEFAULT_CROSS_SUBJEC
         row["selected_inner_rank"] = int(rank)
         row["selected_inner_second_best_balanced_accuracy_mean"] = second_best_balanced_mean
         row["selected_inner_second_best_selection_score_mean"] = second_best_score
-        row["selected_inner_winner_margin"] = winner_margin if rank == 1 else selected_score - float(row["selected_inner_selection_score_mean"])
+        row_score = float(row.get("selected_inner_selection_ranking_score", row["selected_inner_selection_score_mean"]))
+        row["selected_inner_winner_margin"] = winner_margin if rank == 1 else selected_score - row_score
         row["selection_ensemble_requested_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
         row["selection_ensemble_size"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE
         row["selection_ensemble_diversity"] = DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_DIVERSITY
@@ -2552,6 +2555,8 @@ def _row_float(row, key):
 
 def _nested_row_selection_score(row, selection_metric):
     selection_metric = _normalize_selection_metric(selection_metric)
+    if selection_metric == "balanced_top2_top3_rank_lcb":
+        selection_metric = "balanced_top2_top3_rank"
     if selection_metric == "balanced_accuracy":
         return _row_float(row, "balanced_accuracy")
     if selection_metric == "accuracy":
@@ -2588,6 +2593,10 @@ def _nested_row_selection_score(row, selection_metric):
 
 def _nested_selection_score(summary, selection_metric):
     selection_metric = _normalize_selection_metric(selection_metric)
+    if selection_metric == "balanced_top2_top3_rank_lcb":
+        mean = float(summary["selected_inner_selection_score_mean"])
+        sem = float(summary.get("selected_inner_selection_score_sem", 0.0))
+        return mean - (sem if np.isfinite(sem) else 0.0)
     if selection_metric == "balanced_accuracy":
         return float(summary["selected_inner_balanced_accuracy_mean"])
     if selection_metric == "accuracy":
@@ -2627,7 +2636,7 @@ def _finite_sort_value(value, *, missing=-np.inf):
 
 def _nested_selection_sort_key(row):
     return (
-        _finite_sort_value(row["selected_inner_selection_score_mean"]),
+        _finite_sort_value(row.get("selected_inner_selection_ranking_score", row["selected_inner_selection_score_mean"])),
         _finite_sort_value(row["selected_inner_balanced_accuracy_mean"]),
         _finite_sort_value(row["selected_inner_top2_accuracy_mean"]),
         _finite_sort_value(row["selected_inner_top3_accuracy_mean"]),

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -971,6 +971,73 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(rank_composite["selection_metric"], "balanced_top2_top3_rank")
         self.assertGreater(rank_composite["selected_inner_rank_score_mean"], 0.8)
 
+    def test_nested_selection_metric_can_use_lcb_topk_rank_signal(self):
+        configs = (
+            CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),
+            CrossSubjectStimulusConfig(window_center=0.20, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),
+        )
+
+        def inner_row(candidate_index, balanced_accuracy, top2_accuracy, top3_accuracy, mean_true_label_rank):
+            return {
+                "outer_test_participant": 4,
+                "candidate_index": candidate_index,
+                "balanced_accuracy": balanced_accuracy,
+                "accuracy": balanced_accuracy,
+                "top2_accuracy": top2_accuracy,
+                "top3_accuracy": top3_accuracy,
+                "mean_true_label_rank": mean_true_label_rank,
+                "chance_mean_rank": 8.5,
+                "train_participants": "1,2,3",
+                "n_train_participants": 3,
+                "window_center_s": 0.10 * candidate_index,
+                "window_size_s": 0.1,
+                "window_start_s": 0.10 * candidate_index - 0.05,
+                "window_stop_s": 0.10 * candidate_index + 0.05,
+                "feature_mode": "sensor_mean",
+                "normalization": "none",
+                "alignment": "none",
+                "classifier": "multiclass-svm",
+                "classifier_param": 0.5,
+                "components_pca": float("inf"),
+                "max_trials_per_class_per_participant": "",
+            }
+
+        inner_rows = [
+            inner_row(1, 1.00, 1.00, 1.00, 1.0),
+            inner_row(1, 0.55, 0.57, 0.59, 6.5),
+            inner_row(2, 0.70, 0.72, 0.74, 3.0),
+            inner_row(2, 0.69, 0.71, 0.73, 3.1),
+        ]
+
+        rank_composite, _rank_composite_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=1,
+            selection_ensemble_diversity="none",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            selection_metric="balanced_top2_top3_rank",
+            candidate_configs=configs,
+        )
+        lcb_composite, _lcb_composite_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=1,
+            selection_ensemble_diversity="none",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            selection_metric="balanced_top2_top3_rank_lcb",
+            candidate_configs=configs,
+        )
+
+        self.assertEqual(rank_composite["selected_candidate_index"], 1)
+        self.assertEqual(lcb_composite["selected_candidate_index"], 2)
+        self.assertEqual(lcb_composite["selection_metric"], "balanced_top2_top3_rank_lcb")
+        self.assertLess(
+            lcb_composite["selected_inner_selection_ranking_score"],
+            lcb_composite["selected_inner_selection_score_mean"],
+        )
+
     def test_rank_softmax_score_normalization_ignores_score_scale(self):
         small_scale = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
             np.asarray([[0.30, 0.10, 0.20]], dtype=float),


### PR DESCRIPTION
## Summary
- add `balanced_top2_top3_rank_lcb` as a source-candidate selection metric
- rank nested candidates by the lower confidence bound of the balanced/top-2/top-3/rank composite score
- point the source-only-next workflow at the LCB metric to penalize unstable source-fold winners

## Validation
- `PYTHONPATH=... python -m pytest tests\test_stimulus_cross_subject.py tests\test_stimulus_cross_subject_next.py` (42 passed)
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py`
- `git diff --check` (line-ending warnings only)

The held-out target participant remains excluded from source selection; the change only affects source-fold candidate ranking.