### PR TITLE
Add BUSH inner confusion calibration

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -40,13 +40,16 @@ on:
           - windowed_logreg_175_bias_calibration
           - windowed_logreg_175_rank_bias_calibration
           - windowed_logreg_175_probability_map
+          - windowed_logreg_175_confusion_blend
           - windowed_logreg_175_train_scorecal
           - windowed_logreg_lean_reciprocal_inner_prior
           - windowed_logreg_lean_inner_prior
+          - windowed_logreg_lean_inner_confusion
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
           - windowed_logreg_175_inner_prior
+          - windowed_logreg_175_inner_confusion
           - windowed_logreg_175_reciprocal_inner_prior
           - windowed_logreg_core
           - feature_check
@@ -85,6 +88,11 @@ on:
           - rank_top2_vote_inner_balanced
           - rank_top3_vote_inner_balanced
           - rank_z_blend_inner_balanced
+          - rank_softmax_inner_confusion
+          - rank_reciprocal_inner_confusion
+          - rank_top2_vote_inner_confusion
+          - rank_top3_vote_inner_confusion
+          - rank_z_blend_inner_confusion
       selection_metric_override:
         description: Override the bundle's nested inner-LOSO selection metric.
         required: true
@@ -386,6 +394,24 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_confusion_blend": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_confusion_blend",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_train_scorecal": {
                   "window_centers": "0.175",
                   "feature_modes": "sensor_flat",
@@ -431,6 +457,20 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_lean_inner_confusion": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_inner_prior": {
                   "window_centers": "0.175",
                   "feature_modes": "sensor_flat",
@@ -442,6 +482,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_balanced",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_inner_confusion": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -86,6 +86,11 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top2_vote_inner_balanced",
     "rank_top3_vote_inner_balanced",
     "rank_z_blend_inner_balanced",
+    "rank_softmax_inner_confusion",
+    "rank_reciprocal_inner_confusion",
+    "rank_top2_vote_inner_confusion",
+    "rank_top3_vote_inner_confusion",
+    "rank_z_blend_inner_confusion",
 )
 INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_inner_balanced": "rank_softmax",
@@ -93,6 +98,13 @@ INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_top2_vote_inner_balanced": "rank_top2_vote",
     "rank_top3_vote_inner_balanced": "rank_top3_vote",
     "rank_z_blend_inner_balanced": "rank_z_blend",
+}
+INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
+    "rank_softmax_inner_confusion": "rank_softmax",
+    "rank_reciprocal_inner_confusion": "rank_reciprocal",
+    "rank_top2_vote_inner_confusion": "rank_top2_vote",
+    "rank_top3_vote_inner_confusion": "rank_top3_vote",
+    "rank_z_blend_inner_confusion": "rank_z_blend",
 }
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
@@ -1500,6 +1512,9 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=DEFAULT_CROSS_SUBJEC
         example = candidate_rows[0]
         inner_test_label_counts = _sum_formatted_counters(candidate_rows, "test_label_counts")
         inner_predicted_label_counts = _sum_formatted_counters(candidate_rows, "predicted_label_counts")
