### PR TITLE
Add affine source score calibration

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -60,7 +60,7 @@ jobs:
             --classifier-params 0.1,1.0 \
             --components-pca-values 64,128 \
             --sample-weightings none,subject_class_balanced \
-            --score-calibrations none,inner_class_bias \
+            --score-calibrations none,inner_class_affine \
             --selection-ensemble-size 6 \
             --selection-ensemble-diversity window_feature_classifier \
             --selection-metric balanced_top2_top3_rank_lcb \
@@ -78,7 +78,7 @@ jobs:
             --per-stimulus-output outputs/stimulus_source_only_next_per_stimulus.csv \
             --confusion-pairs-output outputs/stimulus_source_only_next_confusion_pairs.csv
 
-      - name: Run source-only class-bias calibration smoke
+      - name: Run source-only affine score calibration smoke
         shell: bash
         run: |
           OUTER_ARGS=()
@@ -97,7 +97,7 @@ jobs:
             --classifier-param 1.0 \
             --components-pca 128 \
             --sample-weighting subject_class_balanced \
-            --score-calibration inner_class_bias \
+            --score-calibration inner_class_affine \
             --outer-output outputs/stimulus_source_bias_outer.csv \
             --summary-output outputs/stimulus_source_bias_group_summary.csv \
             --predictions-output outputs/stimulus_source_bias_predictions.csv

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -19,7 +19,7 @@ from pymegdec.classifiers import get_default_classifier_param, should_use_defaul
 DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING = "none"
 SAMPLE_WEIGHTING_MODES = ("none", "subject_class_balanced")
 DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION = "none"
-SCORE_CALIBRATION_MODES = ("none", "inner_class_bias")
+SCORE_CALIBRATION_MODES = ("none", "inner_class_bias", "inner_class_affine")
 DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = 1.0
 DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
 DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
@@ -109,6 +109,7 @@ def install(impl) -> None:
     impl._fit_outer_fold_model = _fit_outer_fold_model
     impl._score_outer_fold_model = _score_outer_fold_model
     impl._candidate_model_scores = _candidate_model_scores
+    impl._apply_score_calibration = _apply_score_calibration
     impl._align_training_features_by_subject = _align_training_features_by_subject
     impl._align_test_features_by_subject = _align_test_features_by_subject
     impl._prediction_rows = _prediction_rows
@@ -443,8 +444,8 @@ def _fit_outer_fold_model(train_sets, config, classifier_param, *, label_shuffle
     }
     if feature_transform_metadata is not None:
         fitted_model["feature_transform_metadata"] = feature_transform_metadata
-    if fit_score_calibration and config.score_calibration == "inner_class_bias":
-        fitted_model["score_calibration_metadata"] = _fit_inner_class_bias_calibration(
+    if fit_score_calibration and config.score_calibration in {"inner_class_bias", "inner_class_affine"}:
+        fitted_model["score_calibration_metadata"] = _fit_inner_score_calibration(
             train_sets,
             config,
             classifier_param,
@@ -469,9 +470,10 @@ def _training_sample_weights(train_sets, label_arrays, config):
     return weights
 
 
-def _fit_inner_class_bias_calibration(train_sets, config, classifier_param, *, label_shuffle_seed=None, label_shuffle_context=()):
+def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_shuffle_seed=None, label_shuffle_context=()):
+    mode = _normalize_score_calibration(getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION))
     if len(train_sets) < 3:
-        return {"mode": "inner_class_bias", "status": "skipped_not_enough_source_subjects"}
+        return {"mode": mode, "status": "skipped_not_enough_source_subjects"}
     all_scores = []
     all_labels = []
     class_order = np.arange(int(config.chance_classes), dtype=int)
