### PR TITLE
Add train score calibration workflow

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -31,6 +31,8 @@ on:
           - windowed_logreg_lean_rankaware
           - windowed_logreg_lean_rankaware_reciprocal
           - windowed_logreg_175_finetune
+          - windowed_logreg_175_bias_calibration
+          - windowed_logreg_175_train_scorecal
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
@@ -49,6 +51,8 @@ on:
           - window
           - classifier
           - window_classifier
+          - window_feature_classifier_score_calibration
+          - full_config
       selection_ensemble_score_normalization_override:
         description: Override the bundle's selected-ensemble score normalization.
         required: true
@@ -221,6 +225,40 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_bias_calibration": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_class_bias",
+                  "alignment_alphas": "1.0",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_train_scorecal": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,train_class_bias,train_class_affine",
+                  "alignment_alphas": "1.0",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w075": {
                   "window_centers": "0.175",
                   "window_size": "0.075",
@@ -346,6 +384,9 @@ jobs:
                       **bundles[bundle_id],
                   }
                   row.setdefault("window_size", "0.1")
+                  row.setdefault("sample_weightings", "none")
+                  row.setdefault("score_calibrations", "none")
+                  row.setdefault("alignment_alphas", "1.0")
                   row.setdefault("selection_metric", "balanced_accuracy")
                   if diversity_override != "bundle-default":
                       row["selection_ensemble_diversity"] = diversity_override
@@ -416,6 +457,9 @@ jobs:
       CLASSIFIERS: ${{ matrix.classifiers }}
       CLASSIFIER_PARAMS: ${{ matrix.classifier_params }}
       COMPONENTS_PCA_VALUES: ${{ matrix.components_pca_values }}
+      SAMPLE_WEIGHTINGS: ${{ matrix.sample_weightings }}
+      SCORE_CALIBRATIONS: ${{ matrix.score_calibrations }}
+      ALIGNMENT_ALPHAS: ${{ matrix.alignment_alphas }}
       SELECTION_ENSEMBLE_SIZE: ${{ matrix.selection_ensemble_size }}
       SELECTION_ENSEMBLE_DIVERSITY: ${{ matrix.selection_ensemble_diversity }}
       SELECTION_ENSEMBLE_SCORE_NORMALIZATION: ${{ matrix.selection_ensemble_score_normalization }}
@@ -484,6 +528,9 @@ jobs:
           echo "Config bundle: ${{ matrix.config_id }}"
           echo "Outer participant shard: ${OUTER_PARTICIPANTS}"
           echo "Output prefix: ${output_prefix}"
