### PR TITLE
Add classifier-param source diversity

### DIFF
--- a/.github/workflows/stimulus-source-only-next.yml
+++ b/.github/workflows/stimulus-source-only-next.yml
@@ -62,7 +62,7 @@ jobs:
             --sample-weightings none,subject_class_balanced \
             --score-calibrations none,inner_class_affine \
             --selection-ensemble-size 6 \
-            --selection-ensemble-diversity window_feature_classifier_sample_weighting_score_calibration_pca \
+            --selection-ensemble-diversity window_feature_classifier_param_sample_weighting_score_calibration_pca \
             --selection-metric balanced_top2_top3_rank_lcb \
             --selection-ensemble-score-normalization rank_z_blend \
             --selection-ensemble-weighting inner_selection_lcb_softmax \

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -81,6 +81,7 @@ SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "window_feature_classifier_score_calibration",
     "window_feature_classifier_sample_weighting_score_calibration",
     "window_feature_classifier_sample_weighting_score_calibration_pca",
+    "window_feature_classifier_param_sample_weighting_score_calibration_pca",
     "full_config",
 )
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
@@ -1317,6 +1318,7 @@ def _select_nested_candidate_ensemble(
     selected["selected_ensemble_weights"] = _format_float_mapping((row["selected_candidate_index"], weight) for row, weight in zip(selected_rows, weights))
     selected_configs = tuple(candidate_configs[int(row["selected_candidate_index"]) - 1] for row in selected_rows)
     selected["selected_ensemble_classifier_counts"] = _format_counter(Counter(config.classifier for config in selected_configs))
+    selected["selected_ensemble_classifier_param_counts"] = _format_counter(Counter(str(_resolved_classifier_param(config)) for config in selected_configs))
     selected["selected_ensemble_window_center_counts"] = _format_counter(Counter(float(config.window_center) for config in selected_configs))
     selected["selected_ensemble_feature_mode_counts"] = _format_counter(Counter(config.feature_mode for config in selected_configs))
     selected["selected_ensemble_normalization_counts"] = _format_counter(Counter(config.normalization for config in selected_configs))
@@ -1393,6 +1395,15 @@ def _ensemble_diversity_key(config, diversity):
         return (
             f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
             f"feature={config.feature_mode},classifier={config.classifier},"
+            f"sample_weighting={getattr(config, 'sample_weighting', 'none')},"
+            f"score_calibration={getattr(config, 'score_calibration', 'none')},"
+            f"pca={config.components_pca}"
+        )
+    if diversity == "window_feature_classifier_param_sample_weighting_score_calibration_pca":
+        return (
+            f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
+            f"feature={config.feature_mode},classifier={config.classifier},"
+            f"param={_resolved_classifier_param(config)},"
             f"sample_weighting={getattr(config, 'sample_weighting', 'none')},"
             f"score_calibration={getattr(config, 'score_calibration', 'none')},"
             f"pca={config.components_pca}"

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1098,6 +1098,99 @@ class TestStimulusCrossSubject(unittest.TestCase):
         )
         self.assertEqual(pca_diverse["selected_ensemble_components_pca_counts"], "128:1;64:1")
 
+    def test_nested_ensemble_can_diversify_by_classifier_param(self):
+        configs = (
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.1,
+                sample_weighting="none",
+                score_calibration="none",
+                components_pca=64,
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=1.0,
+                sample_weighting="none",
+                score_calibration="none",
+                components_pca=64,
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.10,
+                window_size=0.1,
+                feature_mode="sensor_flat",
+                normalization="none",
+                classifier="multiclass-svm",
+                classifier_param=0.1,
+                sample_weighting="subject_class_balanced",
+                score_calibration="none",
+                components_pca=64,
+            ),
+        )
+
+        def inner_row(candidate_index, balanced_accuracy, classifier_param, sample_weighting):
+            return {
+                "outer_test_participant": 4,
+                "candidate_index": candidate_index,
+                "balanced_accuracy": balanced_accuracy,
+                "accuracy": balanced_accuracy,
+                "train_participants": "1,2,3",
+                "n_train_participants": 3,
+                "window_center_s": 0.10,
+                "window_size_s": 0.1,
+                "window_start_s": 0.05,
+                "window_stop_s": 0.15,
+                "feature_mode": "sensor_flat",
+                "normalization": "none",
+                "alignment": "none",
+                "classifier": "multiclass-svm",
+                "classifier_param": classifier_param,
+                "components_pca": 64,
+                "max_trials_per_class_per_participant": "",
+                "sample_weighting": sample_weighting,
+                "score_calibration": "none",
+            }
+
+        inner_rows = [
+            inner_row(1, 0.90, 0.1, "none"),
+            inner_row(2, 0.85, 1.0, "none"),
+            inner_row(3, 0.80, 0.1, "subject_class_balanced"),
+        ]
+
+        pca_diverse, _pca_diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window_feature_classifier_sample_weighting_score_calibration_pca",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+        param_diverse, _param_diverse_rows = cross_subject._select_nested_candidate_ensemble(  # pylint: disable=protected-access
+            inner_rows,
+            selection_ensemble_size=2,
+            selection_ensemble_diversity="window_feature_classifier_param_sample_weighting_score_calibration_pca",
+            selection_ensemble_score_normalization="row_z_softmax",
+            selection_ensemble_weighting="uniform",
+            selection_ensemble_temperature=0.02,
+            candidate_configs=configs,
+        )
+
+        self.assertEqual(pca_diverse["selected_candidate_indices"], "1;3")
+        self.assertEqual(param_diverse["selected_candidate_indices"], "1;2")
+        self.assertEqual(
+            param_diverse["selection_ensemble_diversity"],
+            "window_feature_classifier_param_sample_weighting_score_calibration_pca",
+        )
+        self.assertEqual(param_diverse["selected_ensemble_classifier_param_counts"], "0.1:1;1.0:1")
+
     def test_nested_selection_metric_can_use_topk_signal(self):
         configs = (
             CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),


### PR DESCRIPTION
## Summary
- add a selected-ensemble diversity mode that distinguishes classifier parameter values in addition to window, feature, classifier, sample weighting, score calibration, and PCA dimensionality
- record selected-ensemble classifier-parameter counts in the selected-output provenance
- switch the source-only-next workflow to the classifier-param-aware diversity mode
- cover the selection behavior with a focused nested-ensemble unit test

## Validation
- `PYTHONPATH=$PWD/src;../NeuRepTrace/src python -m pytest tests/test_stimulus_cross_subject.py tests/test_stimulus_cross_subject_next.py` -> 50 passed
- `python -m ruff check src/pymegdec/_stimulus_cross_subject_legacy.py tests/test_stimulus_cross_subject.py` -> passed
- `git diff --check` -> only existing LF/CRLF warnings