### PR TITLE
Add reciprocal rank-aware selection workflow

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -28,6 +28,8 @@ on:
         options:
           - windowed_logreg_lean
           - windowed_logreg_lean_no_diversity
+          - windowed_logreg_lean_rankaware
+          - windowed_logreg_lean_rankaware_reciprocal
           - windowed_logreg_175_finetune
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
@@ -47,6 +49,34 @@ on:
           - window
           - classifier
           - window_classifier
+      selection_ensemble_score_normalization_override:
+        description: Override the bundle's selected-ensemble score normalization.
+        required: true
+        default: bundle-default
+        type: choice
+        options:
+          - bundle-default
+          - row_z_softmax
+          - rank_softmax
+          - rank_reciprocal
+          - rank_z_blend
+      selection_metric_override:
+        description: Override the bundle's nested inner-LOSO selection metric.
+        required: true
+        default: bundle-default
+        type: choice
+        options:
+          - bundle-default
+          - balanced_accuracy
+          - accuracy
+          - top2_accuracy
+          - top3_accuracy
+          - mean_true_label_rank
+          - balanced_top2
+          - balanced_top2_top3
+          - balanced_top2_top3_rank
+          - balanced_top2_top3_rank_lcb
+          - balanced_rank
       benchmark_preset:
         description: Screening keeps the trial cap; final-all-trials ignores it and can exceed 2h per shard.
         required: true
@@ -110,6 +140,8 @@ jobs:
         env:
           CONFIG_BUNDLE: ${{ inputs.config_bundle }}
           SELECTION_ENSEMBLE_DIVERSITY_OVERRIDE: ${{ inputs.selection_ensemble_diversity_override }}
+          SELECTION_ENSEMBLE_SCORE_NORMALIZATION_OVERRIDE: ${{ inputs.selection_ensemble_score_normalization_override }}
+          SELECTION_METRIC_OVERRIDE: ${{ inputs.selection_metric_override }}
           PARTICIPANTS: ${{ inputs.participants }}
           PARTICIPANTS_PER_JOB: ${{ inputs.participants_per_job }}
         run: |
@@ -142,6 +174,36 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_rankaware": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+              },
+              "windowed_logreg_lean_rankaware_reciprocal": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_reciprocal",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -267,6 +329,8 @@ jobs:
 
           requested = os.environ["CONFIG_BUNDLE"]
           diversity_override = os.environ["SELECTION_ENSEMBLE_DIVERSITY_OVERRIDE"]
+          score_normalization_override = os.environ["SELECTION_ENSEMBLE_SCORE_NORMALIZATION_OVERRIDE"]
+          selection_metric_override = os.environ["SELECTION_METRIC_OVERRIDE"]
           selected_ids = tuple(bundles) if requested == "all" else (requested,)
           participants = parse_participants(os.environ["PARTICIPANTS"])
           participants_per_job = int(os.environ["PARTICIPANTS_PER_JOB"])
@@ -282,8 +346,13 @@ jobs:
                       **bundles[bundle_id],
                   }
                   row.setdefault("window_size", "0.1")
+                  row.setdefault("selection_metric", "balanced_accuracy")
                   if diversity_override != "bundle-default":
                       row["selection_ensemble_diversity"] = diversity_override
+                  if score_normalization_override != "bundle-default":
+                      row["selection_ensemble_score_normalization"] = score_normalization_override
+                  if selection_metric_override != "bundle-default":
+                      row["selection_metric"] = selection_metric_override
                   include.append(row)
 
           matrix = json.dumps({"include": include}, separators=(",", ":"))
@@ -352,6 +421,7 @@ jobs:
       SELECTION_ENSEMBLE_SCORE_NORMALIZATION: ${{ matrix.selection_ensemble_score_normalization }}
       SELECTION_ENSEMBLE_WEIGHTING: ${{ matrix.selection_ensemble_weighting }}
       SELECTION_ENSEMBLE_TEMPERATURE: ${{ matrix.selection_ensemble_temperature }}
+      SELECTION_METRIC: ${{ matrix.selection_metric }}
       MAX_TRIALS_PER_CLASS_PER_PARTICIPANT: ${{ inputs.max_trials_per_class_per_participant }}
       LABEL_SHUFFLE_CONTROL: ${{ inputs.label_shuffle_control }}
       LABEL_SHUFFLE_SEED: ${{ inputs.label_shuffle_seed }}
@@ -433,6 +503,7 @@ jobs:
             --selection-ensemble-score-normalization "${SELECTION_ENSEMBLE_SCORE_NORMALIZATION}"
             --selection-ensemble-weighting "${SELECTION_ENSEMBLE_WEIGHTING}"
             --selection-ensemble-temperature "${SELECTION_ENSEMBLE_TEMPERATURE}"
+            --selection-metric "${SELECTION_METRIC}"
             --outer-output "${output_prefix}_outer.csv"
             --summary-output "${output_prefix}_group_summary.csv"
             --inner-validation-output "${output_prefix}_inner_validation.csv"
@@ -520,15 +591,16 @@ jobs:
               "",
               f"Aggregated {len(rows)} completed config bundle(s).",
               "",