@@ -491,11 +493,16 @@ def _fit_inner_class_bias_calibration(train_sets, config, classifier_param, *, l
         all_labels.append(np.asarray(validation_set.labels, dtype=int) - 1)
     scores = np.vstack(all_scores)
     labels = np.concatenate(all_labels)
-    bias, inner_balanced = _optimize_class_bias(scores, labels, class_order)
+    if mode == "inner_class_affine":
+        bias, scale, inner_balanced = _optimize_class_affine(scores, labels, class_order)
+    else:
+        bias, inner_balanced = _optimize_class_bias(scores, labels, class_order)
+        scale = np.ones(class_order.shape[0], dtype=float)
     return {
-        "mode": "inner_class_bias",
+        "mode": mode,
         "classes": class_order,
         "bias": bias,
+        "scale": scale,
         "inner_balanced_accuracy": inner_balanced,
         "l2_penalty": SCORE_CALIBRATION_L2,
     }
@@ -530,9 +537,51 @@ def _optimize_class_bias(scores, labels, class_order):
     return bias, _balanced_accuracy_for_scores(scores + bias[None, :], labels, class_order)
 
 
+def _optimize_class_affine(scores, labels, class_order):
+    scores = np.asarray(scores, dtype=float)
+    labels = np.asarray(labels, dtype=int)
+    class_order = np.asarray(class_order, dtype=int)
+    bias, _inner_balanced = _optimize_class_bias(scores, labels, class_order)
+    log_scale = np.zeros(class_order.shape[0], dtype=float)
+    best = _affine_objective(scores, labels, class_order, bias, log_scale)
+    for step in (0.5, 0.25, 0.1, 0.05, 0.02):
+        improved = True
+        while improved:
+            improved = False
+            for column in range(class_order.shape[0]):
+                for parameter in ("bias", "log_scale"):
+                    for direction in (1.0, -1.0):
+                        candidate_bias = bias.copy()
+                        candidate_log_scale = log_scale.copy()
+                        if parameter == "bias":
+                            candidate_bias[column] += direction * step
+                            candidate_bias -= np.mean(candidate_bias)
+                        else:
+                            candidate_log_scale[column] += direction * step
+                            candidate_log_scale -= np.mean(candidate_log_scale)
+                            candidate_log_scale = np.clip(candidate_log_scale, -1.5, 1.5)
+                        value = _affine_objective(scores, labels, class_order, candidate_bias, candidate_log_scale)
+                        if value > best + 1e-12:
+                            bias = candidate_bias
+                            log_scale = candidate_log_scale
+                            best = value
+                            improved = True
+    scale = np.exp(log_scale)
+    calibrated = scores * scale[None, :] + bias[None, :]
+    return bias, scale, _balanced_accuracy_for_scores(calibrated, labels, class_order)
+
+
 def _bias_objective(scores, labels, class_order, bias):
     balanced = _balanced_accuracy_for_scores(scores + bias[None, :], labels, class_order)
     return balanced - SCORE_CALIBRATION_L2 * float(np.mean(np.square(bias)))
+
+
+def _affine_objective(scores, labels, class_order, bias, log_scale):
+    scale = np.exp(np.asarray(log_scale, dtype=float))
+    calibrated = np.asarray(scores, dtype=float) * scale[None, :] + np.asarray(bias, dtype=float)[None, :]
+    balanced = _balanced_accuracy_for_scores(calibrated, labels, class_order)
+    penalty = float(np.mean(np.square(bias)) + np.mean(np.square(log_scale)))
+    return balanced - SCORE_CALIBRATION_L2 * penalty
 
 
 def _balanced_accuracy_for_scores(scores, labels, class_order):
@@ -567,18 +616,19 @@ def _candidate_model_scores(fitted_model, test_set, config):
 
 def _apply_score_calibration(scores, classes, fitted_model):
     metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
-    if metadata.get("mode") != "inner_class_bias" or "bias" not in metadata:
+    if metadata.get("mode") not in {"inner_class_bias", "inner_class_affine"} or "bias" not in metadata:
         return scores, classes
     calibration_classes = np.asarray(metadata["classes"], dtype=int)
     bias = np.asarray(metadata["bias"], dtype=float)
+    scale = np.asarray(metadata.get("scale", np.ones_like(bias)), dtype=float)
     aligned = _align_class_score_columns(scores, classes, calibration_classes)
-    return aligned + bias[None, :], calibration_classes
+    return aligned * scale[None, :] + bias[None, :], calibration_classes
 
 
 def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictions=True):
     config = _normalized_config(config)
     metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
-    if metadata.get("mode") != "inner_class_bias" or "bias" not in metadata:
+    if metadata.get("mode") not in {"inner_class_bias", "inner_class_affine"} or "bias" not in metadata:
         outer_row, prediction_rows = _previous_score_outer_fold_model(fitted_model, test_set, config, include_predictions=include_predictions)
         _add_next_fields(outer_row, config, fitted_model)
         for row in prediction_rows:

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -110,6 +110,21 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual({config.score_calibration for config in configs}, {"none", "inner_class_bias"})
         self.assertEqual({config.alignment_alpha for config in configs}, {0.25, 1.0})
 
