### PR TITLE
Add rank probability map calibration

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -40,6 +40,7 @@ on:
           - windowed_logreg_175_bias_calibration
           - windowed_logreg_175_rank_bias_calibration
           - windowed_logreg_175_probability_map
+          - windowed_logreg_175_rank_probability_map
           - windowed_logreg_175_confusion_blend
           - windowed_logreg_175_train_scorecal
           - windowed_logreg_lean_reciprocal_inner_prior
@@ -386,6 +387,24 @@ jobs:
                   "components_pca_values": "128",
                   "sample_weightings": "none",
                   "score_calibrations": "none,inner_probability_map",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_rank_probability_map": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_rank_probability_map",
                   "alignment_alphas": "1.0",
                   "selection_metric": "balanced_top2_top3_rank_lcb",
                   "selection_ensemble_size": "3",

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -106,6 +106,8 @@ INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_top3_vote_inner_confusion": "rank_top3_vote",
     "rank_z_blend_inner_confusion": "rank_z_blend",
 }
+INNER_CONFUSION_CORRECTION_SMOOTHING = 1.0
+INNER_CONFUSION_CORRECTION_IDENTITY_BLEND = 0.20
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
     "window",
@@ -1515,6 +1517,9 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=DEFAULT_CROSS_SUBJEC
         inner_true_predicted_label_pair_counts = _sum_formatted_counters(
             candidate_rows, "true_predicted_label_pair_counts"
         )