+          echo "Sample weightings: ${SAMPLE_WEIGHTINGS}"
+          echo "Score calibrations: ${SCORE_CALIBRATIONS}"
+          echo "Alignment alphas: ${ALIGNMENT_ALPHAS}"
           args=(
             python scripts/export_stimulus_cross_subject_nested.py
             --data-dir "${DATA_DIR}"
@@ -498,6 +545,9 @@ jobs:
             --classifiers "${CLASSIFIERS}"
             --classifier-params "${CLASSIFIER_PARAMS}"
             --components-pca-values "${COMPONENTS_PCA_VALUES}"
+            --sample-weightings "${SAMPLE_WEIGHTINGS}"
+            --score-calibrations "${SCORE_CALIBRATIONS}"
+            --alignment-alphas "${ALIGNMENT_ALPHAS}"
             --selection-ensemble-size "${SELECTION_ENSEMBLE_SIZE}"
             --selection-ensemble-diversity "${SELECTION_ENSEMBLE_DIVERSITY}"
             --selection-ensemble-score-normalization "${SELECTION_ENSEMBLE_SCORE_NORMALIZATION}"

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -19,7 +19,18 @@ from pymegdec.classifiers import get_default_classifier_param, should_use_defaul
 DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING = "none"
 SAMPLE_WEIGHTING_MODES = ("none", "subject_class_balanced")
 DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION = "none"
-SCORE_CALIBRATION_MODES = ("none", "inner_class_bias", "inner_class_affine")
+INNER_SCORE_CALIBRATION_MODES = frozenset(("inner_class_bias", "inner_class_affine"))
+TRAIN_SCORE_CALIBRATION_MODES = frozenset(("train_class_bias", "train_class_affine"))
+ACTIVE_SCORE_CALIBRATION_MODES = (
+    INNER_SCORE_CALIBRATION_MODES | TRAIN_SCORE_CALIBRATION_MODES
+)
+SCORE_CALIBRATION_MODES = (
+    "none",
+    "inner_class_bias",
+    "inner_class_affine",
+    "train_class_bias",
+    "train_class_affine",
+)
 DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = 1.0
 DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
 DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
@@ -453,7 +464,8 @@ def _fit_outer_fold_model(train_sets, config, classifier_param, *, label_shuffle
     }
     if feature_transform_metadata is not None:
         fitted_model["feature_transform_metadata"] = feature_transform_metadata
-    if fit_score_calibration and config.score_calibration in {"inner_class_bias", "inner_class_affine"}:
+    score_calibration = _normalize_score_calibration(config.score_calibration)
+    if fit_score_calibration and score_calibration in INNER_SCORE_CALIBRATION_MODES:
         fitted_model["score_calibration_metadata"] = _fit_inner_score_calibration(
             train_sets,
             config,
@@ -461,8 +473,15 @@ def _fit_outer_fold_model(train_sets, config, classifier_param, *, label_shuffle
             label_shuffle_seed=label_shuffle_seed,
             label_shuffle_context=label_shuffle_context,
         )
+    elif fit_score_calibration and score_calibration in TRAIN_SCORE_CALIBRATION_MODES:
+        fitted_model["score_calibration_metadata"] = _fit_train_score_calibration(
+            model_bundle,
+            train_features,
+            train_labels,
+            config,
+        )
     else:
-        fitted_model["score_calibration_metadata"] = {"mode": config.score_calibration}
+        fitted_model["score_calibration_metadata"] = {"mode": score_calibration}
     return fitted_model
 
 
@@ -513,6 +532,37 @@ def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_
         "bias": bias,
         "scale": scale,
         "inner_balanced_accuracy": inner_balanced,
+        "l2_penalty": SCORE_CALIBRATION_L2,
+    }
+
+
+def _fit_train_score_calibration(model_bundle, train_features, train_labels, config):
+    """Fit source-only class score calibration on the final source model."""
+
+    mode = _normalize_score_calibration(
+        getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION)
+    )
+    class_order = np.arange(int(config.chance_classes), dtype=int)
+    scores, score_classes = _impl._model_class_scores(model_bundle, train_features)
+    scores = _align_class_score_columns(scores, score_classes, class_order)
+    labels = np.asarray(train_labels, dtype=int)
+    if scores.shape[0] == 0 or labels.shape[0] == 0:
+        return {"mode": mode, "status": "skipped_no_training_scores"}
+    if mode == "train_class_affine":
+        bias, scale, source_balanced = _optimize_class_affine(
+            scores, labels, class_order
+        )
+    else:
+        bias, source_balanced = _optimize_class_bias(scores, labels, class_order)
+        scale = np.ones(class_order.shape[0], dtype=float)
+    return {
+        "mode": mode,
+        "classes": class_order,
+        "bias": bias,
+        "scale": scale,
+        "inner_balanced_accuracy": source_balanced,
+        "source_balanced_accuracy": source_balanced,
+        "calibration_source": "train_scores",
         "l2_penalty": SCORE_CALIBRATION_L2,
     }
 
@@ -625,7 +675,7 @@ def _candidate_model_scores(fitted_model, test_set, config):
 
 def _apply_score_calibration(scores, classes, fitted_model):
     metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
-    if metadata.get("mode") not in {"inner_class_bias", "inner_class_affine"} or "bias" not in metadata:
+    if metadata.get("mode") not in ACTIVE_SCORE_CALIBRATION_MODES or "bias" not in metadata:
         return scores, classes
     calibration_classes = np.asarray(metadata["classes"], dtype=int)
     bias = np.asarray(metadata["bias"], dtype=float)
@@ -637,7 +687,7 @@ def _apply_score_calibration(scores, classes, fitted_model):
 def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictions=True):
     config = _normalized_config(config)
     metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