-              "| config bundle | outer folds | candidates | balanced accuracy | top-2 | top-3 | selected classifiers | selected windows |",
-              "| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+              "| config bundle | outer folds | candidates | selection metric | balanced accuracy | top-2 | top-3 | selected classifiers | selected windows |",
+              "| --- | ---: | ---: | --- | ---: | ---: | ---: | --- | --- |",
           ]
           for row in rows:
               lines.append(
-                  "| {bundle} | {folds} | {candidates} | {balanced:.2f}% | {top2:.2f}% | {top3:.2f}% | {classifiers} | {windows} |".format(
+                  "| {bundle} | {folds} | {candidates} | {metric} | {balanced:.2f}% | {top2:.2f}% | {top3:.2f}% | {classifiers} | {windows} |".format(
                       bundle=row.get("matrix_config_bundle", ""),
                       folds=row.get("n_outer_folds", ""),
                       candidates=row.get("n_candidates", ""),
+                      metric=row.get("selection_metric", ""),
                       balanced=float(row.get("balanced_percent_mean", "nan")),
                       top2=float(row.get("top2_percent_mean", "nan")),
                       top3=float(row.get("top3_percent_mean", "nan")),

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -71,7 +71,7 @@ SELECTION_ENSEMBLE_WEIGHTING_MODES = (
     "inner_selection_softmax",
     "inner_selection_lcb_softmax",
 )
-ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax", "rank_z_blend")
+ENSEMBLE_SCORE_NORMALIZATION_MODES = ("row_z_softmax", "rank_softmax", "rank_reciprocal", "rank_z_blend")
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
     "window",
@@ -1865,6 +1865,8 @@ def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJ
         return _row_softmax_probabilities(scores)
     if score_normalization == "rank_softmax":
         return _rank_softmax_probabilities(scores)
+    if score_normalization == "rank_reciprocal":
+        return _rank_reciprocal_probabilities(scores)
     if score_normalization == "rank_z_blend":
         return _rank_z_blend_probabilities(scores)
     raise ValueError(f"Unsupported ensemble score normalization: {score_normalization}")
@@ -1888,6 +1890,35 @@ def _rank_softmax_probabilities(scores):
         logits[~finite] = -50.0
         exp_logits = np.exp(logits - np.max(logits))
         probabilities[row_index] = exp_logits / np.sum(exp_logits)
+    return probabilities
+
+
+def _rank_reciprocal_probabilities(scores):
+    """Convert class scores to a soft rank distribution using reciprocal ranks.
+
+    ``rank_softmax`` is intentionally top-heavy: with 16 classes, the highest
+    ranked class receives roughly 63% of a candidate's mass before averaging.
+    The BUSH-MEG source-only runs show strong top-2/top-3 signal, so a softer
+    reciprocal-rank distribution can let several models agree on a near-top
+    class instead of letting each model's argmax dominate the ensemble.
+    """
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError("Nested score ensembling requires a non-empty two-dimensional class-score matrix.")
+    probabilities = np.empty_like(scores, dtype=float)
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        if not np.any(finite):
+            probabilities[row_index] = np.full(row.shape[0], 1.0 / row.shape[0], dtype=float)
+            continue
+        rank_scores = np.where(finite, row, -np.inf)
+        descending_columns = np.argsort(-rank_scores, kind="mergesort")
+        ranks = np.empty(row.shape[0], dtype=float)
+        ranks[descending_columns] = np.arange(row.shape[0], dtype=float)
+        weights = np.zeros(row.shape[0], dtype=float)
+        weights[finite] = 1.0 / (ranks[finite] + 1.0)
+        probabilities[row_index] = weights / np.sum(weights)
     return probabilities
 
 

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -239,6 +239,25 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(feature_set.baseline_whitening_matrix.shape, (2, 2))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
+    def test_rank_reciprocal_score_normalization_softens_rank_probabilities(self):
+        self.assertIn("rank_reciprocal", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        scores = np.asarray(
+            [
+                [3.0, 2.0, 1.0, 0.0],
+                [np.nan, 10.0, 9.0, 8.0],
+            ],
+            dtype=float,
+        )
+
+        probabilities = cross_subject._class_score_probabilities(scores, score_normalization="rank_reciprocal")
+
+        expected = np.asarray([1.0, 0.5, 1.0 / 3.0, 0.25], dtype=float)
+        np.testing.assert_allclose(probabilities[0], expected / np.sum(expected))
+        self.assertEqual(probabilities[1, 0], 0.0)
+        self.assertGreater(probabilities[1, 1], probabilities[1, 2])
+        self.assertGreater(probabilities[1, 2], probabilities[1, 3])
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(2))
+
     def test_sensor_mean_slope_supports_baseline_whitening(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
         trials = [


### PR DESCRIPTION
﻿## Summary
- add reciprocal-rank ensemble score normalization for cross-subject nested stimulus selection
- add rank-aware workflow bundles and selection metric overrides to the nested matrix workflow
- add regression coverage for reciprocal-rank probabilities

## Validation
- `git diff --check`
- `python -m py_compile src/pymegdec/_stimulus_cross_subject_legacy.py tests/test_stimulus_cross_subject.py`
- `python -m ruff check src/pymegdec/_stimulus_cross_subject_legacy.py tests/test_stimulus_cross_subject.py`

Tests were not run per request.
