### PR TITLE
Add BUSH score calibration bundles

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -30,16 +30,21 @@ on:
           - windowed_logreg_lean_no_diversity
           - windowed_logreg_lean_rankaware
           - windowed_logreg_lean_rankaware_reciprocal
+          - windowed_logreg_lean_rankaware_reciprocal_inner_prior
           - windowed_logreg_lean_rankaware_top2vote
           - windowed_logreg_lean_rankaware_top3vote
           - windowed_logreg_175_finetune
           - windowed_logreg_175_bias_calibration
+          - windowed_logreg_175_rank_bias_calibration
+          - windowed_logreg_175_probability_map
           - windowed_logreg_175_train_scorecal
+          - windowed_logreg_lean_reciprocal_inner_prior
           - windowed_logreg_lean_inner_prior
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
           - windowed_logreg_175_inner_prior
+          - windowed_logreg_175_reciprocal_inner_prior
           - windowed_logreg_core
           - feature_check
           - lda_svm_check
@@ -71,6 +76,9 @@ on:
           - rank_top3_vote
           - rank_z_blend
           - rank_softmax_inner_balanced
+          - rank_reciprocal_inner_balanced
+          - rank_top2_vote_inner_balanced
+          - rank_top3_vote_inner_balanced
           - rank_z_blend_inner_balanced
       selection_metric_override:
         description: Override the bundle's nested inner-LOSO selection metric.
@@ -219,6 +227,21 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_lean_rankaware_reciprocal_inner_prior": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_reciprocal_inner_balanced",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_lean_rankaware_top2vote": {
                   "window_centers": "0.175,0.200",
                   "feature_modes": "sensor_flat",
@@ -280,6 +303,41 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_rank_bias_calibration": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_rank_bias,train_rank_bias",
+                  "alignment_alphas": "1.0",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_probability_map": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_probability_map",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_train_scorecal": {
                   "window_centers": "0.175",
                   "feature_modes": "sensor_flat",
@@ -294,6 +352,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
                   "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_reciprocal_inner_prior": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_reciprocal_inner_balanced",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -322,6 +394,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_balanced",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_reciprocal_inner_prior": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_reciprocal_inner_balanced",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -79,8 +79,18 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top3_vote",
     "rank_z_blend",
     "rank_softmax_inner_balanced",
+    "rank_reciprocal_inner_balanced",
+    "rank_top2_vote_inner_balanced",
+    "rank_top3_vote_inner_balanced",
     "rank_z_blend_inner_balanced",
 )
+INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
+    "rank_softmax_inner_balanced": "rank_softmax",
+    "rank_reciprocal_inner_balanced": "rank_reciprocal",
+    "rank_top2_vote_inner_balanced": "rank_top2_vote",
+    "rank_top3_vote_inner_balanced": "rank_top3_vote",
+    "rank_z_blend_inner_balanced": "rank_z_blend",
+}
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
     "window",
@@ -2007,11 +2017,9 @@ def _align_score_columns(probabilities, score_classes, class_order):
 
 def _base_ensemble_score_normalization(score_normalization):
     score_normalization = _normalize_ensemble_score_normalization(score_normalization)
-    if score_normalization == "rank_softmax_inner_balanced":
-        return "rank_softmax"
-    if score_normalization == "rank_z_blend_inner_balanced":
-        return "rank_z_blend"
-    return score_normalization
+    return INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(
+        score_normalization, score_normalization
+    )
 
 
 def _inner_class_prior_balance_metadata(selected_rows, class_order, weights, score_normalization):
