### PR TITLE
Add 175 ms finetune matrix bundle

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -28,6 +28,7 @@ on:
         options:
           - windowed_logreg_lean
           - windowed_logreg_lean_no_diversity
+          - windowed_logreg_175_finetune
           - windowed_logreg_core
           - feature_check
           - lda_svm_check
@@ -135,6 +136,20 @@ jobs:
                   "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
                   "classifier_params": "0.3,1",
                   "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_finetune": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.1,0.2,0.3,0.5,1,2,3",
+                  "components_pca_values": "96,128,160,192",
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",


### PR DESCRIPTION
## Summary
- add `windowed_logreg_175_finetune` to the nested matrix workflow
- keep the grid focused on the 0.175 s source-only window
- tune logistic/weighted-logistic regularization over `0.1,0.2,0.3,0.5,1,2,3` and PCA over `96,128,160,192`

## Validation
- inspected the workflow diff
- confirmed `--components-pca-values` accepts arbitrary integer values
- ran `git diff --check` before commit (only the existing LF-to-CRLF warning for the workflow file)