### PR TITLE
Add BUSH balanced quota ensemble modes

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -33,6 +33,9 @@ on:
           - windowed_logreg_lean_rankaware_reciprocal_inner_prior
           - windowed_logreg_lean_rankaware_top2vote
           - windowed_logreg_lean_rankaware_top3vote
+          - windowed_logreg_lean_rankaware_top2vote_inner_prior
+          - windowed_logreg_lean_balanced_quota
+          - windowed_logreg_175_balanced_quota
           - windowed_logreg_175_finetune
           - windowed_logreg_175_bias_calibration
           - windowed_logreg_175_rank_bias_calibration
@@ -75,6 +78,8 @@ on:
           - rank_top2_vote
           - rank_top3_vote
           - rank_z_blend
+          - rank_softmax_balanced_quota
+          - rank_z_blend_balanced_quota
           - rank_softmax_inner_balanced
           - rank_reciprocal_inner_balanced
           - rank_top2_vote_inner_balanced
@@ -270,6 +275,49 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_top3_vote",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_rankaware_top2vote_inner_prior": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top2_vote_inner_balanced",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_balanced_quota": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_balanced_quota",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_balanced_quota": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_balanced_quota",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_finetune": {

--- a/.github/workflows/stimulus-cross-subject-nested.yml
+++ b/.github/workflows/stimulus-cross-subject-nested.yml
@@ -102,7 +102,20 @@ on:
         required: true
         default: row_z_softmax
         type: choice
-        options: [row_z_softmax, rank_softmax]
+        options:
+          - row_z_softmax
+          - rank_softmax
+          - rank_reciprocal
+          - rank_top2_vote
+          - rank_top3_vote
+          - rank_z_blend
+          - rank_softmax_balanced_quota
+          - rank_z_blend_balanced_quota
+          - rank_softmax_inner_balanced
+          - rank_reciprocal_inner_balanced
+          - rank_top2_vote_inner_balanced
+          - rank_top3_vote_inner_balanced
+          - rank_z_blend_inner_balanced
       selection_ensemble_weighting:
         description: Weighting for top-K ensemble candidates.
         required: true

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import numpy as np
 import scipy.io as sio
+from scipy.optimize import linear_sum_assignment
 from pymegdec.alpha_metrics import write_alpha_metrics_csv
 from pymegdec.alpha_signal import get_data_field
 from pymegdec.classifiers import (
@@ -78,6 +79,8 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top2_vote",
     "rank_top3_vote",
     "rank_z_blend",
+    "rank_softmax_balanced_quota",
+    "rank_z_blend_balanced_quota",
     "rank_softmax_inner_balanced",
     "rank_reciprocal_inner_balanced",
     "rank_top2_vote_inner_balanced",
@@ -1787,7 +1790,12 @@ def _score_outer_fold_ensemble_models(
     ensemble_probabilities = _apply_inner_class_prior_balance(
         ensemble_probabilities, prior_balance_metadata
     )
-    predictions = class_order[np.argmax(ensemble_probabilities, axis=1)]
+    balanced_quota_metadata = _balanced_quota_metadata(
+        ensemble_probabilities, class_order, ensemble_score_normalization
+    )
+    predictions = np.asarray(balanced_quota_metadata.get("predictions", ()), dtype=int)
+    if predictions.shape[0] != ensemble_probabilities.shape[0]:
+        predictions = class_order[np.argmax(ensemble_probabilities, axis=1)]
     rank_metrics = _ranked_label_metrics(test_labels, ensemble_probabilities, class_order)
     accuracy = float(accuracy_score(test_labels, predictions))
     balanced_accuracy = float(balanced_accuracy_score(test_labels, predictions))
@@ -1808,6 +1816,9 @@ def _score_outer_fold_ensemble_models(
             "mean_true_label_rank": rank_metrics["mean_true_label_rank"],
             "median_true_label_rank": rank_metrics["median_true_label_rank"],
             "above_chance": bool(balanced_accuracy > outer_row["chance_accuracy"]),
+            "predicted_label_counts": _format_counter(
+                Counter((np.asarray(predictions, dtype=int) + 1).tolist())
+            ),
         }
     )
     _add_ensemble_output_fields(
@@ -1821,6 +1832,7 @@ def _score_outer_fold_ensemble_models(
         ensemble_score_normalization=ensemble_score_normalization,
     )
     _add_inner_class_prior_balance_fields(outer_row, prior_balance_metadata)
+    _add_balanced_quota_fields(outer_row, balanced_quota_metadata)
 
     prediction_rows = []
     if include_predictions:
@@ -1845,6 +1857,7 @@ def _score_outer_fold_ensemble_models(
                 ensemble_score_normalization=ensemble_score_normalization,
             )
             _add_inner_class_prior_balance_fields(row, prior_balance_metadata)
+            _add_balanced_quota_fields(row, balanced_quota_metadata)
     return outer_row, prediction_rows
 
 
@@ -2017,6 +2030,8 @@ def _align_score_columns(probabilities, score_classes, class_order):
 
 def _base_ensemble_score_normalization(score_normalization):
     score_normalization = _normalize_ensemble_score_normalization(score_normalization)
+    if score_normalization.endswith("_balanced_quota"):
+        return score_normalization.removesuffix("_balanced_quota")
     return INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(
         score_normalization, score_normalization
     )
@@ -2076,6 +2091,85 @@ def _apply_inner_class_prior_balance(probabilities, metadata):
     )
 
 
+def _balanced_quota_metadata(probabilities, class_order, score_normalization):
+    """Return optional test-batch balanced assignment metadata."""
+
+    mode = _normalize_ensemble_score_normalization(score_normalization)
+    if not mode.endswith("_balanced_quota"):
+        return {"mode": "none"}
+    predictions, quota_counts, status = _balanced_quota_predictions(
+        probabilities, class_order
+    )
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    return {
+        "mode": mode,
+        "status": status,
+        "class_order": class_order,
+        "quota_counts": quota_counts,
+        "predictions": predictions,
+    }
+
+
+def _balanced_quota_predictions(probabilities, class_order):
+    probabilities = np.asarray(probabilities, dtype=float)
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    if (
+        probabilities.ndim != 2
+        or probabilities.shape[0] == 0
+        or probabilities.shape[1] == 0
+    ):
+        return (
+            np.asarray([], dtype=int),
+            np.zeros(class_order.shape[0], dtype=int),
+            "skipped_empty_scores",
+        )
+    if class_order.shape[0] != probabilities.shape[1]:
+        return (
+            np.asarray([], dtype=int),
+            np.zeros(class_order.shape[0], dtype=int),
+            "skipped_class_order_mismatch",
+        )
+
+    sanitized = _finite_assignment_scores(probabilities)
+    quotas = _balanced_quota_counts(sanitized)
+    expanded_columns = np.repeat(np.arange(sanitized.shape[1], dtype=int), quotas)
+    if expanded_columns.shape[0] != sanitized.shape[0]:
+        return class_order[np.argmax(sanitized, axis=1)], quotas, "skipped_invalid_quota"
+
+    row_indices, slot_indices = linear_sum_assignment(-sanitized[:, expanded_columns])
+    prediction_columns = np.empty(sanitized.shape[0], dtype=int)
+    prediction_columns[row_indices] = expanded_columns[slot_indices]
+    return class_order[prediction_columns], quotas, "applied"
+
+
+def _finite_assignment_scores(probabilities):
+    scores = np.asarray(probabilities, dtype=float).copy()
+    if scores.ndim != 2:
+        raise ValueError(
+            "Balanced quota assignment requires a two-dimensional score matrix."
+        )
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        if np.any(finite):
+            row[~finite] = float(np.min(row[finite]) - 1.0)
+        else:
+            row[:] = 0.0
+        scores[row_index] = row
+    return scores
+
+
+def _balanced_quota_counts(scores):
+    scores = np.asarray(scores, dtype=float)
+    n_trials, n_classes = scores.shape
+    quotas = np.full(n_classes, n_trials // n_classes, dtype=int)
+    remainder = int(n_trials - np.sum(quotas))
+    if remainder > 0:
+        class_totals = np.sum(scores, axis=0)
+        extra_columns = np.argsort(-class_totals, kind="mergesort")[:remainder]
+        quotas[extra_columns] += 1
+    return quotas
+
+
 def _add_inner_class_prior_balance_fields(row, metadata):
     row["ensemble_inner_class_prior_balancing"] = metadata.get("mode", "none")
     row["ensemble_inner_class_prior_smoothing"] = metadata.get("smoothing", "")
@@ -2084,6 +2178,16 @@ def _add_inner_class_prior_balance_fields(row, metadata):
     row["ensemble_inner_class_prior_target_counts"] = _format_float_mapping(zip(labels_one_based, metadata.get("target_counts", ())))
     row["ensemble_inner_class_prior_predicted_counts"] = _format_float_mapping(zip(labels_one_based, metadata.get("predicted_counts", ())))
     row["ensemble_inner_class_prior_log_adjustment"] = _format_float_mapping(zip(labels_one_based, metadata.get("log_adjustment", ())))
+
+
+def _add_balanced_quota_fields(row, metadata):
+    row["ensemble_balanced_quota"] = metadata.get("mode", "none")
+    row["ensemble_balanced_quota_status"] = metadata.get("status", "")
+    class_order = np.asarray(metadata.get("class_order", ()), dtype=int)
+    labels_one_based = class_order + 1
+    row["ensemble_balanced_quota_counts"] = _format_float_mapping(
+        zip(labels_one_based, metadata.get("quota_counts", ()))
+    )
 
 
 def _normalized_ensemble_weights(weights, expected_size):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -325,6 +325,46 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertLess(adjusted[0, 0], 0.60)
         self.assertGreater(adjusted[0, 1], 0.40)
 
+    def test_balanced_quota_rank_softmax_is_valid_base_normalization(self):
+        self.assertIn(
+            "rank_softmax_balanced_quota",
+            cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+        )
+        scores = np.asarray([[3.0, 1.0, 2.0], [0.0, 2.0, 1.0]], dtype=float)
+
+        expected = cross_subject._class_score_probabilities(
+            scores, score_normalization="rank_softmax"
+        )
+        actual = cross_subject._class_score_probabilities(
+            scores, score_normalization="rank_softmax_balanced_quota"
+        )
+
+        np.testing.assert_allclose(actual, expected)
+
+    def test_balanced_quota_assignment_enforces_known_batch_balance(self):
+        probabilities = np.asarray(
+            [
+                [0.95, 0.05],
+                [0.90, 0.10],
+                [0.70, 0.30],
+                [0.60, 0.40],
+            ],
+            dtype=float,
+        )
+
+        metadata = cross_subject._balanced_quota_metadata(
+            probabilities,
+            np.asarray([0, 1], dtype=int),
+            "rank_softmax_balanced_quota",
+        )
+
+        self.assertEqual(metadata["status"], "applied")
+        self.assertEqual(metadata["predictions"].tolist(), [0, 0, 1, 1])
+        self.assertEqual(
+            np.bincount(metadata["predictions"], minlength=2).tolist(),
+            [2, 2],
+        )
+
     def test_inner_class_prior_balance_downweights_overpredicted_class(self):
         probabilities = np.asarray([[0.60, 0.40]], dtype=float)
         selected_rows = (


### PR DESCRIPTION
Summary:
- add balanced-quota ensemble score-normalization modes
- expose balanced-quota and top2 inner-prior BUSH workflow bundles
- expose the expanded ensemble normalization choices in the single nested workflow

Validation:
- git diff --check
- python -m py_compile on edited source module
- python -m ruff check on edited source/test files

Tests were not run per request.