### PR TITLE
Add sample-weight-aware source diversity

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -62,7 +62,7 @@ jobs:
             --sample-weightings none,subject_class_balanced \
             --score-calibrations none,inner_class_affine \
             --selection-ensemble-size 6 \
-            --selection-ensemble-diversity window_feature_classifier_score_calibration \
+            --selection-ensemble-diversity window_feature_classifier_sample_weighting_score_calibration \
             --selection-metric balanced_top2_top3_rank_lcb \
             --selection-ensemble-score-normalization rank_z_blend \
             --selection-ensemble-weighting inner_selection_lcb_softmax \

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -79,6 +79,7 @@ SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "window_classifier",
     "window_feature_classifier",
     "window_feature_classifier_score_calibration",
+    "window_feature_classifier_sample_weighting_score_calibration",
     "full_config",
 )
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
@@ -1319,6 +1320,7 @@ def _select_nested_candidate_ensemble(
     selected["selected_ensemble_feature_mode_counts"] = _format_counter(Counter(config.feature_mode for config in selected_configs))
     selected["selected_ensemble_normalization_counts"] = _format_counter(Counter(config.normalization for config in selected_configs))
     selected["selected_ensemble_alignment_counts"] = _format_counter(Counter(config.alignment for config in selected_configs))
+    selected["selected_ensemble_sample_weighting_counts"] = _format_counter(Counter(str(getattr(config, "sample_weighting", "none")) for config in selected_configs))
     selected["selected_ensemble_score_calibration_counts"] = _format_counter(Counter(str(getattr(config, "score_calibration", "none")) for config in selected_configs))
     selected["selected_ensemble_components_pca_counts"] = _format_counter(Counter(str(config.components_pca) for config in selected_configs))
     selected["selected_ensemble_diversity_keys"] = _format_sequence(
@@ -1377,6 +1379,13 @@ def _ensemble_diversity_key(config, diversity):
         return (
             f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
             f"feature={config.feature_mode},classifier={config.classifier},"
+            f"score_calibration={getattr(config, 'score_calibration', 'none')}"
+        )
+    if diversity == "window_feature_classifier_sample_weighting_score_calibration":
+        return (
+            f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
+            f"feature={config.feature_mode},classifier={config.classifier},"
+            f"sample_weighting={getattr(config, 'sample_weighting', 'none')},"
             f"score_calibration={getattr(config, 'score_calibration', 'none')}"
         )
     return (

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -915,6 +915,96 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(calibration_diverse["selection_ensemble_diversity"], "window_feature_classifier_score_calibration")
         self.assertEqual(calibration_diverse["selected_ensemble_score_calibration_counts"], "inner_class_affine:1;none:1")
 
+    def test_nested_ensemble_can_diversify_by_sample_weighting_and_score_calibration(self):
+        configs = (
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                sample_weighting="none",
+                score_calibration="none",
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                sample_weighting="subject_class_balanced",
+                score_calibration="none",
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                sample_weighting="none",
+                score_calibration="inner_class_affine",
+            ),
+        )
+
+        def inner_row(candidate_index, balanced_accuracy, sample_weighting, score_calibration):
+            return {
+                "outer_test_participant": 4,
+                "candidate_index": candidate_index,
+                "balanced_accuracy": balanced_accuracy,
+                "accuracy": balanced_accuracy,
+                "train_participants": "1,2,3",
+                "n_train_participants": 3,
+                "window_center_s": 0.10,
+                "window_size_s": 0.1,
+                "window_start_s": 0.05,
+                "window_stop_s": 0.15,
+                "feature_mode": "sensor_flat",
+                "normalization": "none",
+                "alignment": "none",
+                "classifier": "multiclass-svm",
+                "classifier_param": 0.5,
+                "components_pca": float("inf"),
+                "max_trials_per_class_per_participant": "",
+                "sample_weighting": sample_weighting,
+                "score_calibration": score_calibration,
+            }
+
+        inner_rows = [
+            inner_row(1, 0.90, "none", "none"),
+            inner_row(2, 0.85, "subject_class_balanced", "none"),
+            inner_row(3, 0.80, "none", "inner_class_affine"),
+        ]
+
+        calibration_diverse, _calibration_diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window_feature_classifier_score_calibration",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+        sample_weight_diverse, _sample_weight_diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window_feature_classifier_sample_weighting_score_calibration",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+
+        self.assertEqual(calibration_diverse["selected_candidate_indices"], "1;3")
+        self.assertEqual(sample_weight_diverse["selected_candidate_indices"], "1;2")
+        self.assertEqual(
+            sample_weight_diverse["selection_ensemble_diversity"],
+            "window_feature_classifier_sample_weighting_score_calibration",
+        )
+        self.assertEqual(sample_weight_diverse["selected_ensemble_sample_weighting_counts"], "none:1;subject_class_balanced:1")
+
     def test_nested_selection_metric_can_use_topk_signal(self):
         configs = (
             CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),


### PR DESCRIPTION
## Summary
- add `window_feature_classifier_sample_weighting_score_calibration` as a selected-ensemble diversity mode
- let source-only ensembles keep unweighted and subject/class-balanced variants of the same window/feature/classifier/calibration when source folds rank both highly
- record selected ensemble sample-weighting counts in selected metadata
- switch the source-only-next workflow to the sample-weighting-aware diversity key

## Why
The current source-only grid compares sample-weighting modes, but the selected ensemble diversity key treated them as duplicates when the window, feature, classifier, and score calibration matched. This lets nested source-fold selection combine complementary sample-weighting variants without using held-out target labels.

## Validation
- `PYTHONPATH=... python -m pytest tests\test_stimulus_cross_subject.py tests\test_stimulus_cross_subject_next.py` (48 passed)
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py`
- `git diff --check` (line-ending warnings only)