### PR TITLE
Add PCA-aware source diversity

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -62,7 +62,7 @@ jobs:
             --sample-weightings none,subject_class_balanced \
             --score-calibrations none,inner_class_affine \
             --selection-ensemble-size 6 \
-            --selection-ensemble-diversity window_feature_classifier_sample_weighting_score_calibration \
+            --selection-ensemble-diversity window_feature_classifier_sample_weighting_score_calibration_pca \
             --selection-metric balanced_top2_top3_rank_lcb \
             --selection-ensemble-score-normalization rank_z_blend \
             --selection-ensemble-weighting inner_selection_lcb_softmax \

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -80,6 +80,7 @@ SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "window_feature_classifier",
     "window_feature_classifier_score_calibration",
     "window_feature_classifier_sample_weighting_score_calibration",
+    "window_feature_classifier_sample_weighting_score_calibration_pca",
     "full_config",
 )
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
@@ -1387,6 +1388,14 @@ def _ensemble_diversity_key(config, diversity):
             f"feature={config.feature_mode},classifier={config.classifier},"
             f"sample_weighting={getattr(config, 'sample_weighting', 'none')},"
             f"score_calibration={getattr(config, 'score_calibration', 'none')}"
+        )
+    if diversity == "window_feature_classifier_sample_weighting_score_calibration_pca":
+        return (
+            f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
+            f"feature={config.feature_mode},classifier={config.classifier},"
+            f"sample_weighting={getattr(config, 'sample_weighting', 'none')},"
+            f"score_calibration={getattr(config, 'score_calibration', 'none')},"
+            f"pca={config.components_pca}"
         )
     return (
         f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1005,6 +1005,99 @@ class TestStimulusCrossSubject(unittest.TestCase):
         )
         self.assertEqual(sample_weight_diverse["selected_ensemble_sample_weighting_counts"], "none:1;subject_class_balanced:1")
 
+    def test_nested_ensemble_can_diversify_by_pca_components(self):
+        configs = (
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                sample_weighting="none",
+                score_calibration="none",
+                components_pca=64,
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                sample_weighting="none",
+                score_calibration="none",
+                components_pca=128,
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.5,
+                sample_weighting="subject_class_balanced",
+                score_calibration="none",
+                components_pca=64,
+            ),
+        )
+
+        def inner_row(candidate_index, balanced_accuracy, components_pca, sample_weighting):
+            return {
+                "outer_test_participant": 4,
+                "candidate_index": candidate_index,
+                "balanced_accuracy": balanced_accuracy,
+                "accuracy": balanced_accuracy,
+                "train_participants": "1,2,3",
+                "n_train_participants": 3,
+                "window_center_s": 0.10,
+                "window_size_s": 0.1,
+                "window_start_s": 0.05,
+                "window_stop_s": 0.15,
+                "feature_mode": "sensor_flat",
+                "normalization": "none",
+                "alignment": "none",
+                "classifier": "multiclass-svm",
+                "classifier_param": 0.5,
+                "components_pca": components_pca,
+                "max_trials_per_class_per_participant": "",
+                "sample_weighting": sample_weighting,
+                "score_calibration": "none",
+            }
+
+        inner_rows = [
+            inner_row(1, 0.90, 64, "none"),
+            inner_row(2, 0.85, 128, "none"),
+            inner_row(3, 0.80, 64, "subject_class_balanced"),
+        ]
+
+        sample_weight_diverse, _sample_weight_diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window_feature_classifier_sample_weighting_score_calibration",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+        pca_diverse, _pca_diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window_feature_classifier_sample_weighting_score_calibration_pca",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+
+        self.assertEqual(sample_weight_diverse["selected_candidate_indices"], "1;3")
+        self.assertEqual(pca_diverse["selected_candidate_indices"], "1;2")
+        self.assertEqual(
+            pca_diverse["selection_ensemble_diversity"],
+            "window_feature_classifier_sample_weighting_score_calibration_pca",
+        )
+        self.assertEqual(pca_diverse["selected_ensemble_components_pca_counts"], "128:1;64:1")
+
     def test_nested_selection_metric_can_use_topk_signal(self):
         configs = (
             CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),


### PR DESCRIPTION
## Summary
- add a selected-ensemble diversity mode that distinguishes PCA component counts in addition to window, feature, classifier, sample weighting, and score calibration
- switch the source-only-next workflow to use the PCA-aware diversity mode
- cover the selection behavior with a focused nested-ensemble unit test

## Validation
- `PYTHONPATH=$PWD/src;../NeuRepTrace/src python -m pytest tests/test_stimulus_cross_subject.py tests/test_stimulus_cross_subject_next.py` -> 49 passed
- `python -m ruff check src/pymegdec/_stimulus_cross_subject_legacy.py tests/test_stimulus_cross_subject.py` -> passed
- `git diff --check` -> only existing LF/CRLF warnings