### PR TITLE
Add pyramid logpower source feature

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -52,7 +52,7 @@ jobs:
             --window-centers "${{ github.event.inputs.window_centers }}" \
             --window-size 0.100 \
             --baseline-window=-0.35,-0.05 \
-            --feature-modes sensor_flat,sensor_temporal_pyramid,sensor_mean_logpower \
+            --feature-modes sensor_flat,sensor_temporal_pyramid,sensor_time_pyramid_logpower \
             --normalizations subject_baseline_whiten \
             --alignments none \
             --alignment-alphas 1.0 \

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -23,8 +23,15 @@ SCORE_CALIBRATION_MODES = ("none", "inner_class_bias", "inner_class_affine")
 DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = 1.0
 DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
 DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
-BASELINE_WHITENED_EXTENDED_FEATURE_MODES = ("sensor_time_pyramid",)
-EXTENDED_FEATURE_MODES = ("sensor_logpower", "sensor_mean_logpower", "sensor_bandpower", "sensor_cov_tangent", "sensor_time_pyramid")
+BASELINE_WHITENED_EXTENDED_FEATURE_MODES = ("sensor_time_pyramid", "sensor_time_pyramid_logpower")
+EXTENDED_FEATURE_MODES = (
+    "sensor_logpower",
+    "sensor_mean_logpower",
+    "sensor_bandpower",
+    "sensor_cov_tangent",
+    "sensor_time_pyramid",
+    "sensor_time_pyramid_logpower",
+)
 SCORE_CALIBRATION_L2 = 1e-3
 
 _impl = None
@@ -257,6 +264,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_cov_tangent_feature(signal)
         elif feature_mode == "sensor_time_pyramid":
             feature = _sensor_time_pyramid_feature(signal)
+        elif feature_mode == "sensor_time_pyramid_logpower":
+            feature = np.concatenate((_sensor_time_pyramid_feature(signal), _sensor_logpower_feature(signal)))
         else:
             raise ValueError(f"Unsupported feature_mode: {feature_mode}")
         features.append(feature)

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -14,6 +14,7 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertIn("sensor_bandpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_cov_tangent", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_time_pyramid", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_time_pyramid_logpower", cross_subject.FEATURE_MODES)
 
     def test_sensor_mean_logpower_feature(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
@@ -89,6 +90,36 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
                 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
             ]),
         )
+
+    def test_sensor_time_pyramid_logpower_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 1.0, 3.0, 5.0, 7.0], [0.0, 2.0, 4.0, 6.0, 8.0]],
+            [[0.0, 2.0, 4.0, 6.0, 8.0], [0.0, 1.0, 3.0, 5.0, 7.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.3,
+            feature_mode="sensor_time_pyramid_logpower",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 16))
+        np.testing.assert_allclose(
+            feature_set.features[0, :14],
+            np.asarray([
+                4.0, 5.0,
+                2.0, 3.0, 6.0, 7.0,
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+            ]),
+        )
+        np.testing.assert_allclose(feature_set.features[0, 14:], np.log(np.asarray([21.0, 30.0]) + 1e-12))
 
     def test_candidate_grid_expands_next_knobs(self):
         configs = make_cross_subject_candidate_configs(


### PR DESCRIPTION
## Summary
- add `sensor_time_pyramid_logpower` as a source-only feature mode
- concatenate temporal-pyramid channel means with per-sensor log-power
- use the new feature in the source-only-next workflow in place of `sensor_mean_logpower`, keeping the default feature-mode count unchanged

## Why
The current source-only grid has useful temporal-shape features and useful log-power features, but not their compact combination. This gives nested source-fold selection a richer low-dimensional candidate without increasing the default workflow grid size.

## Validation
- `PYTHONPATH=... python -m pytest tests\test_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject.py` (46 passed)
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject_next.py`
- `git diff --check` (line-ending warnings only)