+    def test_candidate_grid_accepts_inner_class_affine_score_calibration(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            score_calibrations=("inner_class_affine",),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 1)
+        self.assertEqual(configs[0].score_calibration, "inner_class_affine")
+
     def test_inner_class_bias_score_calibration_fits_source_fold_metadata(self):
         time = np.asarray([-0.1, 0.0, 0.1, 0.2], dtype=float)
         labels = [1, 2, 1, 2]
@@ -139,7 +154,62 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(metadata["mode"], "inner_class_bias")
         np.testing.assert_array_equal(metadata["classes"], np.asarray([0, 1]))
         self.assertEqual(metadata["bias"].shape, (2,))
+        self.assertEqual(metadata["scale"].shape, (2,))
+        np.testing.assert_allclose(metadata["scale"], np.ones(2))
         self.assertTrue(np.isfinite(metadata["inner_balanced_accuracy"]))
+
+    def test_inner_class_affine_score_calibration_fits_source_fold_metadata(self):
+        time = np.asarray([-0.1, 0.0, 0.1, 0.2], dtype=float)
+        labels = [1, 2, 1, 2]
+        data_by_participant = {
+            1: mat_data_from_trials(labels, [[[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]], [[-0.9, -0.9, -0.9, -0.9]], [[0.9, 0.9, 0.9, 0.9]]], time),
+            2: mat_data_from_trials(labels, [[[-1.1, -1.1, -1.1, -1.1]], [[1.1, 1.1, 1.1, 1.1]], [[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]]], time),
+            3: mat_data_from_trials(labels, [[[-1.2, -1.2, -1.2, -1.2]], [[1.2, 1.2, 1.2, 1.2]], [[-1.1, -1.1, -1.1, -1.1]], [[1.1, 1.1, 1.1, 1.1]]], time),
+        }
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean",
+            normalization="none",
+            classifier="multinomial-logistic",
+            classifier_param=1.0,
+            components_pca=float("inf"),
+            score_calibration="inner_class_affine",
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            train_sets = [load_participant_stimulus_features("unused", participant, config=config) for participant in (1, 2, 3)]
+
+        fitted_model = cross_subject._fit_outer_fold_model(train_sets, config, 1.0)  # pylint: disable=protected-access
+        metadata = fitted_model["score_calibration_metadata"]
+
+        self.assertEqual(metadata["mode"], "inner_class_affine")
+        np.testing.assert_array_equal(metadata["classes"], np.asarray([0, 1]))
+        self.assertEqual(metadata["bias"].shape, (2,))
+        self.assertEqual(metadata["scale"].shape, (2,))
+        self.assertTrue(np.all(metadata["scale"] > 0.0))
+        self.assertTrue(np.isfinite(metadata["inner_balanced_accuracy"]))
+
+    def test_inner_class_affine_score_calibration_applies_scale_and_bias(self):
+        scores = np.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=float)
+        fitted_model = {
+            "score_calibration_metadata": {
+                "mode": "inner_class_affine",
+                "classes": np.asarray([0, 1]),
+                "bias": np.asarray([0.5, -0.5]),
+                "scale": np.asarray([2.0, 0.25]),
+            }
+        }
+
+        calibrated, classes = cross_subject._apply_score_calibration(  # pylint: disable=protected-access
+            scores,
+            np.asarray([0, 1]),
+            fitted_model,
+        )
+
+        np.testing.assert_array_equal(classes, np.asarray([0, 1]))
+        np.testing.assert_allclose(calibrated, np.asarray([[2.5, 0.0], [6.5, 0.5]]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `inner_class_affine` as a source-fold score calibration mode
- fit class-specific score scale and bias on source inner-validation folds only
- run the next source-only workflow with `none,inner_class_affine` so the default grid size stays comparable while testing the stronger calibrator

## Why
The current `inner_class_bias` calibrator can correct class-wise offset bias, but it cannot fix classes whose decision scores are systematically too compressed or too spread out. The affine mode keeps the held-out target participant untouched and gives nested source selection another low-risk way to improve top-1 ranking.

## Validation
- `PYTHONPATH=... python -m pytest tests\test_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject.py` (45 passed)
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject_next.py`
- `git diff --check` (line-ending warnings only)