### PR TITLE
Add calibration-aware source diversity

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -62,7 +62,7 @@ jobs:
             --sample-weightings none,subject_class_balanced \
             --score-calibrations none,inner_class_affine \
             --selection-ensemble-size 6 \
-            --selection-ensemble-diversity window_feature_classifier \
+            --selection-ensemble-diversity window_feature_classifier_score_calibration \
             --selection-metric balanced_top2_top3_rank_lcb \
             --selection-ensemble-score-normalization rank_z_blend \
             --selection-ensemble-weighting inner_selection_lcb_softmax \

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -72,7 +72,15 @@ SELECTION_ENSEMBLE_WEIGHTING_MODES = (
     "inner_selection_lcb_softmax",
 )
 ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax", "rank_z_blend")
-SELECTION_ENSEMBLE_DIVERSITY_MODES = ("none", "window", "classifier", "window_classifier", "window_feature_classifier", "full_config")
+SELECTION_ENSEMBLE_DIVERSITY_MODES = (
+    "none",
+    "window",
+    "classifier",
+    "window_classifier",
+    "window_feature_classifier",
+    "window_feature_classifier_score_calibration",
+    "full_config",
+)
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
 NESTED_SCORE_ENSEMBLE_NORMALIZATION = DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
 FEATURE_MODES = (
@@ -1311,6 +1319,7 @@ def _select_nested_candidate_ensemble(
     selected["selected_ensemble_feature_mode_counts"] = _format_counter(Counter(config.feature_mode for config in selected_configs))
     selected["selected_ensemble_normalization_counts"] = _format_counter(Counter(config.normalization for config in selected_configs))
     selected["selected_ensemble_alignment_counts"] = _format_counter(Counter(config.alignment for config in selected_configs))
+    selected["selected_ensemble_score_calibration_counts"] = _format_counter(Counter(str(getattr(config, "score_calibration", "none")) for config in selected_configs))
     selected["selected_ensemble_components_pca_counts"] = _format_counter(Counter(str(config.components_pca) for config in selected_configs))
     selected["selected_ensemble_diversity_keys"] = _format_sequence(
         _ensemble_diversity_key(candidate_configs[int(row["selected_candidate_index"]) - 1], diversity)
@@ -1363,6 +1372,12 @@ def _ensemble_diversity_key(config, diversity):
         return (
             f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
             f"feature={config.feature_mode},classifier={config.classifier}"
+        )
+    if diversity == "window_feature_classifier_score_calibration":
+        return (
+            f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
+            f"feature={config.feature_mode},classifier={config.classifier},"
+            f"score_calibration={getattr(config, 'score_calibration', 'none')}"
         )
     return (
         f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -832,6 +832,89 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(feature_diverse["selection_ensemble_diversity"], "window_feature_classifier")
         self.assertEqual(feature_diverse["selected_ensemble_feature_mode_counts"], "sensor_flat:1;sensor_mean_logpower:1")
 
+    def test_nested_ensemble_can_diversify_by_score_calibration(self):
+        configs = (
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                score_calibration="none",
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                score_calibration="inner_class_affine",
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_mean_logpower",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                score_calibration="none",
+            ),
+        )
+
+        def inner_row(candidate_index, balanced_accuracy, feature_mode, score_calibration):
+            return {
+                "outer_test_participant": 4,
+                "candidate_index": candidate_index,
+                "balanced_accuracy": balanced_accuracy,
+                "accuracy": balanced_accuracy,
+                "train_participants": "1,2,3",
+                "n_train_participants": 3,
+                "window_center_s": 0.10,
+                "window_size_s": 0.1,
+                "window_start_s": 0.05,
+                "window_stop_s": 0.15,
+                "feature_mode": feature_mode,
+                "normalization": "none",
+                "alignment": "none",
+                "classifier": "multiclass-svm",
+                "classifier_param": 0.5,
+                "components_pca": float("inf"),
+                "max_trials_per_class_per_participant": "",
+                "score_calibration": score_calibration,
+            }
+
+        inner_rows = [
+            inner_row(1, 0.90, "sensor_flat", "none"),
+            inner_row(2, 0.85, "sensor_flat", "inner_class_affine"),
+            inner_row(3, 0.80, "sensor_mean_logpower", "none"),
+        ]
+
+        feature_diverse, _feature_diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window_feature_classifier",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+        calibration_diverse, _calibration_diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window_feature_classifier_score_calibration",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+
+        self.assertEqual(feature_diverse["selected_candidate_indices"], "1;3")
+        self.assertEqual(calibration_diverse["selected_candidate_indices"], "1;2")
+        self.assertEqual(calibration_diverse["selection_ensemble_diversity"], "window_feature_classifier_score_calibration")
+        self.assertEqual(calibration_diverse["selected_ensemble_score_calibration_counts"], "inner_class_affine:1;none:1")
+
     def test_nested_selection_metric_can_use_topk_signal(self):
         configs = (
             CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),


### PR DESCRIPTION
## Summary
- add `window_feature_classifier_score_calibration` as a selected-ensemble diversity mode
- let source-only ensembles keep calibrated and uncalibrated variants of the same window/feature/classifier when source folds rank both highly
- record selected ensemble score-calibration counts in the selected-row metadata
- switch the source-only-next workflow to the calibration-aware diversity key

## Why
The current source-only grid now compares `none` and `inner_class_affine` score calibration, but the selected ensemble diversity key still treated them as duplicates when window, feature, and classifier matched. This change lets nested source-fold selection combine both forms when useful while still excluding the held-out target participant from selection.

## Validation
- `PYTHONPATH=... python -m pytest tests\test_stimulus_cross_subject.py tests\test_stimulus_cross_subject_next.py` (47 passed)
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py`
- `git diff --check` (line-ending warnings only)