+        inner_confusion_counts = _sum_formatted_confusion_counters(
+            candidate_rows, "confusion_counts"
+        )
         chance_mean_rank = float(example.get("chance_mean_rank", 0.5 * (example.get("chance_classes", DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES) + 1)))
         summary = {
             "selection_mode": "nested_loso",
@@ -1547,6 +1552,9 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=DEFAULT_CROSS_SUBJEC
             "selected_inner_predicted_label_counts": _format_counter(inner_predicted_label_counts),
             "selected_inner_true_predicted_label_pair_counts": _format_counter(
                 inner_true_predicted_label_pair_counts
+            ),
+            "selected_inner_confusion_counts": _format_confusion_counter(
+                inner_confusion_counts
             ),
             "selected_window_center_s": example["window_center_s"],
             "selected_window_size_s": example["window_size_s"],
@@ -1702,6 +1710,9 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
     true_predicted_label_pair_counts = _true_predicted_label_pair_counts(
         test_labels_one_based, predictions
     )
+    fold_confusion_counts = _confusion_counter(
+        test_labels_one_based, np.asarray(predictions, dtype=int) + 1
+    )
 
     outer_row = {
         "outer_fold": int(test_set.participant),
@@ -1747,6 +1758,7 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
         "true_predicted_label_pair_counts": _format_counter(
             true_predicted_label_pair_counts
         ),
+        "confusion_counts": _format_confusion_counter(fold_confusion_counts),
         "classifier": config.classifier,
         "classifier_param": fitted_model["classifier_param"],
         "components_pca": config.components_pca,
@@ -1829,6 +1841,9 @@ def _score_outer_fold_ensemble_models(
     true_predicted_label_pair_counts = _true_predicted_label_pair_counts(
         test_labels + 1, predictions
     )
+    fold_confusion_counts = _confusion_counter(
+        reference_test_set.labels, np.asarray(predictions, dtype=int) + 1
+    )
     rank_metrics = _ranked_label_metrics(test_labels, ensemble_probabilities, class_order)
     accuracy = float(accuracy_score(test_labels, predictions))
     balanced_accuracy = float(balanced_accuracy_score(test_labels, predictions))
@@ -1855,6 +1870,7 @@ def _score_outer_fold_ensemble_models(
             "true_predicted_label_pair_counts": _format_counter(
                 true_predicted_label_pair_counts
             ),
+            "confusion_counts": _format_confusion_counter(fold_confusion_counts),
         }
     )
     _add_ensemble_output_fields(
@@ -2236,16 +2252,26 @@ def _inner_confusion_correction_metadata(
     weights = _normalized_ensemble_weights(weights, len(selected_rows))
     counts = np.zeros((class_order.shape[0], class_order.shape[0]), dtype=float)
     for row, weight in zip(selected_rows, weights):
-        counts += float(weight) * _true_predicted_pair_count_matrix(
+        row_counts = _true_predicted_pair_count_matrix(
             row.get("selected_inner_true_predicted_label_pair_counts", ""),
             labels_one_based,
         )
+        if not np.any(row_counts > 0.0):
+            row_counts = _confusion_counter_matrix(
+                _parse_confusion_counter(row.get("selected_inner_confusion_counts", "")),
+                labels_one_based,
+            )
+        counts += float(weight) * row_counts
 
     if not np.any(counts > 0.0):
-        return {"mode": "skipped_missing_inner_confusion_counts"}
+        return {
+            "mode": score_normalization,
+            "status": "skipped_missing_inner_confusion_counts",
+        }
 
-    smoothing = 1.0
-    blend = 0.35
+    smoothing = float(INNER_CONFUSION_CORRECTION_SMOOTHING)
+    identity_blend = float(INNER_CONFUSION_CORRECTION_IDENTITY_BLEND)
+    blend = 1.0
     smoothed = counts + smoothing
     predicted_totals = np.sum(smoothed, axis=0, keepdims=True)
     true_given_predicted = np.divide(
@@ -2254,10 +2280,23 @@ def _inner_confusion_correction_metadata(
         out=np.full_like(smoothed, 1.0 / smoothed.shape[0]),
         where=predicted_totals > 0.0,
     )
+    true_given_predicted = (
+        (1.0 - identity_blend) * true_given_predicted
+        + identity_blend * np.eye(class_order.shape[0], dtype=float)
+    )
+    posterior_totals = np.sum(true_given_predicted, axis=0, keepdims=True)
+    true_given_predicted = np.divide(
+        true_given_predicted,
+        posterior_totals,
+        out=np.full_like(true_given_predicted, 1.0 / true_given_predicted.shape[0]),
+        where=posterior_totals > 0.0,
+    )
     return {
         "mode": score_normalization,
+        "status": "applied",
         "smoothing": smoothing,
         "blend": blend,
+        "identity_blend": identity_blend,
         "class_order": class_order,
         "true_predicted_counts": counts,
         "true_given_predicted": true_given_predicted,
@@ -2286,12 +2325,26 @@ def _apply_inner_confusion_correction(probabilities, metadata):
 
 def _add_inner_confusion_correction_fields(row, metadata):
     row["ensemble_inner_confusion_correction"] = metadata.get("mode", "none")
+    row["ensemble_inner_confusion_status"] = metadata.get("status", "")
     row["ensemble_inner_confusion_smoothing"] = metadata.get("smoothing", "")
     row["ensemble_inner_confusion_blend"] = metadata.get("blend", "")
+    row["ensemble_inner_confusion_identity_blend"] = metadata.get(
+        "identity_blend", ""
+    )
     row["ensemble_inner_confusion_true_predicted_counts"] = _format_matrix_mapping(
         metadata.get("class_order", ()),
         metadata.get("true_predicted_counts", ()),
     )
+    confusion = np.asarray(metadata.get("true_predicted_counts", ()), dtype=float)
+    total = float(np.sum(confusion)) if confusion.ndim == 2 and confusion.size else np.nan
+    if np.isfinite(total) and total > 0.0:
+        row["ensemble_inner_confusion_total"] = total
+        row["ensemble_inner_confusion_diagonal_fraction"] = float(
+            np.trace(confusion) / total
+        )
+    else:
+        row["ensemble_inner_confusion_total"] = ""
+        row["ensemble_inner_confusion_diagonal_fraction"] = ""
 
 
 def _add_balanced_quota_fields(row, metadata):
@@ -2836,6 +2889,74 @@ def _percent_sem_or_nan(values):
 
 def _format_counter(counter):
     return ";".join(f"{key}:{counter[key]}" for key in sorted(counter))
+
+
+def _confusion_counter(true_labels_one_based, predicted_labels_one_based):
+    true_labels = np.asarray(true_labels_one_based, dtype=int).ravel()
+    predicted_labels = np.asarray(predicted_labels_one_based, dtype=int).ravel()
+    if true_labels.shape[0] != predicted_labels.shape[0]:
+        raise ValueError(
+            "true and predicted labels must have the same length for confusion counting."
+        )
+    counter: Counter[tuple[int, int]] = Counter()
+    for true_label, predicted_label in zip(true_labels, predicted_labels):
+        counter[(int(true_label), int(predicted_label))] += 1
+    return counter
+
+
+def _format_confusion_counter(counter):
+    return ";".join(
+        f"{int(true_label)}>{int(predicted_label)}:{_format_compact_count(count)}"
+        for (true_label, predicted_label), count in sorted(counter.items())
+    )
+
+
+def _format_compact_count(value):
+    value = float(value)
+    rounded = int(round(value))
+    if abs(value - rounded) <= 1e-9:
+        return str(rounded)
+    return f"{value:.6g}"
+
+
+def _parse_confusion_counter(value):
+    counter: Counter[tuple[int, int]] = Counter()
+    if value in (None, ""):
+        return counter
+    for token in str(value).split(";"):
+        token = token.strip()
+        if not token or ":" not in token or ">" not in token:
+            continue
+        pair, count = token.rsplit(":", 1)
+        true_label, predicted_label = pair.split(">", 1)
+        try:
+            counter[(int(true_label), int(predicted_label))] += float(count)
+        except ValueError:
+            continue
+    return counter
+
+
+def _sum_formatted_confusion_counters(rows, key):
+    counter: Counter[tuple[int, int]] = Counter()
+    for row in rows:
+        counter.update(_parse_confusion_counter(row.get(key, "")))
+    return counter
+
+
+def _confusion_counter_matrix(counter, labels_one_based):
+    labels_one_based = np.asarray(labels_one_based, dtype=int).ravel()
+    label_to_index = {
+        int(label): index for index, label in enumerate(labels_one_based.tolist())
+    }
+    matrix = np.zeros(
+        (labels_one_based.shape[0], labels_one_based.shape[0]), dtype=float
+    )
+    for (true_label, predicted_label), count in counter.items():
+        true_index = label_to_index.get(int(true_label))
+        predicted_index = label_to_index.get(int(predicted_label))
+        if true_index is not None and predicted_index is not None:
+            matrix[true_index, predicted_index] += float(count)
+    return matrix
 
 
 def _parse_formatted_counter(value):

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -25,6 +25,7 @@ INNER_SCORE_CALIBRATION_MODES = frozenset(
         "inner_class_affine",
         "inner_rank_bias",
         "inner_probability_map",
+        "inner_rank_probability_map",
         "inner_confusion_blend",
     )
 )
@@ -40,6 +41,7 @@ SCORE_CALIBRATION_MODES = (
     "inner_class_affine",
     "inner_rank_bias",
     "inner_probability_map",
+    "inner_rank_probability_map",
     "inner_confusion_blend",
     "train_class_bias",
     "train_class_affine",
@@ -541,12 +543,18 @@ def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_
         all_labels.append(np.asarray(validation_set.labels, dtype=int) - 1)
     scores = np.vstack(all_scores)
     labels = np.concatenate(all_labels)
-    if mode == "inner_probability_map":
+    if mode in {"inner_probability_map", "inner_rank_probability_map"}:
+        score_space = "rank" if mode == "inner_rank_probability_map" else "raw"
+        map_scores = _rank_score_matrix(scores) if score_space == "rank" else scores
         probability_map, inner_balanced = _fit_probability_map(
-            scores, labels, class_order
+            map_scores, labels, class_order
         )
         return _probability_map_metadata(
-            mode, class_order, probability_map, inner_balanced
+            mode,
+            class_order,
+            probability_map,
+            inner_balanced,
+            score_space=score_space,
         )
     if mode == "inner_confusion_blend":
         confusion_matrix, blend_alpha, inner_balanced = _fit_confusion_blend(
@@ -631,9 +639,12 @@ def _config_with(config, **updates):
     return CrossSubjectStimulusConfig(**kwargs)
 
 
-def _probability_map_metadata(mode, class_order, probability_map, inner_balanced):
+def _probability_map_metadata(
+    mode, class_order, probability_map, inner_balanced, *, score_space="raw"
+):
     return {
         "mode": mode,
+        "score_space": score_space,
         "classes": np.asarray(class_order, dtype=int),
         "probability_map": np.asarray(probability_map, dtype=float),
         "inner_balanced_accuracy": inner_balanced,
@@ -962,6 +973,8 @@ def _apply_score_calibration(scores, classes, fitted_model):
         )
     if "probability_map" in metadata:
         aligned = _align_class_score_columns(scores, classes, calibration_classes)
+        if metadata.get("score_space") == "rank":
+            aligned = _rank_score_matrix(aligned)
         probabilities = _score_softmax_probabilities(aligned)
         probability_map = _row_normalize_probabilities(
             np.maximum(np.asarray(metadata["probability_map"], dtype=float), 0.0)
@@ -993,6 +1006,8 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
     class_scores, score_classes = _apply_score_calibration(class_scores, score_classes, fitted_model)
     test_labels = np.asarray(test_set.labels, dtype=int) - 1
     predictions = np.asarray(score_classes, dtype=int)[np.argmax(class_scores, axis=1)]
+    true_labels_one_based = np.asarray(test_set.labels, dtype=int)
+    predicted_labels_one_based = np.asarray(predictions, dtype=int) + 1
     rank_metrics = _impl._ranked_label_metrics(test_labels, class_scores, score_classes)
     accuracy = float(_impl.accuracy_score(test_labels, predictions))
     balanced_accuracy = float(_impl.balanced_accuracy_score(test_labels, predictions))
@@ -1010,11 +1025,16 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
             "median_true_label_rank": rank_metrics["median_true_label_rank"],
             "above_chance": bool(balanced_accuracy > outer_row["chance_accuracy"]),
             "predicted_label_counts": _impl._format_counter(
-                Counter((np.asarray(predictions, dtype=int) + 1).tolist())
+                Counter(predicted_labels_one_based.tolist())
             ),
             "true_predicted_label_pair_counts": _impl._format_counter(
                 _impl._true_predicted_label_pair_counts(
-                    np.asarray(test_set.labels, dtype=int), predictions
+                    true_labels_one_based, predictions
+                )
+            ),
+            "confusion_counts": _impl._format_confusion_counter(
+                _impl._confusion_counter(
+                    true_labels_one_based, predicted_labels_one_based
                 )
             ),
             "alignment_test_transform": test_alignment_metadata.get("test_transform", ""),

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1,6 +1,7 @@
 import re
 import tempfile
 import unittest
+from collections import Counter
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1615,6 +1616,50 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertGreater(adjusted[0, 1], probabilities[0, 1])
         self.assertGreater(adjusted[1, 0], probabilities[1, 0])
         np.testing.assert_allclose(np.sum(adjusted, axis=1), np.ones(2))
+
+    def test_confusion_counter_round_trips_pair_counts(self):
+        counter = Counter({(1, 2): 3, (2, 1): 1})
+
+        parsed = cross_subject._parse_confusion_counter(  # pylint: disable=protected-access
+            cross_subject._format_confusion_counter(counter)  # pylint: disable=protected-access
+        )
+
+        self.assertEqual(parsed[(1, 2)], 3.0)
+        self.assertEqual(parsed[(2, 1)], 1.0)
+
+    def test_inner_confusion_normalization_maps_to_base_rank_mode(self):
+        self.assertIn(
+            "rank_reciprocal_inner_confusion",
+            cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+        )
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(  # pylint: disable=protected-access
+                "rank_reciprocal_inner_confusion"
+            ),
+            "rank_reciprocal",
+        )
+
+    def test_inner_confusion_correction_uses_source_validation_map(self):
+        selected_rows = (
+            {
+                "selected_inner_confusion_counts": "1>1:1;1>2:9;2>1:9;2>2:1",
+            },
+        )
+
+        metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            selected_rows,
+            np.asarray([0, 1], dtype=int),
+            np.asarray([1.0], dtype=float),
+            "rank_softmax_inner_confusion",
+        )
+        corrected = cross_subject._apply_inner_confusion_correction(  # pylint: disable=protected-access
+            np.asarray([[0.8, 0.2]], dtype=float),
+            metadata,
+        )
+
+        self.assertEqual(metadata["mode"], "rank_softmax_inner_confusion")
+        self.assertGreater(corrected[0, 1], corrected[0, 0])
+        self.assertAlmostEqual(float(np.sum(corrected[0])), 1.0)
 
     def test_nested_cross_subject_can_evaluate_outer_subset(self):
         data_by_participant = {

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -182,12 +182,15 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
             classifiers=("multinomial-logistic",),
             classifier_params=(1.0,),
             components_pca_values=(64,),
-            score_calibrations=("inner_probability_map",),
+            score_calibrations=("inner_probability_map", "inner_rank_probability_map"),
             chance_classes=2,
         )
 
-        self.assertEqual(len(configs), 1)
-        self.assertEqual(configs[0].score_calibration, "inner_probability_map")
+        self.assertEqual(len(configs), 2)
+        self.assertEqual(
+            {config.score_calibration for config in configs},
+            {"inner_probability_map", "inner_rank_probability_map"},
+        )
 
     def test_candidate_grid_accepts_inner_confusion_blend_score_calibration(self):
         configs = make_cross_subject_candidate_configs(
@@ -449,6 +452,35 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_array_equal(classes, np.asarray([0, 1]))
         np.testing.assert_array_equal(np.argmax(calibrated, axis=1), np.asarray([1, 0]))
         np.testing.assert_allclose(np.sum(np.exp(calibrated), axis=1), np.ones(2))
+
+    def test_rank_probability_map_score_calibration_uses_rank_space(self):
+        scores = np.asarray([[100.0, 99.0, 0.0], [1.0, 0.0, 100.0]], dtype=float)
+        fitted_model = {
+            "score_calibration_metadata": {
+                "mode": "inner_rank_probability_map",
+                "score_space": "rank",
+                "classes": np.asarray([0, 1, 2]),
+                "probability_map": np.eye(3, dtype=float),
+            }
+        }
+
+        calibrated, classes = cross_subject._apply_score_calibration(  # pylint: disable=protected-access
+            scores,
+            np.asarray([0, 1, 2]),
+            fitted_model,
+        )
+
+        rank_scores = np.asarray(
+            [[0.0, -1.0, -2.0], [-1.0, -2.0, 0.0]], dtype=float
+        )
+        centered = rank_scores - np.mean(rank_scores, axis=1, keepdims=True)
+        centered /= np.std(centered, axis=1, keepdims=True)
+        probabilities = np.exp(centered - np.max(centered, axis=1, keepdims=True))
+        probabilities /= np.sum(probabilities, axis=1, keepdims=True)
+        expected = np.log(probabilities)
+
+        np.testing.assert_array_equal(classes, np.asarray([0, 1, 2]))
+        np.testing.assert_allclose(calibrated, expected)
 
     def test_inner_confusion_blend_score_calibration_applies_confusion_matrix(self):
         scores = np.asarray([[4.0, 1.0], [1.0, 4.0]], dtype=float)


### PR DESCRIPTION
## Summary
- add inner_rank_probability_map score calibration using rank-space probability maps
- expose the rank probability-map BUSH matrix bundle
- add confusion-count diagnostics alongside inner-confusion correction metadata

## Validation
- python -m py_compile src\\pymegdec\\_stimulus_cross_subject_legacy.py src\\pymegdec\\_stimulus_cross_subject_next.py
- python -m ruff check src\\pymegdec\\_stimulus_cross_subject_legacy.py src\\pymegdec\\_stimulus_cross_subject_next.py tests\\test_stimulus_cross_subject.py tests\\test_stimulus_cross_subject_next.py
- git diff --check origin/main..HEAD

Tests not run per request.