-    if metadata.get("mode") not in {"inner_class_bias", "inner_class_affine"} or "bias" not in metadata:
+    if metadata.get("mode") not in ACTIVE_SCORE_CALIBRATION_MODES or "bias" not in metadata:
         outer_row, prediction_rows = _previous_score_outer_fold_model(fitted_model, test_set, config, include_predictions=include_predictions)
         _add_next_fields(outer_row, config, fitted_model)
         for row in prediction_rows:
@@ -707,6 +757,8 @@ def _add_next_fields(row, config, fitted_model):
     row["score_calibration"] = metadata.get("mode", getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION))
     row["score_calibration_inner_balanced_accuracy"] = metadata.get("inner_balanced_accuracy", "")
     row["score_calibration_status"] = metadata.get("status", "")
+    row["score_calibration_source"] = metadata.get("calibration_source", "")
+    row["score_calibration_source_balanced_accuracy"] = metadata.get("source_balanced_accuracy", "")
 
 
 def _rank_nested_candidates(inner_rows, *, selection_metric=None):

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -156,6 +156,24 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(len(configs), 1)
         self.assertEqual(configs[0].score_calibration, "inner_class_affine")
 
+    def test_candidate_grid_accepts_train_score_calibration_modes(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            score_calibrations=("train_class_bias", "train_class_affine"),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 2)
+        self.assertEqual(
+            {config.score_calibration for config in configs},
+            {"train_class_bias", "train_class_affine"},
+        )
+
     def test_inner_class_bias_score_calibration_fits_source_fold_metadata(self):
         time = np.asarray([-0.1, 0.0, 0.1, 0.2], dtype=float)
         labels = [1, 2, 1, 2]
@@ -221,6 +239,39 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(metadata["scale"].shape, (2,))
         self.assertTrue(np.all(metadata["scale"] > 0.0))
         self.assertTrue(np.isfinite(metadata["inner_balanced_accuracy"]))
+
+    def test_train_class_bias_score_calibration_fits_source_metadata(self):
+        time = np.asarray([-0.1, 0.0, 0.1, 0.2], dtype=float)
+        labels = [1, 2, 1, 2]
+        data_by_participant = {
+            1: mat_data_from_trials(labels, [[[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]], [[-0.9, -0.9, -0.9, -0.9]], [[0.9, 0.9, 0.9, 0.9]]], time),
+            2: mat_data_from_trials(labels, [[[-1.1, -1.1, -1.1, -1.1]], [[1.1, 1.1, 1.1, 1.1]], [[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]]], time),
+        }
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean",
+            normalization="none",
+            classifier="multinomial-logistic",
+            classifier_param=1.0,
+            components_pca=float("inf"),
+            score_calibration="train_class_bias",
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            train_sets = [load_participant_stimulus_features("unused", participant, config=config) for participant in (1, 2)]
+
+        fitted_model = cross_subject._fit_outer_fold_model(train_sets, config, 1.0)  # pylint: disable=protected-access
+        metadata = fitted_model["score_calibration_metadata"]
+
+        self.assertEqual(metadata["mode"], "train_class_bias")
+        self.assertEqual(metadata["calibration_source"], "train_scores")
+        np.testing.assert_array_equal(metadata["classes"], np.asarray([0, 1]))
+        self.assertEqual(metadata["bias"].shape, (2,))
+        self.assertEqual(metadata["scale"].shape, (2,))
+        np.testing.assert_allclose(metadata["scale"], np.ones(2))
+        self.assertTrue(np.isfinite(metadata["source_balanced_accuracy"]))
 
     def test_inner_class_affine_score_calibration_applies_scale_and_bias(self):
         scores = np.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=float)


### PR DESCRIPTION
Summary
- Add train_class_bias and train_class_affine score calibration modes to the next cross-subject workflow hooks.
- Surface train score calibration metadata in output rows.
- Add nested-matrix bundles for inner bias calibration and train-score calibration, with sample weighting and calibration matrix inputs wired through.

Validation
- git diff --check
- python -m py_compile src/pymegdec/_stimulus_cross_subject_next.py tests/test_stimulus_cross_subject_next.py
- python -m ruff check src/pymegdec/_stimulus_cross_subject_next.py tests/test_stimulus_cross_subject_next.py

Tests not run, per request.