### PR TITLE
Add top-k-aware nested matrix workflow

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-topk-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-topk-matrix.yml
@@ -1,0 +1,466 @@
+name: Manual stimulus nested top-k matrix
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_type:
+        description: Runner backend used for shard jobs.
+        required: true
+        default: self-hosted
+        type: choice
+        options: [github-hosted, self-hosted]
+      self_hosted_runner_label:
+        description: Self-hosted runner label.
+        required: true
+        default: self-hosted
+        type: string
+      use_nextcloud_data:
+        description: Allow WebDAV download on cache miss; cached/self-hosted data are still exposed when false.
+        required: true
+        default: true
+        type: boolean
+      config_bundle:
+        description: Named top-k-aware candidate bundle to shard.
+        required: true
+        default: topk_lean_no_diversity
+        type: choice
+        options:
+          - topk_lean_no_diversity
+          - topk_175_finetune
+          - topk_175_affine_light
+          - topk_175_rank_blend_light
+          - all
+      benchmark_preset:
+        description: Screening keeps the trial cap; final-all-trials ignores it.
+        required: true
+        default: final-all-trials
+        type: choice
+        options: [screening, final-all-trials]
+      participants:
+        description: Participant ids used for training and held-out shards.
+        required: true
+        default: "1-4,6,8,9,10,13-27"
+        type: string
+      participants_per_job:
+        description: Number of held-out participants per matrix job.
+        required: true
+        default: "1"
+        type: choice
+        options: ["1", "2", "4"]
+      max_parallel:
+        description: Maximum matrix shard jobs to run concurrently.
+        required: true
+        default: "4"
+        type: choice
+        options: ["1", "2", "4", "8"]
+      per_job_timeout_minutes:
+        description: Timeout for each shard job.
+        required: true
+        default: "180"
+        type: choice
+        options: ["60", "90", "120", "180"]
+      max_trials_per_class_per_participant:
+        description: Screening trial cap per stimulus class and participant.
+        required: false
+        default: "10"
+        type: string
+      label_shuffle_control:
+        description: Shuffle training labels within each participant as a nested null control.
+        required: true
+        default: false
+        type: boolean
+      label_shuffle_seed:
+        description: Seed for the nested label-shuffle control.
+        required: true
+        default: "0"
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  prepare-matrix:
+    name: Prepare top-k nested matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      shard_count: ${{ steps.matrix.outputs.shard_count }}
+    steps:
+      - name: Build matrix
+        id: matrix
+        shell: python
+        env:
+          CONFIG_BUNDLE: ${{ inputs.config_bundle }}
+          PARTICIPANTS: ${{ inputs.participants }}
+          PARTICIPANTS_PER_JOB: ${{ inputs.participants_per_job }}
+        run: |
+          import json
+          import os
+
+          base = {
+              "feature_modes": "sensor_flat",
+              "normalizations": "subject_baseline_whiten",
+              "alignments": "none",
+              "selection_ensemble_score_normalization": "rank_softmax",
+              "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+              "selection_ensemble_temperature": "0.02",
+              "sample_weightings": "none",
+              "score_calibrations": "none",
+              "window_size": "0.1",
+          }
+
+          bundles = {
+              # Same search space as windowed_logreg_lean_no_diversity, but source-fold
+              # selection and weighting use the stronger top-k signal instead of only top-1.
+              "topk_lean_no_diversity": {
+                  **base,
+                  "window_centers": "0.175,0.200",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_metric": "balanced_top2_top3",
+              },
+              # Fine-tune the observed 175 ms/PCA/logistic winner with top-k-aware selection.
+              "topk_175_finetune": {
+                  **base,
+                  "window_centers": "0.175",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.1,0.2,0.3,0.5,1,2,3",
+                  "components_pca_values": "96,128,160,192",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_metric": "balanced_top2_top3",
+              },
+              # Add source-only sample weighting and affine score calibration. This targets
+              # the observed top-3/top-1 gap without touching held-out target labels.
+              "topk_175_affine_light": {
+                  **base,
+                  "window_centers": "0.175",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none,subject_class_balanced",
+                  "score_calibrations": "none,inner_class_affine",
+                  "selection_ensemble_size": "4",
+                  "selection_ensemble_diversity": "window_feature_classifier_param_sample_weighting_score_calibration_pca",
+                  "selection_metric": "balanced_top2_top3",
+              },
+              # Conservative rank/blend variant: use the existing rank-aware LCB selector
+              # and rank-z score normalization added for source-only-next.
+              "topk_175_rank_blend_light": {
+                  **base,
+                  "window_centers": "0.175",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+              },
+          }
+
+          def parse_participants(spec):
+              values = []
+              for token in spec.split(","):
+                  token = token.strip()
+                  if not token:
+                      continue
+                  if "-" in token:
+                      start, stop = token.split("-", 1)
+                      values.extend(range(int(start), int(stop) + 1))
+                  else:
+                      values.append(int(token))
+              return sorted(dict.fromkeys(values))
+
+          def chunks(values, size):
+              for index in range(0, len(values), size):
+                  yield values[index:index + size]
+
+          requested = os.environ["CONFIG_BUNDLE"]
+          selected_ids = tuple(bundles) if requested == "all" else (requested,)
+          participants = parse_participants(os.environ["PARTICIPANTS"])
+          participants_per_job = int(os.environ["PARTICIPANTS_PER_JOB"])
+          include = []
+          for bundle_id in selected_ids:
+              for participant_chunk in chunks(participants, participants_per_job):
+                  outer_participants = ",".join(str(participant) for participant in participant_chunk)
+                  outer_label = "p" + "-p".join(f"{participant:02d}" for participant in participant_chunk)
+                  include.append({
+                      "config_id": bundle_id,
+                      "outer_participants": outer_participants,
+                      "outer_label": outer_label,
+                      **bundles[bundle_id],
+                  })
+
+          matrix = json.dumps({"include": include}, separators=(",", ":"))
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"matrix={matrix}\n")
+              output.write(f"shard_count={len(include)}\n")
+
+  prepare-data:
+    name: Prepare main MEG data cache
+    runs-on: ${{ inputs.runner_type == 'github-hosted' && 'ubuntu-latest' || inputs.self_hosted_runner_label }}
+    timeout-minutes: 360
+    env:
+      DATA_DIR: .cache/meg-data-main
+      DATA_CACHE_VERSION: v2
+      MAIN_FILE_NAMES: >-
+        Part1Data.mat,Part2Data.mat,Part3Data.mat,Part4Data.mat,Part6Data.mat,
+        Part8Data.mat,Part9Data.mat,Part10Data.mat,Part13Data.mat,Part14Data.mat,
+        Part15Data.mat,Part16Data.mat,Part17Data.mat,Part18Data.mat,Part19Data.mat,
+        Part20Data.mat,Part21Data.mat,Part22Data.mat,Part23Data.mat,Part24Data.mat,
+        Part25Data.mat,Part26Data.mat,Part27Data.mat
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Prepare main MEG data
+        uses: ./.github/actions/prepare-meg-data
+        with:
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          cache-key: meg-data-main-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+          download-on-miss: ${{ inputs.use_nextcloud_data }}
+          file-names: ${{ env.MAIN_FILE_NAMES }}
+          require-cue-files: "false"
+          expected-main-files: "23"
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
+
+  nested-matrix:
+    name: Top-k ${{ matrix.config_id }} ${{ matrix.outer_label }}
+    needs: [prepare-matrix, prepare-data]
+    runs-on: ${{ inputs.runner_type == 'github-hosted' && 'ubuntu-latest' || inputs.self_hosted_runner_label }}
+    timeout-minutes: ${{ fromJSON(inputs.per_job_timeout_minutes) }}
+    strategy:
+      fail-fast: false
+      max-parallel: ${{ fromJSON(inputs.max_parallel) }}
+      matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
+    env:
+      DATA_DIR: .cache/meg-data-main
+      DATA_CACHE_VERSION: v2
+      BENCHMARK_PRESET: ${{ inputs.benchmark_preset }}
+      OUTPUT_STEM: topk_${{ matrix.config_id }}_${{ matrix.outer_label }}
+      PARTICIPANTS: ${{ inputs.participants }}
+      OUTER_PARTICIPANTS: ${{ matrix.outer_participants }}
+      WINDOW_CENTERS: ${{ matrix.window_centers }}
+      WINDOW_SIZE: ${{ matrix.window_size }}
+      BASELINE_WINDOW: "-0.35,-0.05"
+      FEATURE_MODES: ${{ matrix.feature_modes }}
+      NORMALIZATIONS: ${{ matrix.normalizations }}
+      ALIGNMENTS: ${{ matrix.alignments }}
+      CLASSIFIERS: ${{ matrix.classifiers }}
+      CLASSIFIER_PARAMS: ${{ matrix.classifier_params }}
+      COMPONENTS_PCA_VALUES: ${{ matrix.components_pca_values }}
+      SAMPLE_WEIGHTINGS: ${{ matrix.sample_weightings }}
+      SCORE_CALIBRATIONS: ${{ matrix.score_calibrations }}
+      SELECTION_ENSEMBLE_SIZE: ${{ matrix.selection_ensemble_size }}
+      SELECTION_ENSEMBLE_DIVERSITY: ${{ matrix.selection_ensemble_diversity }}
+      SELECTION_ENSEMBLE_SCORE_NORMALIZATION: ${{ matrix.selection_ensemble_score_normalization }}
+      SELECTION_ENSEMBLE_WEIGHTING: ${{ matrix.selection_ensemble_weighting }}
+      SELECTION_ENSEMBLE_TEMPERATURE: ${{ matrix.selection_ensemble_temperature }}
+      SELECTION_METRIC: ${{ matrix.selection_metric }}
+      MAX_TRIALS_PER_CLASS_PER_PARTICIPANT: ${{ inputs.max_trials_per_class_per_participant }}
+      LABEL_SHUFFLE_CONTROL: ${{ inputs.label_shuffle_control }}
+      LABEL_SHUFFLE_SEED: ${{ inputs.label_shuffle_seed }}
+      MAIN_FILE_NAMES: >-
+        Part1Data.mat,Part2Data.mat,Part3Data.mat,Part4Data.mat,Part6Data.mat,
+        Part8Data.mat,Part9Data.mat,Part10Data.mat,Part13Data.mat,Part14Data.mat,
+        Part15Data.mat,Part16Data.mat,Part17Data.mat,Part18Data.mat,Part19Data.mat,
+        Part20Data.mat,Part21Data.mat,Part22Data.mat,Part23Data.mat,Part24Data.mat,
+        Part25Data.mat,Part26Data.mat,Part27Data.mat
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Prepare main MEG data
+        timeout-minutes: 120
+        uses: ./.github/actions/prepare-meg-data
+        with:
+          data-dir: ${{ env.DATA_DIR }}
+          cache-version: ${{ env.DATA_CACHE_VERSION }}
+          cache-key: meg-data-main-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
+          download-on-miss: ${{ inputs.runner_type == 'github-hosted' && 'false' || inputs.use_nextcloud_data }}
+          file-names: ${{ env.MAIN_FILE_NAMES }}
+          require-cue-files: "false"
+          expected-main-files: "23"
+          webdav-url: ${{ secrets.BUSHMEG_WEBDAV_URL }}
+          webdav-user: ${{ secrets.BUSHMEG_DATA_KEY }}
+          webdav-password: ${{ secrets.BUSHMEG_DATA_PASSWORD }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Validate main data files
+        shell: bash
+        run: |
+          set -euo pipefail
+          main_count="$(find -L "${DATA_DIR}" -name 'Part*Data.mat' ! -name 'Part*CueData.mat' | wc -l | tr -d ' ')"
+          echo "Main files: ${main_count}"
+          test "${main_count}" -ge 23
+
+      - name: Run top-k nested shard
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs
+          output_prefix="outputs/${OUTPUT_STEM}"
+          effective_trial_cap="${MAX_TRIALS_PER_CLASS_PER_PARTICIPANT}"
+          if [[ "${BENCHMARK_PRESET}" == "final-all-trials" ]]; then
+            effective_trial_cap=""
+          fi
+          echo "Config bundle: ${{ matrix.config_id }}"
+          echo "Outer participant shard: ${OUTER_PARTICIPANTS}"
+          echo "Selection metric: ${SELECTION_METRIC}"
+          echo "Output prefix: ${output_prefix}"
+          args=(
+            python scripts/export_stimulus_cross_subject_nested.py
+            --data-dir "${DATA_DIR}"
+            --participants "${PARTICIPANTS}"
+            --outer-participants "${OUTER_PARTICIPANTS}"
+            --window-centers "${WINDOW_CENTERS}"
+            --window-size "${WINDOW_SIZE}"
+            --baseline-window "${BASELINE_WINDOW}"
+            --feature-modes "${FEATURE_MODES}"
+            --normalizations "${NORMALIZATIONS}"
+            --alignments "${ALIGNMENTS}"
+            --classifiers "${CLASSIFIERS}"
+            --classifier-params "${CLASSIFIER_PARAMS}"
+            --components-pca-values "${COMPONENTS_PCA_VALUES}"
+            --sample-weightings "${SAMPLE_WEIGHTINGS}"
+            --score-calibrations "${SCORE_CALIBRATIONS}"
+            --selection-ensemble-size "${SELECTION_ENSEMBLE_SIZE}"
+            --selection-ensemble-diversity "${SELECTION_ENSEMBLE_DIVERSITY}"
+            --selection-ensemble-score-normalization "${SELECTION_ENSEMBLE_SCORE_NORMALIZATION}"
+            --selection-ensemble-weighting "${SELECTION_ENSEMBLE_WEIGHTING}"
+            --selection-ensemble-temperature "${SELECTION_ENSEMBLE_TEMPERATURE}"
+            --selection-metric "${SELECTION_METRIC}"
+            --outer-output "${output_prefix}_outer.csv"
+            --summary-output "${output_prefix}_group_summary.csv"
+            --inner-validation-output "${output_prefix}_inner_validation.csv"
+            --selected-output "${output_prefix}_selected.csv"
+            --predictions-output "${output_prefix}_predictions.csv"
+            --confusion-output "${output_prefix}_confusion.csv"
+            --per-stimulus-output "${output_prefix}_per_stimulus.csv"
+            --confusion-pairs-output "${output_prefix}_confusion_pairs.csv"
+            --write-incremental
+          )
+          if [[ -n "${effective_trial_cap}" ]]; then
+            args+=(--max-trials-per-class-per-participant "${effective_trial_cap}")
+          fi
+          if [[ "${LABEL_SHUFFLE_CONTROL}" == "true" ]]; then
+            args+=(--label-shuffle-control --label-shuffle-seed "${LABEL_SHUFFLE_SEED}")
+          fi
+          "${args[@]}"
+
+      - name: Upload top-k nested shard outputs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: nested-topk-matrix-${{ matrix.config_id }}-${{ matrix.outer_label }}
+          path: outputs/*.csv
+          if-no-files-found: warn
+
+  aggregate-matrix:
+    name: Aggregate top-k nested matrix
+    needs: [prepare-matrix, nested-matrix]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Download shard artifacts
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          pattern: nested-topk-matrix-*
+          path: shard-artifacts
+          merge-multiple: false
+
+      - name: Aggregate completed shards
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pymegdec.stimulus_nested_matrix \
+            --input-dir shard-artifacts \
+            --output-dir outputs \
+            --output-stem nested_topk_matrix \
+            --strict-shards \
+            --expected-shard-count "${{ needs.prepare-matrix.outputs.shard_count }}"
+
+      - name: Append aggregate summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import csv
+          import os
+          from pathlib import Path
+
+          path = Path("outputs/nested_topk_matrix_group_summary.csv")
+          if not path.exists():
+              Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("# Top-k nested matrix\n\nNo aggregate summary was produced.\n", encoding="utf-8")
+              raise SystemExit(0)
+
+          rows = list(csv.DictReader(path.open(newline="", encoding="utf-8")))
+          lines = [
+              "# Top-k nested matrix",
+              "",
+              f"Aggregated {len(rows)} completed config bundle(s).",
+              "",
+              "| config bundle | selection metric | outer folds | candidates | balanced accuracy | top-2 | top-3 | selected classifiers | selected windows |",
+              "| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+          ]
+          for row in rows:
+              lines.append(
+                  "| {bundle} | {metric} | {folds} | {candidates} | {balanced:.2f}% | {top2:.2f}% | {top3:.2f}% | {classifiers} | {windows} |".format(
+                      bundle=row.get("matrix_config_bundle", ""),
+                      metric=row.get("selection_metric", ""),
+                      folds=row.get("n_outer_folds", ""),
+                      candidates=row.get("n_candidates", ""),
+                      balanced=float(row.get("balanced_percent_mean", "nan")),
+                      top2=float(row.get("top2_percent_mean", "nan")),
+                      top3=float(row.get("top3_percent_mean", "nan")),
+                      classifiers=row.get("selected_classifier_counts", ""),
+                      windows=row.get("selected_window_center_counts", ""),
+                  )
+              )
+          Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload aggregate outputs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: nested-topk-matrix-aggregate
+          path: outputs/*.csv
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- add a manual `stimulus-cross-subject-nested-topk-matrix` workflow that exposes the existing top-k/rank-aware nested selection controls to BUSH nested matrix runs
- add focused bundles using `balanced_top2_top3` / `balanced_top2_top3_rank_lcb`, metric-aligned ensemble weighting, and optional source-only affine score calibration/sample weighting
- keep shard/data-cache behavior aligned with the existing nested matrix workflow so the held-out target subject remains label-unseen

## Why
The clean BUSH source-only run has strong top-2/top-3 signal relative to top-1. The codebase already implements top-k-aware selection metrics and metric-aligned weights, but the current nested-matrix workflow still ranks/weights the matrix runs by inner balanced accuracy only. This workflow lets us test whether using the stronger rank signal improves top-1 LOSO results without cue alignment or target-label leakage.

## Validation
- generated the workflow locally
- parsed the YAML structure with PyYAML (`yaml.safe_load`)
- no benchmark run dispatched from this patch