+        inner_true_predicted_label_pair_counts = _sum_formatted_counters(
+            candidate_rows, "true_predicted_label_pair_counts"
+        )
         chance_mean_rank = float(example.get("chance_mean_rank", 0.5 * (example.get("chance_classes", DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES) + 1)))
         summary = {
             "selection_mode": "nested_loso",
@@ -1530,6 +1545,9 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=DEFAULT_CROSS_SUBJEC
             "selected_inner_selection_score_sem": _sem_or_nan(selection_scores),
             "selected_inner_test_label_counts": _format_counter(inner_test_label_counts),
             "selected_inner_predicted_label_counts": _format_counter(inner_predicted_label_counts),
+            "selected_inner_true_predicted_label_pair_counts": _format_counter(
+                inner_true_predicted_label_pair_counts
+            ),
             "selected_window_center_s": example["window_center_s"],
             "selected_window_size_s": example["window_size_s"],
             "selected_window_start_s": example["window_start_s"],
@@ -1681,6 +1699,9 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
     train_window = fitted_model["train_window"]
     alignment_metadata = fitted_model["alignment_metadata"]
     predicted_label_counts = Counter((np.asarray(predictions, dtype=int) + 1).tolist())
+    true_predicted_label_pair_counts = _true_predicted_label_pair_counts(
+        test_labels_one_based, predictions
+    )
 
     outer_row = {
         "outer_fold": int(test_set.participant),
@@ -1723,6 +1744,9 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
         "min_test_trials_per_class": int(min(test_class_counts.values())),
         "test_label_counts": _format_counter(test_class_counts),
         "predicted_label_counts": _format_counter(predicted_label_counts),
+        "true_predicted_label_pair_counts": _format_counter(
+            true_predicted_label_pair_counts
+        ),
         "classifier": config.classifier,
         "classifier_param": fitted_model["classifier_param"],
         "components_pca": config.components_pca,
@@ -1790,12 +1814,21 @@ def _score_outer_fold_ensemble_models(
     ensemble_probabilities = _apply_inner_class_prior_balance(
         ensemble_probabilities, prior_balance_metadata
     )
+    confusion_correction_metadata = _inner_confusion_correction_metadata(
+        selected_rows, class_order, weights, ensemble_score_normalization
+    )
+    ensemble_probabilities = _apply_inner_confusion_correction(
+        ensemble_probabilities, confusion_correction_metadata
+    )
     balanced_quota_metadata = _balanced_quota_metadata(
         ensemble_probabilities, class_order, ensemble_score_normalization
     )
     predictions = np.asarray(balanced_quota_metadata.get("predictions", ()), dtype=int)
     if predictions.shape[0] != ensemble_probabilities.shape[0]:
         predictions = class_order[np.argmax(ensemble_probabilities, axis=1)]
+    true_predicted_label_pair_counts = _true_predicted_label_pair_counts(
+        test_labels + 1, predictions
+    )
     rank_metrics = _ranked_label_metrics(test_labels, ensemble_probabilities, class_order)
     accuracy = float(accuracy_score(test_labels, predictions))
     balanced_accuracy = float(balanced_accuracy_score(test_labels, predictions))
@@ -1819,6 +1852,9 @@ def _score_outer_fold_ensemble_models(
             "predicted_label_counts": _format_counter(
                 Counter((np.asarray(predictions, dtype=int) + 1).tolist())
             ),
+            "true_predicted_label_pair_counts": _format_counter(
+                true_predicted_label_pair_counts
+            ),
         }
     )
     _add_ensemble_output_fields(
@@ -1832,6 +1868,7 @@ def _score_outer_fold_ensemble_models(
         ensemble_score_normalization=ensemble_score_normalization,
     )
     _add_inner_class_prior_balance_fields(outer_row, prior_balance_metadata)
+    _add_inner_confusion_correction_fields(outer_row, confusion_correction_metadata)
     _add_balanced_quota_fields(outer_row, balanced_quota_metadata)
 
     prediction_rows = []
@@ -1857,6 +1894,7 @@ def _score_outer_fold_ensemble_models(
                 ensemble_score_normalization=ensemble_score_normalization,
             )
             _add_inner_class_prior_balance_fields(row, prior_balance_metadata)
+            _add_inner_confusion_correction_fields(row, confusion_correction_metadata)
             _add_balanced_quota_fields(row, balanced_quota_metadata)
     return outer_row, prediction_rows
 
@@ -2033,7 +2071,10 @@ def _base_ensemble_score_normalization(score_normalization):
     if score_normalization.endswith("_balanced_quota"):
         return score_normalization.removesuffix("_balanced_quota")
     return INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(
-        score_normalization, score_normalization
+        score_normalization,
+        INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(
+            score_normalization, score_normalization
+        ),
     )
 
 
@@ -2178,6 +2219,79 @@ def _add_inner_class_prior_balance_fields(row, metadata):
     row["ensemble_inner_class_prior_target_counts"] = _format_float_mapping(zip(labels_one_based, metadata.get("target_counts", ())))
     row["ensemble_inner_class_prior_predicted_counts"] = _format_float_mapping(zip(labels_one_based, metadata.get("predicted_counts", ())))
     row["ensemble_inner_class_prior_log_adjustment"] = _format_float_mapping(zip(labels_one_based, metadata.get("log_adjustment", ())))
+
+
+def _inner_confusion_correction_metadata(
+    selected_rows, class_order, weights, score_normalization
+):
+    """Return source-inner confusion metadata for leakage-safe re-ranking."""
+
+    score_normalization = _normalize_ensemble_score_normalization(score_normalization)
+    if score_normalization not in INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES:
+        return {"mode": "none"}
+
+    selected_rows = tuple(selected_rows)
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    labels_one_based = class_order + 1
+    weights = _normalized_ensemble_weights(weights, len(selected_rows))
+    counts = np.zeros((class_order.shape[0], class_order.shape[0]), dtype=float)
+    for row, weight in zip(selected_rows, weights):
+        counts += float(weight) * _true_predicted_pair_count_matrix(
+            row.get("selected_inner_true_predicted_label_pair_counts", ""),
+            labels_one_based,
+        )
+
+    if not np.any(counts > 0.0):
+        return {"mode": "skipped_missing_inner_confusion_counts"}
+
+    smoothing = 1.0
+    blend = 0.35
+    smoothed = counts + smoothing
+    predicted_totals = np.sum(smoothed, axis=0, keepdims=True)
+    true_given_predicted = np.divide(
+        smoothed,
+        predicted_totals,
+        out=np.full_like(smoothed, 1.0 / smoothed.shape[0]),
+        where=predicted_totals > 0.0,
+    )
+    return {
+        "mode": score_normalization,
+        "smoothing": smoothing,
+        "blend": blend,
+        "class_order": class_order,
+        "true_predicted_counts": counts,
+        "true_given_predicted": true_given_predicted,
+    }
+
+
+def _apply_inner_confusion_correction(probabilities, metadata):
+    probabilities = np.asarray(probabilities, dtype=float)
+    if (
+        metadata.get("mode") not in INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        or "true_given_predicted" not in metadata
+    ):
+        return probabilities
+    true_given_predicted = np.asarray(metadata["true_given_predicted"], dtype=float)
+    corrected = probabilities @ true_given_predicted.T
+    blend = float(metadata.get("blend", 0.35))
+    adjusted = (1.0 - blend) * probabilities + blend * corrected
+    row_sums = np.sum(adjusted, axis=1, keepdims=True)
+    return np.divide(
+        adjusted,
+        row_sums,
+        out=np.full_like(adjusted, 1.0 / adjusted.shape[1]),
+        where=row_sums > 0.0,
+    )
+
+
+def _add_inner_confusion_correction_fields(row, metadata):
+    row["ensemble_inner_confusion_correction"] = metadata.get("mode", "none")
+    row["ensemble_inner_confusion_smoothing"] = metadata.get("smoothing", "")
+    row["ensemble_inner_confusion_blend"] = metadata.get("blend", "")
+    row["ensemble_inner_confusion_true_predicted_counts"] = _format_matrix_mapping(
+        metadata.get("class_order", ()),
+        metadata.get("true_predicted_counts", ()),
+    )
 
 
 def _add_balanced_quota_fields(row, metadata):
@@ -2752,12 +2866,60 @@ def _counter_vector(value, labels):
     return np.asarray([float(counter.get(int(label), 0.0)) for label in labels], dtype=float)
 
 
+def _true_predicted_label_pair_counts(true_labels_one_based, predictions_zero_based):
+    return Counter(
+        _true_predicted_pair_key(int(true_label), int(predicted_label) + 1)
+        for true_label, predicted_label in zip(
+            true_labels_one_based, predictions_zero_based
+        )
+    )
+
+
+def _true_predicted_pair_key(true_label_one_based, predicted_label_one_based):
+    return 1000 * int(true_label_one_based) + int(predicted_label_one_based)
+
+
+def _true_predicted_pair_count_matrix(value, labels_one_based):
+    labels_one_based = np.asarray(labels_one_based, dtype=int).ravel()
+    label_to_index = {
+        int(label): index for index, label in enumerate(labels_one_based.tolist())
+    }
+    matrix = np.zeros(
+        (labels_one_based.shape[0], labels_one_based.shape[0]), dtype=float
+    )
+    for key, count in _parse_formatted_counter(value).items():
+        true_label = int(key) // 1000
+        predicted_label = int(key) % 1000
+        true_index = label_to_index.get(true_label)
+        predicted_index = label_to_index.get(predicted_label)
+        if true_index is not None and predicted_index is not None:
+            matrix[true_index, predicted_index] += float(count)
+    return matrix
+
+
 def _format_sequence(values):
     return ";".join(str(value) for value in values)
 
 
 def _format_float_mapping(items):
     return ";".join(f"{key}:{float(value):.6g}" for key, value in items)
+
+
+def _format_matrix_mapping(class_order, matrix):
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    matrix = np.asarray(matrix, dtype=float)
+    if class_order.size == 0 or matrix.shape != (class_order.size, class_order.size):
+        return ""
+    labels_one_based = class_order + 1
+    return _format_float_mapping(
+        (
+            _true_predicted_pair_key(true_label, predicted_label),
+            matrix[true_index, predicted_index],
+        )
+        for true_index, true_label in enumerate(labels_one_based)
+        for predicted_index, predicted_label in enumerate(labels_one_based)
+        if matrix[true_index, predicted_index] > 0.0
+    )
 
 
 def _row_semicolon_value_counts(rows, key):

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -25,6 +25,7 @@ INNER_SCORE_CALIBRATION_MODES = frozenset(
         "inner_class_affine",
         "inner_rank_bias",
         "inner_probability_map",
+        "inner_confusion_blend",
     )
 )
 TRAIN_SCORE_CALIBRATION_MODES = frozenset(
@@ -39,6 +40,7 @@ SCORE_CALIBRATION_MODES = (
     "inner_class_affine",
     "inner_rank_bias",
     "inner_probability_map",
+    "inner_confusion_blend",
     "train_class_bias",
     "train_class_affine",
     "train_rank_bias",
@@ -58,6 +60,10 @@ EXTENDED_FEATURE_MODES = (
 SCORE_CALIBRATION_L2 = 1e-3
 SCORE_CALIBRATION_PROBABILITY_MAP_L2 = 1e-2
 SCORE_CALIBRATION_PROBABILITY_MAP_IDENTITY_BLEND = 0.20
+CONFUSION_CALIBRATION_SMOOTHING = 1.0
+CONFUSION_CALIBRATION_BLEND_GRID = tuple(
+    float(value) for value in np.linspace(0.0, 1.0, 11)
+)
 
 _impl = None
 _BaseConfig = None
@@ -542,6 +548,19 @@ def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_
         return _probability_map_metadata(
             mode, class_order, probability_map, inner_balanced
         )
+    if mode == "inner_confusion_blend":
+        confusion_matrix, blend_alpha, inner_balanced = _fit_confusion_blend(
+            scores, labels, class_order
+        )
+        return {
+            "mode": mode,
+            "classes": class_order,
+            "confusion_matrix": confusion_matrix,
+            "blend_alpha": blend_alpha,
+            "inner_balanced_accuracy": inner_balanced,
+            "calibration_source": "inner_scores",
+            "smoothing": CONFUSION_CALIBRATION_SMOOTHING,
+        }
     score_space = "raw"
     calibration_scores = scores
     if mode == "inner_rank_bias":
@@ -655,6 +674,85 @@ def _fit_probability_map(scores, labels, class_order):
     return probability_map, _balanced_accuracy_for_scores(
         calibrated_scores, labels, class_order
     )
+
+
+def _fit_confusion_blend(scores, labels, class_order):
+    """Fit a source-only predicted-class to true-class re-ranking map."""
+
+    scores = np.asarray(scores, dtype=float)
+    labels = np.asarray(labels, dtype=int)
+    class_order = np.asarray(class_order, dtype=int)
+    confusion_matrix = _confusion_true_given_pred_matrix(
+        scores, labels, class_order
+    )
+    best_alpha = 0.0
+    best_balanced = _balanced_accuracy_for_scores(scores, labels, class_order)
+    for blend_alpha in CONFUSION_CALIBRATION_BLEND_GRID:
+        calibrated_scores = _confusion_blend_scores(
+            scores, confusion_matrix, blend_alpha
+        )
+        balanced = _balanced_accuracy_for_scores(
+            calibrated_scores, labels, class_order
+        )
+        if balanced > best_balanced + 1e-12:
+            best_alpha = float(blend_alpha)
+            best_balanced = balanced
+    return confusion_matrix, best_alpha, best_balanced
+
+
+def _confusion_true_given_pred_matrix(scores, labels, class_order):
+    scores = np.asarray(scores, dtype=float)
+    labels = np.asarray(labels, dtype=int)
+    class_order = np.asarray(class_order, dtype=int)
+    n_classes = int(class_order.shape[0])
+    matrix = CONFUSION_CALIBRATION_SMOOTHING * np.eye(n_classes, dtype=float)
+    if scores.ndim == 2 and scores.shape[0] and scores.shape[1] == n_classes:
+        predictions = class_order[np.argmax(scores, axis=1)]
+        class_to_column = {
+            int(label): column for column, label in enumerate(class_order.tolist())
+        }
+        for predicted_label, true_label in zip(predictions, labels, strict=True):
+            predicted_column = class_to_column.get(int(predicted_label))
+            true_column = class_to_column.get(int(true_label))
+            if predicted_column is not None and true_column is not None:
+                matrix[predicted_column, true_column] += 1.0
+    row_sums = np.sum(matrix, axis=1, keepdims=True)
+    row_sums = np.where(row_sums > 0.0, row_sums, 1.0)
+    return matrix / row_sums
+
+
+def _confusion_blend_scores(scores, confusion_matrix, blend_alpha):
+    probabilities = _score_probabilities(scores)
+    confusion_matrix = np.asarray(confusion_matrix, dtype=float)
+    blend_alpha = float(np.clip(float(blend_alpha), 0.0, 1.0))
+    corrected = probabilities @ confusion_matrix
+    blended = (1.0 - blend_alpha) * probabilities + blend_alpha * corrected
+    return _probabilities_to_logits(blended)
+
+
+def _score_probabilities(scores):
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2:
+        return np.zeros((0, 0), dtype=float)
+    if scores.shape[1] == 0:
+        return np.zeros_like(scores, dtype=float)
+    row_sums = np.sum(scores, axis=1, keepdims=True)
+    probability_like = (
+        np.all(np.isfinite(scores), axis=1)
+        & np.all(scores >= 0.0, axis=1)
+        & (row_sums.ravel() > 0.0)
+        & np.isclose(row_sums.ravel(), 1.0, rtol=1e-3, atol=1e-6)
+    )
+    probabilities = np.zeros_like(scores, dtype=float)
+    if np.any(probability_like):
+        probabilities[probability_like] = (
+            scores[probability_like] / row_sums[probability_like]
+        )
+    if np.any(~probability_like):
+        probabilities[~probability_like] = _score_softmax_probabilities(
+            scores[~probability_like]
+        )
+    return probabilities
 
 
 def _one_hot_labels(labels, class_order):
@@ -842,6 +940,8 @@ def _has_active_score_calibration_metadata(metadata):
         return False
     if metadata.get("mode") not in ACTIVE_SCORE_CALIBRATION_MODES:
         return False
+    if metadata.get("mode") == "inner_confusion_blend":
+        return "classes" in metadata and "confusion_matrix" in metadata
     return "bias" in metadata or "probability_map" in metadata
 
 
@@ -850,6 +950,16 @@ def _apply_score_calibration(scores, classes, fitted_model):
     if not _has_active_score_calibration_metadata(metadata):
         return scores, classes
     calibration_classes = np.asarray(metadata["classes"], dtype=int)
+    if metadata.get("mode") == "inner_confusion_blend":
+        aligned = _align_class_score_columns(scores, classes, calibration_classes)
+        return (
+            _confusion_blend_scores(
+                aligned,
+                metadata["confusion_matrix"],
+                metadata.get("blend_alpha", 0.0),
+            ),
+            calibration_classes,
+        )
     if "probability_map" in metadata:
         aligned = _align_class_score_columns(scores, classes, calibration_classes)
         probabilities = _score_softmax_probabilities(aligned)
@@ -899,6 +1009,14 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
             "mean_true_label_rank": rank_metrics["mean_true_label_rank"],
             "median_true_label_rank": rank_metrics["median_true_label_rank"],
             "above_chance": bool(balanced_accuracy > outer_row["chance_accuracy"]),
+            "predicted_label_counts": _impl._format_counter(
+                Counter((np.asarray(predictions, dtype=int) + 1).tolist())
+            ),
+            "true_predicted_label_pair_counts": _impl._format_counter(
+                _impl._true_predicted_label_pair_counts(
+                    np.asarray(test_set.labels, dtype=int), predictions
+                )
+            ),
             "alignment_test_transform": test_alignment_metadata.get("test_transform", ""),
             "alignment_target_centering": test_alignment_metadata.get("target_centering", ""),
         }
@@ -940,6 +1058,8 @@ def _add_next_fields(row, config, fitted_model):
     row["score_calibration_status"] = metadata.get("status", "")
     row["score_calibration_source"] = metadata.get("calibration_source", "")
     row["score_calibration_source_balanced_accuracy"] = metadata.get("source_balanced_accuracy", "")
+    row["score_calibration_confusion_blend_alpha"] = metadata.get("blend_alpha", "")
+    row["score_calibration_confusion_smoothing"] = metadata.get("smoothing", "")
     row["score_calibration_probability_map_l2"] = metadata.get(
         "probability_map_l2_penalty", ""
     )

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1589,6 +1589,33 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertGreater(blended[1, 0] - blended[1, 2], rank_only[1, 0] - rank_only[1, 2])
         np.testing.assert_allclose(blended, 0.5 * rank_only + 0.5 * row_z)
 
+    def test_inner_confusion_correction_uses_source_validation_confusions(self):
+        class_order = np.asarray([0, 1], dtype=int)
+        selected_rows = [
+            {
+                "selected_inner_true_predicted_label_pair_counts": (
+                    "1001:1;1002:9;2001:9;2002:1"
+                )
+            }
+        ]
+        probabilities = np.asarray([[0.8, 0.2], [0.2, 0.8]], dtype=float)
+
+        metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            selected_rows,
+            class_order,
+            np.ones(1),
+            "rank_softmax_inner_confusion",
+        )
+        adjusted = cross_subject._apply_inner_confusion_correction(  # pylint: disable=protected-access
+            probabilities,
+            metadata,
+        )
+
+        self.assertEqual(metadata["mode"], "rank_softmax_inner_confusion")
+        self.assertGreater(adjusted[0, 1], probabilities[0, 1])
+        self.assertGreater(adjusted[1, 0], probabilities[1, 0])
+        np.testing.assert_allclose(np.sum(adjusted, axis=1), np.ones(2))
+
     def test_nested_cross_subject_can_evaluate_outer_subset(self):
         data_by_participant = {
             1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -189,6 +189,21 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(len(configs), 1)
         self.assertEqual(configs[0].score_calibration, "inner_probability_map")
 
+    def test_candidate_grid_accepts_inner_confusion_blend_score_calibration(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            score_calibrations=("inner_confusion_blend",),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 1)
+        self.assertEqual(configs[0].score_calibration, "inner_confusion_blend")
+
     def test_candidate_grid_accepts_train_score_calibration_modes(self):
         configs = make_cross_subject_candidate_configs(
             window_centers=(0.175,),
@@ -306,6 +321,41 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_allclose(np.sum(metadata["probability_map"], axis=1), np.ones(2))
         self.assertTrue(np.isfinite(metadata["inner_balanced_accuracy"]))
 
+    def test_inner_confusion_blend_score_calibration_fits_source_fold_metadata(self):
+        time = np.asarray([-0.1, 0.0, 0.1, 0.2], dtype=float)
+        labels = [1, 2, 1, 2]
+        data_by_participant = {
+            1: mat_data_from_trials(labels, [[[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]], [[-0.9, -0.9, -0.9, -0.9]], [[0.9, 0.9, 0.9, 0.9]]], time),
+            2: mat_data_from_trials(labels, [[[-1.1, -1.1, -1.1, -1.1]], [[1.1, 1.1, 1.1, 1.1]], [[-1.0, -1.0, -1.0, -1.0]], [[1.0, 1.0, 1.0, 1.0]]], time),
+            3: mat_data_from_trials(labels, [[[-1.2, -1.2, -1.2, -1.2]], [[1.2, 1.2, 1.2, 1.2]], [[-1.1, -1.1, -1.1, -1.1]], [[1.1, 1.1, 1.1, 1.1]]], time),
+        }
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_mean",
+            normalization="none",
+            classifier="multinomial-logistic",
+            classifier_param=1.0,
+            components_pca=float("inf"),
+            score_calibration="inner_confusion_blend",
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            train_sets = [load_participant_stimulus_features("unused", participant, config=config) for participant in (1, 2, 3)]
+
+        fitted_model = cross_subject._fit_outer_fold_model(train_sets, config, 1.0)  # pylint: disable=protected-access
+        metadata = fitted_model["score_calibration_metadata"]
+
+        self.assertEqual(metadata["mode"], "inner_confusion_blend")
+        self.assertEqual(metadata["calibration_source"], "inner_scores")
+        np.testing.assert_array_equal(metadata["classes"], np.asarray([0, 1]))
+        self.assertEqual(metadata["confusion_matrix"].shape, (2, 2))
+        np.testing.assert_allclose(np.sum(metadata["confusion_matrix"], axis=1), np.ones(2))
+        self.assertGreaterEqual(metadata["blend_alpha"], 0.0)
+        self.assertLessEqual(metadata["blend_alpha"], 1.0)
+        self.assertTrue(np.isfinite(metadata["inner_balanced_accuracy"]))
+
     def test_train_class_bias_score_calibration_fits_source_metadata(self):
         time = np.asarray([-0.1, 0.0, 0.1, 0.2], dtype=float)
         labels = [1, 2, 1, 2]
@@ -399,6 +449,29 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_array_equal(classes, np.asarray([0, 1]))
         np.testing.assert_array_equal(np.argmax(calibrated, axis=1), np.asarray([1, 0]))
         np.testing.assert_allclose(np.sum(np.exp(calibrated), axis=1), np.ones(2))
+
+    def test_inner_confusion_blend_score_calibration_applies_confusion_matrix(self):
+        scores = np.asarray([[4.0, 1.0], [1.0, 4.0]], dtype=float)
+        fitted_model = {
+            "score_calibration_metadata": {
+                "mode": "inner_confusion_blend",
+                "classes": np.asarray([0, 1]),
+                "confusion_matrix": np.asarray(
+                    [[0.0, 1.0], [1.0, 0.0]], dtype=float
+                ),
+                "blend_alpha": 1.0,
+            }
+        }
+
+        calibrated, classes = cross_subject._apply_score_calibration(  # pylint: disable=protected-access
+            scores,
+            np.asarray([0, 1]),
+            fitted_model,
+        )
+
+        np.testing.assert_array_equal(classes, np.asarray([0, 1]))
+        self.assertGreater(calibrated[0, 1], calibrated[0, 0])
+        self.assertGreater(calibrated[1, 0], calibrated[1, 1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add inner-confusion ensemble score normalization variants and metadata
- add inner_confusion_blend score calibration for next cross-subject workflows
- expose the new BUSH matrix workflow bundles

## Validation
- python -m py_compile src\\pymegdec\\_stimulus_cross_subject_legacy.py src\\pymegdec\\_stimulus_cross_subject_next.py
- python -m ruff check src\\pymegdec\\_stimulus_cross_subject_legacy.py src\\pymegdec\\_stimulus_cross_subject_next.py tests\\test_stimulus_cross_subject.py tests\\test_stimulus_cross_subject_next.py
- git diff --check

Tests not run per request.