@@ -2052,7 +2060,10 @@ def _inner_class_prior_balance_metadata(selected_rows, class_order, weights, sco
 
 def _apply_inner_class_prior_balance(probabilities, metadata):
     probabilities = np.asarray(probabilities, dtype=float)
-    if metadata.get("mode") not in {"rank_softmax_inner_balanced", "rank_z_blend_inner_balanced"}:
+    if (
+        metadata.get("mode") not in INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        or "log_adjustment" not in metadata
+    ):
         return probabilities
     adjustment = np.exp(np.asarray(metadata["log_adjustment"], dtype=float))
     adjusted = probabilities * adjustment[None, :]

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -19,8 +19,17 @@ from pymegdec.classifiers import get_default_classifier_param, should_use_defaul
 DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING = "none"
 SAMPLE_WEIGHTING_MODES = ("none", "subject_class_balanced")
 DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION = "none"
-INNER_SCORE_CALIBRATION_MODES = frozenset(("inner_class_bias", "inner_class_affine"))
-TRAIN_SCORE_CALIBRATION_MODES = frozenset(("train_class_bias", "train_class_affine"))
+INNER_SCORE_CALIBRATION_MODES = frozenset(
+    (
+        "inner_class_bias",
+        "inner_class_affine",
+        "inner_rank_bias",
+        "inner_probability_map",
+    )
+)
+TRAIN_SCORE_CALIBRATION_MODES = frozenset(
+    ("train_class_bias", "train_class_affine", "train_rank_bias")
+)
 ACTIVE_SCORE_CALIBRATION_MODES = (
     INNER_SCORE_CALIBRATION_MODES | TRAIN_SCORE_CALIBRATION_MODES
 )
@@ -28,8 +37,11 @@ SCORE_CALIBRATION_MODES = (
     "none",
     "inner_class_bias",
     "inner_class_affine",
+    "inner_rank_bias",
+    "inner_probability_map",
     "train_class_bias",
     "train_class_affine",
+    "train_rank_bias",
 )
 DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = 1.0
 DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
@@ -44,6 +56,8 @@ EXTENDED_FEATURE_MODES = (
     "sensor_time_pyramid_logpower",
 )
 SCORE_CALIBRATION_L2 = 1e-3
+SCORE_CALIBRATION_PROBABILITY_MAP_L2 = 1e-2
+SCORE_CALIBRATION_PROBABILITY_MAP_IDENTITY_BLEND = 0.20
 
 _impl = None
 _BaseConfig = None
@@ -521,13 +535,30 @@ def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_
         all_labels.append(np.asarray(validation_set.labels, dtype=int) - 1)
     scores = np.vstack(all_scores)
     labels = np.concatenate(all_labels)
+    if mode == "inner_probability_map":
+        probability_map, inner_balanced = _fit_probability_map(
+            scores, labels, class_order
+        )
+        return _probability_map_metadata(
+            mode, class_order, probability_map, inner_balanced
+        )
+    score_space = "raw"
+    calibration_scores = scores
+    if mode == "inner_rank_bias":
+        score_space = "rank"
+        calibration_scores = _rank_score_matrix(scores)
     if mode == "inner_class_affine":
-        bias, scale, inner_balanced = _optimize_class_affine(scores, labels, class_order)
+        bias, scale, inner_balanced = _optimize_class_affine(
+            calibration_scores, labels, class_order
+        )
     else:
-        bias, inner_balanced = _optimize_class_bias(scores, labels, class_order)
+        bias, inner_balanced = _optimize_class_bias(
+            calibration_scores, labels, class_order
+        )
         scale = np.ones(class_order.shape[0], dtype=float)
     return {
         "mode": mode,
+        "score_space": score_space,
         "classes": class_order,
         "bias": bias,
         "scale": scale,
@@ -548,15 +579,23 @@ def _fit_train_score_calibration(model_bundle, train_features, train_labels, con
     labels = np.asarray(train_labels, dtype=int)
     if scores.shape[0] == 0 or labels.shape[0] == 0:
         return {"mode": mode, "status": "skipped_no_training_scores"}
+    score_space = "raw"
+    calibration_scores = scores
+    if mode == "train_rank_bias":
+        score_space = "rank"
+        calibration_scores = _rank_score_matrix(scores)
     if mode == "train_class_affine":
         bias, scale, source_balanced = _optimize_class_affine(
-            scores, labels, class_order
+            calibration_scores, labels, class_order
         )
     else:
-        bias, source_balanced = _optimize_class_bias(scores, labels, class_order)
+        bias, source_balanced = _optimize_class_bias(
+            calibration_scores, labels, class_order
+        )
         scale = np.ones(class_order.shape[0], dtype=float)
     return {
         "mode": mode,
+        "score_space": score_space,
         "classes": class_order,
         "bias": bias,
         "scale": scale,
@@ -571,6 +610,131 @@ def _config_with(config, **updates):
     kwargs = {field.name: getattr(config, field.name) for field in fields(config)}
     kwargs.update(updates)
     return CrossSubjectStimulusConfig(**kwargs)
+
+
+def _probability_map_metadata(mode, class_order, probability_map, inner_balanced):
+    return {
+        "mode": mode,
+        "classes": np.asarray(class_order, dtype=int),
+        "probability_map": np.asarray(probability_map, dtype=float),
+        "inner_balanced_accuracy": inner_balanced,
+        "calibration_source": "inner_probability_map",
+        "probability_map_l2_penalty": SCORE_CALIBRATION_PROBABILITY_MAP_L2,
+        "probability_map_identity_blend": (
+            SCORE_CALIBRATION_PROBABILITY_MAP_IDENTITY_BLEND
+        ),
+    }
+
+
+def _fit_probability_map(scores, labels, class_order):
+    """Fit a source-inner probability remapping from probabilities to labels."""
+
+    scores = np.asarray(scores, dtype=float)
+    labels = np.asarray(labels, dtype=int)
+    class_order = np.asarray(class_order, dtype=int)
+    n_classes = int(class_order.shape[0])
+    identity = np.eye(n_classes, dtype=float)
+    if scores.shape[0] == 0 or labels.shape[0] == 0 or n_classes == 0:
+        return identity, np.nan
+
+    probabilities = _score_softmax_probabilities(scores)
+    targets = _one_hot_labels(labels, class_order)
+    regularizer = SCORE_CALIBRATION_PROBABILITY_MAP_L2 * identity
+    normal_matrix = probabilities.T @ probabilities + regularizer
+    rhs = probabilities.T @ targets
+    try:
+        probability_map = np.linalg.solve(normal_matrix, rhs)
+    except np.linalg.LinAlgError:
+        probability_map = np.linalg.pinv(normal_matrix) @ rhs
+
+    probability_map = np.maximum(np.asarray(probability_map, dtype=float), 0.0)
+    blend = float(SCORE_CALIBRATION_PROBABILITY_MAP_IDENTITY_BLEND)
+    probability_map = (1.0 - blend) * probability_map + blend * identity
+    probability_map = _row_normalize_probabilities(probability_map)
+    calibrated_scores = _probabilities_to_logits(probabilities @ probability_map)
+    return probability_map, _balanced_accuracy_for_scores(
+        calibrated_scores, labels, class_order
+    )
+
+
+def _one_hot_labels(labels, class_order):
+    labels = np.asarray(labels, dtype=int).ravel()
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    targets = np.zeros((labels.shape[0], class_order.shape[0]), dtype=float)
+    label_to_column = {
+        int(label): column for column, label in enumerate(class_order.tolist())
+    }
+    for row_index, label in enumerate(labels.tolist()):
+        column = label_to_column.get(int(label))
+        if column is not None:
+            targets[row_index, column] = 1.0
+    return targets
+
+
+def _score_softmax_probabilities(scores):
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        rows = scores.shape[0] if scores.ndim == 2 else 0
+        return np.zeros((rows, 0), dtype=float)
+    probabilities = np.empty_like(scores, dtype=float)
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        if not np.any(finite):
+            probabilities[row_index] = np.full(
+                row.shape[0], 1.0 / row.shape[0], dtype=float
+            )
+            continue
+        sanitized = np.asarray(row, dtype=float).copy()
+        sanitized[~finite] = np.min(sanitized[finite])
+        centered = sanitized - np.mean(sanitized)
+        scale = float(np.std(centered))
+        if scale > 1e-12:
+            centered = centered / scale
+        logits = centered - np.max(centered)
+        exp_logits = np.exp(np.clip(logits, -50.0, 50.0))
+        probabilities[row_index] = exp_logits / np.sum(exp_logits)
+    return probabilities
+
+
+def _row_normalize_probabilities(values):
+    values = np.asarray(values, dtype=float)
+    if values.ndim != 2 or values.shape[1] == 0:
+        return np.zeros_like(values, dtype=float)
+    row_sums = np.sum(values, axis=1, keepdims=True)
+    return np.divide(
+        values,
+        row_sums,
+        out=np.full_like(values, 1.0 / values.shape[1]),
+        where=row_sums > 1e-12,
+    )
+
+
+def _probabilities_to_logits(probabilities):
+    probabilities = _row_normalize_probabilities(
+        np.maximum(np.asarray(probabilities, dtype=float), 1e-12)
+    )
+    return np.log(probabilities)
+
+
+def _rank_score_matrix(scores):
+    """Convert arbitrary class scores into per-row negative-rank scores."""
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2:
+        return np.zeros((0, 0), dtype=float)
+    rank_scores = np.empty_like(scores, dtype=float)
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        if not np.any(finite):
+            rank_scores[row_index] = 0.0
+            continue
+        rank_input = np.where(finite, row, -np.inf)
+        descending_columns = np.argsort(-rank_input, kind="mergesort")
+        ranks = np.empty(row.shape[0], dtype=float)
+        ranks[descending_columns] = np.arange(row.shape[0], dtype=float)
+        rank_scores[row_index] = -ranks
+        rank_scores[row_index, ~finite] = -float(row.shape[0])
+    return rank_scores
 
 
 def _optimize_class_bias(scores, labels, class_order):
@@ -673,21 +837,38 @@ def _candidate_model_scores(fitted_model, test_set, config):
     return _apply_score_calibration(scores, classes, fitted_model)
 
 
+def _has_active_score_calibration_metadata(metadata):
+    if not isinstance(metadata, dict):
+        return False
+    if metadata.get("mode") not in ACTIVE_SCORE_CALIBRATION_MODES:
+        return False
+    return "bias" in metadata or "probability_map" in metadata
+
+
 def _apply_score_calibration(scores, classes, fitted_model):
     metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
-    if metadata.get("mode") not in ACTIVE_SCORE_CALIBRATION_MODES or "bias" not in metadata:
+    if not _has_active_score_calibration_metadata(metadata):
         return scores, classes
     calibration_classes = np.asarray(metadata["classes"], dtype=int)
+    if "probability_map" in metadata:
+        aligned = _align_class_score_columns(scores, classes, calibration_classes)
+        probabilities = _score_softmax_probabilities(aligned)
+        probability_map = _row_normalize_probabilities(
+            np.maximum(np.asarray(metadata["probability_map"], dtype=float), 0.0)
+        )
+        return _probabilities_to_logits(probabilities @ probability_map), calibration_classes
     bias = np.asarray(metadata["bias"], dtype=float)
     scale = np.asarray(metadata.get("scale", np.ones_like(bias)), dtype=float)
     aligned = _align_class_score_columns(scores, classes, calibration_classes)
+    if metadata.get("score_space") == "rank":
+        aligned = _rank_score_matrix(aligned)
     return aligned * scale[None, :] + bias[None, :], calibration_classes
 
 
 def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictions=True):
     config = _normalized_config(config)
     metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
-    if metadata.get("mode") not in ACTIVE_SCORE_CALIBRATION_MODES or "bias" not in metadata:
+    if not _has_active_score_calibration_metadata(metadata):
         outer_row, prediction_rows = _previous_score_outer_fold_model(fitted_model, test_set, config, include_predictions=include_predictions)
         _add_next_fields(outer_row, config, fitted_model)
         for row in prediction_rows:
@@ -759,6 +940,12 @@ def _add_next_fields(row, config, fitted_model):
     row["score_calibration_status"] = metadata.get("status", "")
     row["score_calibration_source"] = metadata.get("calibration_source", "")
     row["score_calibration_source_balanced_accuracy"] = metadata.get("source_balanced_accuracy", "")
+    row["score_calibration_probability_map_l2"] = metadata.get(
+        "probability_map_l2_penalty", ""
+    )
+    row["score_calibration_probability_map_identity_blend"] = metadata.get(
+        "probability_map_identity_blend", ""
+    )
 
 
 def _rank_nested_candidates(inner_rows, *, selection_metric=None):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -281,16 +281,49 @@ class TestStimulusCrossSubject(unittest.TestCase):
         np.testing.assert_allclose(np.sum(top2, axis=1), np.ones(3))
         np.testing.assert_allclose(np.sum(top3, axis=1), np.ones(3))
 
-    def test_inner_balanced_rank_softmax_is_valid_base_normalization(self):
+    def test_inner_balanced_suffix_is_valid_for_soft_rank_normalizations(self):
         scores = np.asarray([[3.0, 1.0, 2.0], [0.0, 2.0, 1.0]], dtype=float)
-        expected = cross_subject._class_score_probabilities(
-            scores, score_normalization="rank_softmax"
-        )
-        actual = cross_subject._class_score_probabilities(
-            scores, score_normalization="rank_softmax_inner_balanced"
+        balanced_to_base = {
+            "rank_softmax_inner_balanced": "rank_softmax",
+            "rank_reciprocal_inner_balanced": "rank_reciprocal",
+            "rank_top2_vote_inner_balanced": "rank_top2_vote",
+            "rank_top3_vote_inner_balanced": "rank_top3_vote",
+            "rank_z_blend_inner_balanced": "rank_z_blend",
+        }
+
+        for balanced, base in balanced_to_base.items():
+            with self.subTest(score_normalization=balanced):
+                self.assertIn(balanced, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+                expected = cross_subject._class_score_probabilities(
+                    scores, score_normalization=base
+                )
+                actual = cross_subject._class_score_probabilities(
+                    scores, score_normalization=balanced
+                )
+                np.testing.assert_allclose(actual, expected)
+
+    def test_inner_balanced_suffix_enables_prior_balance_for_rank_reciprocal(self):
+        selected_rows = (
+            {
+                "selected_inner_test_label_counts": "1:10;2:10",
+                "selected_inner_predicted_label_counts": "1:18;2:2",
+            },
         )
 
-        np.testing.assert_allclose(actual, expected)
+        metadata = cross_subject._inner_class_prior_balance_metadata(
+            selected_rows,
+            np.asarray([0, 1], dtype=int),
+            np.asarray([1.0], dtype=float),
+            "rank_reciprocal_inner_balanced",
+        )
+
+        adjusted = cross_subject._apply_inner_class_prior_balance(
+            np.asarray([[0.60, 0.40]], dtype=float), metadata
+        )
+
+        self.assertEqual(metadata["mode"], "rank_reciprocal_inner_balanced")
+        self.assertLess(adjusted[0, 0], 0.60)
+        self.assertGreater(adjusted[0, 1], 0.40)
 
     def test_inner_class_prior_balance_downweights_overpredicted_class(self):
         probabilities = np.asarray([[0.60, 0.40]], dtype=float)

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -156,6 +156,39 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(len(configs), 1)
         self.assertEqual(configs[0].score_calibration, "inner_class_affine")
 
+    def test_candidate_grid_accepts_rank_bias_score_calibration_modes(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            score_calibrations=("inner_rank_bias", "train_rank_bias"),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 2)
+        self.assertEqual(
+            {config.score_calibration for config in configs},
+            {"inner_rank_bias", "train_rank_bias"},
+        )
+
+    def test_candidate_grid_accepts_inner_probability_map_score_calibration(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            score_calibrations=("inner_probability_map",),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 1)
+        self.assertEqual(configs[0].score_calibration, "inner_probability_map")
+
     def test_candidate_grid_accepts_train_score_calibration_modes(self):
         configs = make_cross_subject_candidate_configs(
             window_centers=(0.175,),
@@ -240,6 +273,39 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertTrue(np.all(metadata["scale"] > 0.0))
         self.assertTrue(np.isfinite(metadata["inner_balanced_accuracy"]))
 
+    def test_inner_probability_map_score_calibration_fits_source_fold_metadata(self):
+        time = np.asarray([-0.1, 0.0, 0.1, 0.2], dtype=float)
+        labels = [1, 2, 1, 2]
+        data_by_participant = {
+            1: mat_data_from_trials(labels, [[[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]], [[-0.9, -0.9, -0.9, -0.9]], [[0.9, 0.9, 0.9, 0.9]]], time),
+            2: mat_data_from_trials(labels, [[[-1.1, -1.1, -1.1, -1.1]], [[1.1, 1.1, 1.1, 1.1]], [[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]]], time),
+            3: mat_data_from_trials(labels, [[[-1.2, -1.2, -1.2, -1.2]], [[1.2, 1.2, 1.2, 1.2]], [[-1.1, -1.1, -1.1, -1.1]], [[1.1, 1.1, 1.1, 1.1]]], time),
+        }
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean",
+            normalization="none",
+            classifier="multinomial-logistic",
+            classifier_param=1.0,
+            components_pca=float("inf"),
+            score_calibration="inner_probability_map",
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            train_sets = [load_participant_stimulus_features("unused", participant, config=config) for participant in (1, 2, 3)]
+
+        fitted_model = cross_subject._fit_outer_fold_model(train_sets, config, 1.0)  # pylint: disable=protected-access
+        metadata = fitted_model["score_calibration_metadata"]
+
+        self.assertEqual(metadata["mode"], "inner_probability_map")
+        np.testing.assert_array_equal(metadata["classes"], np.asarray([0, 1]))
+        self.assertEqual(metadata["probability_map"].shape, (2, 2))
+        self.assertTrue(np.all(metadata["probability_map"] >= 0.0))
+        np.testing.assert_allclose(np.sum(metadata["probability_map"], axis=1), np.ones(2))
+        self.assertTrue(np.isfinite(metadata["inner_balanced_accuracy"]))
+
     def test_train_class_bias_score_calibration_fits_source_metadata(self):
         time = np.asarray([-0.1, 0.0, 0.1, 0.2], dtype=float)
         labels = [1, 2, 1, 2]
@@ -292,6 +358,47 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
 
         np.testing.assert_array_equal(classes, np.asarray([0, 1]))
         np.testing.assert_allclose(calibrated, np.asarray([[2.5, 0.0], [6.5, 0.5]]))
+
+    def test_rank_bias_score_calibration_applies_bias_to_rank_scores(self):
+        scores = np.asarray([[10.0, 1.0], [0.0, 3.0]], dtype=float)
+        fitted_model = {
+            "score_calibration_metadata": {
+                "mode": "inner_rank_bias",
+                "score_space": "rank",
+                "classes": np.asarray([0, 1]),
+                "bias": np.asarray([0.0, 2.0]),
+                "scale": np.ones(2),
+            }
+        }
+
+        calibrated, classes = cross_subject._apply_score_calibration(  # pylint: disable=protected-access
+            scores,
+            np.asarray([0, 1]),
+            fitted_model,
+        )
+
+        np.testing.assert_array_equal(classes, np.asarray([0, 1]))
+        np.testing.assert_allclose(calibrated, np.asarray([[0.0, 1.0], [-1.0, 2.0]]))
+
+    def test_inner_probability_map_score_calibration_applies_probability_map(self):
+        scores = np.asarray([[4.0, 1.0], [1.0, 4.0]], dtype=float)
+        fitted_model = {
+            "score_calibration_metadata": {
+                "mode": "inner_probability_map",
+                "classes": np.asarray([0, 1]),
+                "probability_map": np.asarray([[0.0, 1.0], [1.0, 0.0]], dtype=float),
+            }
+        }
+
+        calibrated, classes = cross_subject._apply_score_calibration(  # pylint: disable=protected-access
+            scores,
+            np.asarray([0, 1]),
+            fitted_model,
+        )
+
+        np.testing.assert_array_equal(classes, np.asarray([0, 1]))
+        np.testing.assert_array_equal(np.argmax(calibrated, axis=1), np.asarray([1, 0]))
+        np.testing.assert_allclose(np.sum(np.exp(calibrated), axis=1), np.ones(2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- add rank reciprocal/top-k inner-balanced ensemble normalization support
- add rank-bias and inner-probability-map score calibration modes
- add BUSH-MEG workflow bundles for the new calibration and inner-prior variants

Validation:
- git diff --check
- python -m py_compile on edited source modules
- python -m ruff check on edited source/test files

Tests were not run per request.