### PR TITLE
Add guarded and quota calibration modes

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -31,6 +31,8 @@ on:
           - windowed_logreg_lean_rankaware
           - windowed_logreg_lean_rankaware_reciprocal
           - windowed_logreg_lean_rankaware_reciprocal_inner_prior
+          - windowed_logreg_lean_ranksoft_t2
+          - windowed_logreg_lean_ranksoft_t3
           - windowed_logreg_lean_rankaware_top2vote
           - windowed_logreg_lean_rankaware_top3vote
           - windowed_logreg_lean_rankaware_top2vote_inner_prior
@@ -42,15 +44,21 @@ on:
           - windowed_logreg_175_probability_map
           - windowed_logreg_175_rank_probability_map
           - windowed_logreg_175_confusion_blend
+          - windowed_logreg_175_margin_confusion_blend
+          - windowed_logreg_175_guarded_calibration
           - windowed_logreg_175_train_scorecal
           - windowed_logreg_lean_reciprocal_inner_prior
           - windowed_logreg_lean_inner_prior
+          - windowed_logreg_lean_inner_prior_quota
           - windowed_logreg_lean_inner_confusion
+          - windowed_logreg_lean_inner_confusion_quota
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
           - windowed_logreg_175_inner_prior
+          - windowed_logreg_175_inner_prior_quota
           - windowed_logreg_175_inner_confusion
+          - windowed_logreg_175_inner_confusion_quota
           - windowed_logreg_175_reciprocal_inner_prior
           - windowed_logreg_core
           - feature_check
@@ -78,18 +86,32 @@ on:
           - bundle-default
           - row_z_softmax
           - rank_softmax
+          - rank_softmax_t2
+          - rank_softmax_t3
           - rank_reciprocal
           - rank_top2_vote
           - rank_top3_vote
           - rank_z_blend
           - rank_softmax_balanced_quota
+          - rank_softmax_t2_balanced_quota
+          - rank_softmax_t3_balanced_quota
           - rank_z_blend_balanced_quota
+          - rank_softmax_inner_balanced_balanced_quota
+          - rank_reciprocal_inner_balanced_balanced_quota
+          - rank_z_blend_inner_balanced_balanced_quota
+          - rank_softmax_inner_confusion_balanced_quota
+          - rank_reciprocal_inner_confusion_balanced_quota
+          - rank_z_blend_inner_confusion_balanced_quota
           - rank_softmax_inner_balanced
+          - rank_softmax_t2_inner_balanced
+          - rank_softmax_t3_inner_balanced
           - rank_reciprocal_inner_balanced
           - rank_top2_vote_inner_balanced
           - rank_top3_vote_inner_balanced
           - rank_z_blend_inner_balanced
           - rank_softmax_inner_confusion
+          - rank_softmax_t2_inner_confusion
+          - rank_softmax_t3_inner_confusion
           - rank_reciprocal_inner_confusion
           - rank_top2_vote_inner_confusion
           - rank_top3_vote_inner_confusion
@@ -253,6 +275,36 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_reciprocal_inner_balanced",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_ranksoft_t2": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t2",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_ranksoft_t3": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t3",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -431,6 +483,42 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_margin_confusion_blend": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_margin_confusion_blend",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_guarded_calibration": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_class_bias_guarded,inner_rank_bias_guarded,inner_probability_map_guarded,inner_confusion_blend_guarded",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_train_scorecal": {
                   "window_centers": "0.175",
                   "feature_modes": "sensor_flat",
@@ -476,6 +564,20 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_lean_inner_prior_quota": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_balanced_balanced_quota",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_lean_inner_confusion": {
                   "window_centers": "0.175,0.200",
                   "feature_modes": "sensor_flat",
@@ -487,6 +589,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_confusion",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_inner_confusion_quota": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_balanced_quota",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -504,6 +620,20 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_inner_prior_quota": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_balanced_balanced_quota",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_inner_confusion": {
                   "window_centers": "0.175",
                   "feature_modes": "sensor_flat",
@@ -515,6 +645,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_confusion",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_inner_confusion_quota": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_balanced_quota",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -75,18 +75,32 @@ SELECTION_ENSEMBLE_WEIGHTING_MODES = (
 ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "row_z_softmax",
     "rank_softmax",
+    "rank_softmax_t2",
+    "rank_softmax_t3",
     "rank_reciprocal",
     "rank_top2_vote",
     "rank_top3_vote",
     "rank_z_blend",
     "rank_softmax_balanced_quota",
+    "rank_softmax_t2_balanced_quota",
+    "rank_softmax_t3_balanced_quota",
     "rank_z_blend_balanced_quota",
+    "rank_softmax_inner_balanced_balanced_quota",
+    "rank_reciprocal_inner_balanced_balanced_quota",
+    "rank_z_blend_inner_balanced_balanced_quota",
+    "rank_softmax_inner_confusion_balanced_quota",
+    "rank_reciprocal_inner_confusion_balanced_quota",
+    "rank_z_blend_inner_confusion_balanced_quota",
     "rank_softmax_inner_balanced",
+    "rank_softmax_t2_inner_balanced",
+    "rank_softmax_t3_inner_balanced",
     "rank_reciprocal_inner_balanced",
     "rank_top2_vote_inner_balanced",
     "rank_top3_vote_inner_balanced",
     "rank_z_blend_inner_balanced",
     "rank_softmax_inner_confusion",
+    "rank_softmax_t2_inner_confusion",
+    "rank_softmax_t3_inner_confusion",
     "rank_reciprocal_inner_confusion",
     "rank_top2_vote_inner_confusion",
     "rank_top3_vote_inner_confusion",
@@ -94,6 +108,8 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
 )
 INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_inner_balanced": "rank_softmax",
+    "rank_softmax_t2_inner_balanced": "rank_softmax_t2",
+    "rank_softmax_t3_inner_balanced": "rank_softmax_t3",
     "rank_reciprocal_inner_balanced": "rank_reciprocal",
     "rank_top2_vote_inner_balanced": "rank_top2_vote",
     "rank_top3_vote_inner_balanced": "rank_top3_vote",
@@ -101,6 +117,8 @@ INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
 }
 INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_inner_confusion": "rank_softmax",
+    "rank_softmax_t2_inner_confusion": "rank_softmax_t2",
+    "rank_softmax_t3_inner_confusion": "rank_softmax_t3",
     "rank_reciprocal_inner_confusion": "rank_reciprocal",
     "rank_top2_vote_inner_confusion": "rank_top2_vote",
     "rank_top3_vote_inner_confusion": "rank_top3_vote",
@@ -108,6 +126,11 @@ INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
 }
 INNER_CONFUSION_CORRECTION_SMOOTHING = 1.0
 INNER_CONFUSION_CORRECTION_IDENTITY_BLEND = 0.20
+RANK_SOFTMAX_TEMPERATURES = {
+    "rank_softmax": 1.0,
+    "rank_softmax_t2": 2.0,
+    "rank_softmax_t3": 3.0,
+}
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
     "window",
@@ -1965,8 +1988,8 @@ def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJ
     score_normalization = _base_ensemble_score_normalization(score_normalization)
     if score_normalization == "row_z_softmax":
         return _row_softmax_probabilities(scores)
-    if score_normalization == "rank_softmax":
-        return _rank_softmax_probabilities(scores)
+    if score_normalization in RANK_SOFTMAX_TEMPERATURES:
+        return _rank_softmax_probabilities(scores, temperature=RANK_SOFTMAX_TEMPERATURES[score_normalization])
     if score_normalization == "rank_reciprocal":
         return _rank_reciprocal_probabilities(scores)
     if score_normalization == "rank_top2_vote":
@@ -1978,7 +2001,7 @@ def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJ
     raise ValueError(f"Unsupported ensemble score normalization: {score_normalization}")
 
 
-def _rank_softmax_probabilities(scores):
+def _rank_softmax_probabilities(scores, *, temperature=1.0):
     scores = np.asarray(scores, dtype=float)
     if scores.ndim != 2 or scores.shape[1] == 0:
         raise ValueError("Nested score ensembling requires a non-empty two-dimensional class-score matrix.")
@@ -1988,11 +2011,14 @@ def _rank_softmax_probabilities(scores):
         if not np.any(finite):
             probabilities[row_index] = np.full(row.shape[0], 1.0 / row.shape[0], dtype=float)
             continue
+        temperature = float(temperature)
+        if temperature <= 0.0 or not np.isfinite(temperature):
+            raise ValueError("rank_softmax temperature must be a positive finite value.")
         rank_scores = np.where(finite, row, -np.inf)
         descending_columns = np.argsort(-rank_scores, kind="mergesort")
         ranks = np.empty(row.shape[0], dtype=float)
         ranks[descending_columns] = np.arange(row.shape[0], dtype=float)
-        logits = -ranks
+        logits = -ranks / temperature
         logits[~finite] = -50.0
         exp_logits = np.exp(logits - np.max(logits))
         probabilities[row_index] = exp_logits / np.sum(exp_logits)
@@ -2082,21 +2108,46 @@ def _align_score_columns(probabilities, score_classes, class_order):
     return aligned
 
 
-def _base_ensemble_score_normalization(score_normalization):
-    score_normalization = _normalize_ensemble_score_normalization(score_normalization)
+def _without_balanced_quota_suffix(score_normalization):
+    score_normalization = str(score_normalization).strip()
     if score_normalization.endswith("_balanced_quota"):
         return score_normalization.removesuffix("_balanced_quota")
+    return score_normalization
+
+
+def _inner_class_prior_balance_mode(score_normalization):
+    inner_mode = _without_balanced_quota_suffix(score_normalization)
+    return (
+        inner_mode
+        if inner_mode in INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        else None
+    )
+
+
+def _inner_confusion_correction_mode(score_normalization):
+    inner_mode = _without_balanced_quota_suffix(score_normalization)
+    return (
+        inner_mode
+        if inner_mode in INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        else None
+    )
+
+
+def _base_ensemble_score_normalization(score_normalization):
+    score_normalization = _normalize_ensemble_score_normalization(score_normalization)
+    inner_mode = _without_balanced_quota_suffix(score_normalization)
     return INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(
-        score_normalization,
+        inner_mode,
         INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(
-            score_normalization, score_normalization
+            inner_mode, inner_mode
         ),
     )
 
 
 def _inner_class_prior_balance_metadata(selected_rows, class_order, weights, score_normalization):
     score_normalization = _normalize_ensemble_score_normalization(score_normalization)
-    if not score_normalization.endswith("_inner_balanced"):
+    inner_mode = _inner_class_prior_balance_mode(score_normalization)
+    if inner_mode is None:
         return {"mode": "none"}
 
     selected_rows = tuple(selected_rows)
@@ -2122,6 +2173,7 @@ def _inner_class_prior_balance_metadata(selected_rows, class_order, weights, sco
     log_adjustment = np.clip(log_adjustment, -1.5, 1.5)
     return {
         "mode": score_normalization,
+        "inner_mode": inner_mode,
         "smoothing": smoothing,
         "class_order": class_order,
         "target_counts": target_counts,
@@ -2133,7 +2185,7 @@ def _inner_class_prior_balance_metadata(selected_rows, class_order, weights, sco
 def _apply_inner_class_prior_balance(probabilities, metadata):
     probabilities = np.asarray(probabilities, dtype=float)
     if (
-        metadata.get("mode") not in INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        _inner_class_prior_balance_mode(metadata.get("mode")) is None
         or "log_adjustment" not in metadata
     ):
         return probabilities
@@ -2243,7 +2295,8 @@ def _inner_confusion_correction_metadata(
     """Return source-inner confusion metadata for leakage-safe re-ranking."""
 
     score_normalization = _normalize_ensemble_score_normalization(score_normalization)
-    if score_normalization not in INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES:
+    inner_mode = _inner_confusion_correction_mode(score_normalization)
+    if inner_mode is None:
         return {"mode": "none"}
 
     selected_rows = tuple(selected_rows)
@@ -2266,6 +2319,7 @@ def _inner_confusion_correction_metadata(
     if not np.any(counts > 0.0):
         return {
             "mode": score_normalization,
+            "inner_mode": inner_mode,
             "status": "skipped_missing_inner_confusion_counts",
         }
 
@@ -2293,6 +2347,7 @@ def _inner_confusion_correction_metadata(
     )
     return {
         "mode": score_normalization,
+        "inner_mode": inner_mode,
         "status": "applied",
         "smoothing": smoothing,
         "blend": blend,
@@ -2306,7 +2361,7 @@ def _inner_confusion_correction_metadata(
 def _apply_inner_confusion_correction(probabilities, metadata):
     probabilities = np.asarray(probabilities, dtype=float)
     if (
-        metadata.get("mode") not in INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        _inner_confusion_correction_mode(metadata.get("mode")) is None
         or "true_given_predicted" not in metadata
     ):
         return probabilities

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -27,22 +27,36 @@ INNER_SCORE_CALIBRATION_MODES = frozenset(
         "inner_probability_map",
         "inner_rank_probability_map",
         "inner_confusion_blend",
+        "inner_margin_confusion_blend",
     )
+)
+GUARDED_INNER_SCORE_CALIBRATION_MODES = frozenset(
+    f"{mode}_guarded" for mode in INNER_SCORE_CALIBRATION_MODES
 )
 TRAIN_SCORE_CALIBRATION_MODES = frozenset(
     ("train_class_bias", "train_class_affine", "train_rank_bias")
 )
 ACTIVE_SCORE_CALIBRATION_MODES = (
-    INNER_SCORE_CALIBRATION_MODES | TRAIN_SCORE_CALIBRATION_MODES
+    INNER_SCORE_CALIBRATION_MODES
+    | GUARDED_INNER_SCORE_CALIBRATION_MODES
+    | TRAIN_SCORE_CALIBRATION_MODES
 )
 SCORE_CALIBRATION_MODES = (
     "none",
     "inner_class_bias",
+    "inner_class_bias_guarded",
     "inner_class_affine",
+    "inner_class_affine_guarded",
     "inner_rank_bias",
+    "inner_rank_bias_guarded",
     "inner_probability_map",
+    "inner_probability_map_guarded",
     "inner_rank_probability_map",
+    "inner_rank_probability_map_guarded",
     "inner_confusion_blend",
+    "inner_confusion_blend_guarded",
+    "inner_margin_confusion_blend",
+    "inner_margin_confusion_blend_guarded",
     "train_class_bias",
     "train_class_affine",
     "train_rank_bias",
@@ -60,12 +74,14 @@ EXTENDED_FEATURE_MODES = (
     "sensor_time_pyramid_logpower",
 )
 SCORE_CALIBRATION_L2 = 1e-3
+SCORE_CALIBRATION_MIN_INNER_GAIN = 1e-12
 SCORE_CALIBRATION_PROBABILITY_MAP_L2 = 1e-2
 SCORE_CALIBRATION_PROBABILITY_MAP_IDENTITY_BLEND = 0.20
 CONFUSION_CALIBRATION_SMOOTHING = 1.0
 CONFUSION_CALIBRATION_BLEND_GRID = tuple(
     float(value) for value in np.linspace(0.0, 1.0, 11)
 )
+CONFUSION_CALIBRATION_MARGIN_QUANTILES = (0.10, 0.25, 0.50, 0.75, 0.90, 1.0)
 
 _impl = None
 _BaseConfig = None
@@ -133,6 +149,8 @@ def install(impl) -> None:
     impl.SAMPLE_WEIGHTING_MODES = SAMPLE_WEIGHTING_MODES
     impl.DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION = DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION
     impl.SCORE_CALIBRATION_MODES = SCORE_CALIBRATION_MODES
+    impl.GUARDED_INNER_SCORE_CALIBRATION_MODES = GUARDED_INNER_SCORE_CALIBRATION_MODES
+    impl.SCORE_CALIBRATION_MIN_INNER_GAIN = SCORE_CALIBRATION_MIN_INNER_GAIN
     impl.DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA
     impl.EXTENDED_FEATURE_MODES = EXTENDED_FEATURE_MODES
     impl.DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = DEFAULT_SENSOR_TIME_PYRAMID_LEVELS
@@ -150,6 +168,8 @@ def install(impl) -> None:
     impl._score_outer_fold_model = _score_outer_fold_model
     impl._candidate_model_scores = _candidate_model_scores
     impl._apply_score_calibration = _apply_score_calibration
+    impl._score_calibration_base_mode = _score_calibration_base_mode
+    impl._guard_inner_score_calibration_metadata = _guard_inner_score_calibration_metadata
     impl._align_training_features_by_subject = _align_training_features_by_subject
     impl._align_test_features_by_subject = _align_test_features_by_subject
     impl._prediction_rows = _prediction_rows
@@ -186,6 +206,13 @@ def _normalize_score_calibration(value):
     token = str(value).strip().lower().replace("-", "_")
     if token not in SCORE_CALIBRATION_MODES:
         raise ValueError(f"score_calibration must be one of {SCORE_CALIBRATION_MODES}.")
+    return token
+
+
+def _score_calibration_base_mode(value):
+    token = _normalize_score_calibration(value)
+    if token in GUARDED_INNER_SCORE_CALIBRATION_MODES:
+        return token.removesuffix("_guarded")
     return token
 
 
@@ -487,7 +514,9 @@ def _fit_outer_fold_model(train_sets, config, classifier_param, *, label_shuffle
     if feature_transform_metadata is not None:
         fitted_model["feature_transform_metadata"] = feature_transform_metadata
     score_calibration = _normalize_score_calibration(config.score_calibration)
-    if fit_score_calibration and score_calibration in INNER_SCORE_CALIBRATION_MODES:
+    if fit_score_calibration and score_calibration in (
+        INNER_SCORE_CALIBRATION_MODES | GUARDED_INNER_SCORE_CALIBRATION_MODES
+    ):
         fitted_model["score_calibration_metadata"] = _fit_inner_score_calibration(
             train_sets,
             config,
@@ -522,6 +551,8 @@ def _training_sample_weights(train_sets, label_arrays, config):
 
 def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_shuffle_seed=None, label_shuffle_context=()):
     mode = _normalize_score_calibration(getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION))
+    base_mode = _score_calibration_base_mode(mode)
+    guarded = mode in GUARDED_INNER_SCORE_CALIBRATION_MODES
     if len(train_sets) < 3:
         return {"mode": mode, "status": "skipped_not_enough_source_subjects"}
     all_scores = []
@@ -543,38 +574,66 @@ def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_
         all_labels.append(np.asarray(validation_set.labels, dtype=int) - 1)
     scores = np.vstack(all_scores)
     labels = np.concatenate(all_labels)
-    if mode in {"inner_probability_map", "inner_rank_probability_map"}:
-        score_space = "rank" if mode == "inner_rank_probability_map" else "raw"
+    baseline_balanced = _balanced_accuracy_for_scores(scores, labels, class_order)
+    if base_mode in {"inner_probability_map", "inner_rank_probability_map"}:
+        score_space = "rank" if base_mode == "inner_rank_probability_map" else "raw"
         map_scores = _rank_score_matrix(scores) if score_space == "rank" else scores
         probability_map, inner_balanced = _fit_probability_map(
             map_scores, labels, class_order
         )
-        return _probability_map_metadata(
-            mode,
-            class_order,
-            probability_map,
-            inner_balanced,
-            score_space=score_space,
+        return _guard_inner_score_calibration_metadata(
+            _probability_map_metadata(
+                mode,
+                class_order,
+                probability_map,
+                inner_balanced,
+                score_space=score_space,
+            ),
+            baseline_balanced,
+            guarded=guarded,
         )
-    if mode == "inner_confusion_blend":
+    if base_mode == "inner_confusion_blend":
         confusion_matrix, blend_alpha, inner_balanced = _fit_confusion_blend(
             scores, labels, class_order
         )
-        return {
-            "mode": mode,
-            "classes": class_order,
-            "confusion_matrix": confusion_matrix,
-            "blend_alpha": blend_alpha,
-            "inner_balanced_accuracy": inner_balanced,
-            "calibration_source": "inner_scores",
-            "smoothing": CONFUSION_CALIBRATION_SMOOTHING,
-        }
+        return _guard_inner_score_calibration_metadata(
+            {
+                "mode": mode,
+                "classes": class_order,
+                "confusion_matrix": confusion_matrix,
+                "blend_alpha": blend_alpha,
+                "inner_balanced_accuracy": inner_balanced,
+                "calibration_source": "inner_scores",
+                "smoothing": CONFUSION_CALIBRATION_SMOOTHING,
+            },
+            baseline_balanced,
+            guarded=guarded,
+        )
+    if base_mode == "inner_margin_confusion_blend":
+        confusion_matrix, blend_alpha, margin_threshold, inner_balanced = (
+            _fit_margin_confusion_blend(scores, labels, class_order)
+        )
+        return _guard_inner_score_calibration_metadata(
+            {
+                "mode": mode,
+                "classes": class_order,
+                "confusion_matrix": confusion_matrix,
+                "blend_alpha": blend_alpha,
+                "margin_threshold": margin_threshold,
+                "inner_balanced_accuracy": inner_balanced,
+                "calibration_source": "inner_scores",
+                "smoothing": CONFUSION_CALIBRATION_SMOOTHING,
+                "margin_quantiles": CONFUSION_CALIBRATION_MARGIN_QUANTILES,
+            },
+            baseline_balanced,
+            guarded=guarded,
+        )
     score_space = "raw"
     calibration_scores = scores
-    if mode == "inner_rank_bias":
+    if base_mode == "inner_rank_bias":
         score_space = "rank"
         calibration_scores = _rank_score_matrix(scores)
-    if mode == "inner_class_affine":
+    if base_mode == "inner_class_affine":
         bias, scale, inner_balanced = _optimize_class_affine(
             calibration_scores, labels, class_order
         )
@@ -583,15 +642,19 @@ def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_
             calibration_scores, labels, class_order
         )
         scale = np.ones(class_order.shape[0], dtype=float)
-    return {
-        "mode": mode,
-        "score_space": score_space,
-        "classes": class_order,
-        "bias": bias,
-        "scale": scale,
-        "inner_balanced_accuracy": inner_balanced,
-        "l2_penalty": SCORE_CALIBRATION_L2,
-    }
+    return _guard_inner_score_calibration_metadata(
+        {
+            "mode": mode,
+            "score_space": score_space,
+            "classes": class_order,
+            "bias": bias,
+            "scale": scale,
+            "inner_balanced_accuracy": inner_balanced,
+            "l2_penalty": SCORE_CALIBRATION_L2,
+        },
+        baseline_balanced,
+        guarded=guarded,
+    )
 
 
 def _fit_train_score_calibration(model_bundle, train_features, train_labels, config):
@@ -656,6 +719,34 @@ def _probability_map_metadata(
     }
 
 
+def _guard_inner_score_calibration_metadata(metadata, baseline_balanced, *, guarded):
+    """Disable guarded calibration unless source-inner validation improves."""
+
+    metadata = dict(metadata)
+    baseline = float(baseline_balanced)
+    inner_balanced = float(metadata.get("inner_balanced_accuracy", np.nan))
+    metadata["inner_uncalibrated_balanced_accuracy"] = baseline
+    if not guarded:
+        return metadata
+    if (
+        np.isfinite(inner_balanced)
+        and np.isfinite(baseline)
+        and inner_balanced > baseline + SCORE_CALIBRATION_MIN_INNER_GAIN
+    ):
+        metadata.setdefault("status", "applied_guarded_inner_gain")
+        return metadata
+    return {
+        "mode": metadata.get("mode", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION),
+        "status": "skipped_no_inner_gain",
+        "calibration_source": metadata.get("calibration_source", "inner_scores"),
+        "score_calibration_base_mode": _score_calibration_base_mode(
+            metadata.get("mode", "none")
+        ),
+        "inner_balanced_accuracy": inner_balanced,
+        "inner_uncalibrated_balanced_accuracy": baseline,
+    }
+
+
 def _fit_probability_map(scores, labels, class_order):
     """Fit a source-inner probability remapping from probabilities to labels."""
 
@@ -711,6 +802,54 @@ def _fit_confusion_blend(scores, labels, class_order):
     return confusion_matrix, best_alpha, best_balanced
 
 
+def _fit_margin_confusion_blend(scores, labels, class_order):
+    """Fit a confusion re-ranker only for low-margin source-inner trials."""
+
+    scores = np.asarray(scores, dtype=float)
+    labels = np.asarray(labels, dtype=int)
+    class_order = np.asarray(class_order, dtype=int)
+    confusion_matrix = _confusion_true_given_pred_matrix(
+        scores, labels, class_order
+    )
+    probabilities = _score_probabilities(scores)
+    margins = _top2_probability_margins(probabilities)
+    best_alpha = 0.0
+    best_threshold = float("inf")
+    best_balanced = _balanced_accuracy_for_scores(scores, labels, class_order)
+    for margin_threshold in _candidate_margin_thresholds(margins):
+        for blend_alpha in CONFUSION_CALIBRATION_BLEND_GRID:
+            calibrated_scores = _margin_confusion_blend_scores(
+                scores,
+                confusion_matrix,
+                blend_alpha,
+                margin_threshold,
+            )
+            balanced = _balanced_accuracy_for_scores(
+                calibrated_scores, labels, class_order
+            )
+            if balanced > best_balanced + 1e-12:
+                best_alpha = float(blend_alpha)
+                best_threshold = float(margin_threshold)
+                best_balanced = balanced
+    return confusion_matrix, best_alpha, best_threshold, best_balanced
+
+
+def _candidate_margin_thresholds(margins):
+    margins = np.asarray(margins, dtype=float).ravel()
+    finite_margins = margins[np.isfinite(margins)]
+    if finite_margins.size == 0:
+        return (float("inf"),)
+    thresholds = [
+        float(value)
+        for value in np.quantile(
+            finite_margins,
+            CONFUSION_CALIBRATION_MARGIN_QUANTILES,
+        )
+    ]
+    thresholds.append(float("inf"))
+    return tuple(dict.fromkeys(max(0.0, threshold) for threshold in thresholds))
+
+
 def _confusion_true_given_pred_matrix(scores, labels, class_order):
     scores = np.asarray(scores, dtype=float)
     labels = np.asarray(labels, dtype=int)
@@ -739,6 +878,45 @@ def _confusion_blend_scores(scores, confusion_matrix, blend_alpha):
     corrected = probabilities @ confusion_matrix
     blended = (1.0 - blend_alpha) * probabilities + blend_alpha * corrected
     return _probabilities_to_logits(blended)
+
+
+def _margin_confusion_blend_scores(
+    scores, confusion_matrix, blend_alpha, margin_threshold
+):
+    probabilities = _score_probabilities(scores)
+    if probabilities.ndim != 2 or probabilities.shape[1] == 0:
+        return _probabilities_to_logits(probabilities)
+    confusion_matrix = np.asarray(confusion_matrix, dtype=float)
+    blend_alpha = float(np.clip(float(blend_alpha), 0.0, 1.0))
+    corrected = probabilities @ confusion_matrix
+    margin_threshold = float(margin_threshold)
+    if np.isfinite(margin_threshold):
+        margins = _top2_probability_margins(probabilities)
+        if margin_threshold <= 1e-12:
+            margin_gate = (margins <= margin_threshold).astype(float)
+        else:
+            margin_gate = np.clip(
+                (margin_threshold - margins) / margin_threshold,
+                0.0,
+                1.0,
+            )
+        effective_alpha = blend_alpha * margin_gate[:, None]
+    else:
+        effective_alpha = blend_alpha
+    blended = (1.0 - effective_alpha) * probabilities + effective_alpha * corrected
+    return _probabilities_to_logits(blended)
+
+
+def _top2_probability_margins(probabilities):
+    probabilities = _row_normalize_probabilities(
+        np.asarray(probabilities, dtype=float)
+    )
+    if probabilities.ndim != 2 or probabilities.shape[0] == 0:
+        return np.zeros(0, dtype=float)
+    if probabilities.shape[1] < 2:
+        return np.ones(probabilities.shape[0], dtype=float)
+    sorted_probabilities = np.sort(probabilities, axis=1)
+    return sorted_probabilities[:, -1] - sorted_probabilities[:, -2]
 
 
 def _score_probabilities(scores):
@@ -949,9 +1127,11 @@ def _candidate_model_scores(fitted_model, test_set, config):
 def _has_active_score_calibration_metadata(metadata):
     if not isinstance(metadata, dict):
         return False
-    if metadata.get("mode") not in ACTIVE_SCORE_CALIBRATION_MODES:
+    mode = metadata.get("mode")
+    if mode not in ACTIVE_SCORE_CALIBRATION_MODES:
         return False
-    if metadata.get("mode") == "inner_confusion_blend":
+    base_mode = _score_calibration_base_mode(mode)
+    if base_mode in {"inner_confusion_blend", "inner_margin_confusion_blend"}:
         return "classes" in metadata and "confusion_matrix" in metadata
     return "bias" in metadata or "probability_map" in metadata
 
@@ -961,13 +1141,25 @@ def _apply_score_calibration(scores, classes, fitted_model):
     if not _has_active_score_calibration_metadata(metadata):
         return scores, classes
     calibration_classes = np.asarray(metadata["classes"], dtype=int)
-    if metadata.get("mode") == "inner_confusion_blend":
+    base_mode = _score_calibration_base_mode(metadata.get("mode", "none"))
+    if base_mode == "inner_confusion_blend":
         aligned = _align_class_score_columns(scores, classes, calibration_classes)
         return (
             _confusion_blend_scores(
                 aligned,
                 metadata["confusion_matrix"],
                 metadata.get("blend_alpha", 0.0),
+            ),
+            calibration_classes,
+        )
+    if base_mode == "inner_margin_confusion_blend":
+        aligned = _align_class_score_columns(scores, classes, calibration_classes)
+        return (
+            _margin_confusion_blend_scores(
+                aligned,
+                metadata["confusion_matrix"],
+                metadata.get("blend_alpha", 0.0),
+                metadata.get("margin_threshold", float("inf")),
             ),
             calibration_classes,
         )
@@ -1075,10 +1267,16 @@ def _add_next_fields(row, config, fitted_model):
     metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
     row["score_calibration"] = metadata.get("mode", getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION))
     row["score_calibration_inner_balanced_accuracy"] = metadata.get("inner_balanced_accuracy", "")
+    row["score_calibration_inner_uncalibrated_balanced_accuracy"] = metadata.get(
+        "inner_uncalibrated_balanced_accuracy", ""
+    )
     row["score_calibration_status"] = metadata.get("status", "")
     row["score_calibration_source"] = metadata.get("calibration_source", "")
     row["score_calibration_source_balanced_accuracy"] = metadata.get("source_balanced_accuracy", "")
     row["score_calibration_confusion_blend_alpha"] = metadata.get("blend_alpha", "")
+    row["score_calibration_confusion_margin_threshold"] = metadata.get(
+        "margin_threshold", ""
+    )
     row["score_calibration_confusion_smoothing"] = metadata.get("smoothing", "")
     row["score_calibration_probability_map_l2"] = metadata.get(
         "probability_map_l2_penalty", ""

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -342,6 +342,85 @@ class TestStimulusCrossSubject(unittest.TestCase):
 
         np.testing.assert_allclose(actual, expected)
 
+    def test_inner_balanced_quota_suffix_combines_prior_balance_and_assignment(self):
+        mode = "rank_reciprocal_inner_balanced_balanced_quota"
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        scores = np.asarray([[3.0, 1.0], [1.0, 3.0]], dtype=float)
+
+        expected = cross_subject._class_score_probabilities(
+            scores,
+            score_normalization="rank_reciprocal",
+        )
+        actual = cross_subject._class_score_probabilities(
+            scores,
+            score_normalization=mode,
+        )
+
+        np.testing.assert_allclose(actual, expected)
+        selected_rows = (
+            {
+                "selected_inner_test_label_counts": "1:10;2:10",
+                "selected_inner_predicted_label_counts": "1:18;2:2",
+            },
+        )
+        metadata = cross_subject._inner_class_prior_balance_metadata(
+            selected_rows,
+            np.asarray([0, 1], dtype=int),
+            np.asarray([1.0], dtype=float),
+            mode,
+        )
+        adjusted = cross_subject._apply_inner_class_prior_balance(
+            np.asarray([[0.60, 0.40]], dtype=float),
+            metadata,
+        )
+        quota = cross_subject._balanced_quota_metadata(
+            np.asarray([[0.95, 0.05], [0.60, 0.40]], dtype=float),
+            np.asarray([0, 1], dtype=int),
+            mode,
+        )
+
+        self.assertEqual(metadata["mode"], mode)
+        self.assertEqual(metadata["inner_mode"], "rank_reciprocal_inner_balanced")
+        self.assertLess(adjusted[0, 0], 0.60)
+        self.assertGreater(adjusted[0, 1], 0.40)
+        self.assertEqual(quota["status"], "applied")
+        self.assertEqual(
+            np.bincount(quota["predictions"], minlength=2).tolist(), [1, 1]
+        )
+
+    def test_inner_confusion_quota_suffix_combines_correction_and_assignment(self):
+        mode = "rank_softmax_inner_confusion_balanced_quota"
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        selected_rows = (
+            {
+                "selected_inner_true_predicted_label_pair_counts": (
+                    "1001:2;2001:8;2002:10"
+                ),
+            },
+        )
+        metadata = cross_subject._inner_confusion_correction_metadata(
+            selected_rows,
+            np.asarray([0, 1], dtype=int),
+            np.asarray([1.0], dtype=float),
+            mode,
+        )
+        probabilities = np.asarray([[0.70, 0.30], [0.65, 0.35]], dtype=float)
+        adjusted = cross_subject._apply_inner_confusion_correction(
+            probabilities, metadata
+        )
+        quota = cross_subject._balanced_quota_metadata(
+            adjusted, np.asarray([0, 1], dtype=int), mode
+        )
+
+        self.assertEqual(metadata["mode"], mode)
+        self.assertEqual(metadata["inner_mode"], "rank_softmax_inner_confusion")
+        self.assertEqual(metadata["status"], "applied")
+        self.assertGreater(adjusted[0, 1], probabilities[0, 1])
+        self.assertEqual(quota["status"], "applied")
+        self.assertEqual(
+            np.bincount(quota["predictions"], minlength=2).tolist(), [1, 1]
+        )
+
     def test_balanced_quota_assignment_enforces_known_batch_balance(self):
         probabilities = np.asarray(
             [
@@ -873,6 +952,30 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertAlmostEqual(float(np.sum(selection_lcb_weighted)), 1.0)
         self.assertGreater(selection_lcb_weighted[0], selection_lcb_weighted[1])
         self.assertGreater(selection_lcb_weighted[1], selection_lcb_weighted[2])
+
+    def test_rank_softmax_temperature_modes_soften_rank_mass(self):
+        scores = np.asarray([[4.0, 3.0, 2.0, 1.0]], dtype=float)
+
+        sharp = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax",
+        )[0]
+        t2 = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax_t2",
+        )[0]
+        t3 = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax_t3_inner_balanced",
+        )[0]
+
+        np.testing.assert_allclose(np.sum(sharp), 1.0)
+        np.testing.assert_allclose(np.sum(t2), 1.0)
+        np.testing.assert_allclose(np.sum(t3), 1.0)
+        self.assertGreater(sharp[0], t2[0])
+        self.assertGreater(t2[0], t3[0])
+        self.assertGreater(t2[1], sharp[1])
+        self.assertGreater(t3[2], t2[2])
 
     def test_nested_ensemble_can_prefer_diverse_candidate_windows(self):
         configs = (

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import numpy as np
+from pymegdec import _stimulus_cross_subject_next as next_hooks
 from pymegdec import stimulus_cross_subject as cross_subject
 from pymegdec.stimulus_cross_subject import CrossSubjectStimulusConfig, load_participant_stimulus_features, make_cross_subject_candidate_configs
 from tests.matlab_fixtures import loadmat_side_effect, mat_data_from_trials
@@ -206,6 +207,45 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
 
         self.assertEqual(len(configs), 1)
         self.assertEqual(configs[0].score_calibration, "inner_confusion_blend")
+
+    def test_candidate_grid_accepts_inner_margin_confusion_blend_score_calibration(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            score_calibrations=("inner_margin_confusion_blend",),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 1)
+        self.assertEqual(
+            configs[0].score_calibration,
+            "inner_margin_confusion_blend",
+        )
+
+    def test_candidate_grid_accepts_guarded_inner_score_calibration_modes(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            score_calibrations=(
+                "inner_class_bias_guarded",
+                "inner_probability_map_guarded",
+            ),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 2)
+        self.assertEqual(
+            {config.score_calibration for config in configs},
+            {"inner_class_bias_guarded", "inner_probability_map_guarded"},
+        )
 
     def test_candidate_grid_accepts_train_score_calibration_modes(self):
         configs = make_cross_subject_candidate_configs(
@@ -504,6 +544,54 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_array_equal(classes, np.asarray([0, 1]))
         self.assertGreater(calibrated[0, 1], calibrated[0, 0])
         self.assertGreater(calibrated[1, 0], calibrated[1, 1])
+
+    def test_inner_margin_confusion_blend_only_reranks_low_margin_trials(self):
+        scores = np.asarray(
+            [[0.99, 0.01], [0.51, 0.49], [0.01, 0.99]],
+            dtype=float,
+        )
+        fitted_model = {
+            "score_calibration_metadata": {
+                "mode": "inner_margin_confusion_blend",
+                "classes": np.asarray([0, 1]),
+                "confusion_matrix": np.asarray(
+                    [[0.0, 1.0], [1.0, 0.0]], dtype=float
+                ),
+                "blend_alpha": 1.0,
+                "margin_threshold": 0.1,
+            }
+        }
+
+        calibrated, classes = cross_subject._apply_score_calibration(  # pylint: disable=protected-access
+            scores,
+            np.asarray([0, 1]),
+            fitted_model,
+        )
+
+        np.testing.assert_array_equal(classes, np.asarray([0, 1]))
+        np.testing.assert_array_equal(
+            np.argmax(calibrated, axis=1),
+            np.asarray([0, 1, 1]),
+        )
+
+    def test_guarded_inner_score_calibration_skips_without_inner_gain(self):
+        metadata = next_hooks._guard_inner_score_calibration_metadata(  # pylint: disable=protected-access
+            {
+                "mode": "inner_class_bias_guarded",
+                "classes": np.asarray([0, 1]),
+                "bias": np.asarray([0.5, -0.5]),
+                "scale": np.ones(2),
+                "inner_balanced_accuracy": 0.5,
+                "calibration_source": "inner_scores",
+            },
+            0.5,
+            guarded=True,
+        )
+
+        self.assertEqual(metadata["status"], "skipped_no_inner_gain")
+        self.assertEqual(metadata["inner_uncalibrated_balanced_accuracy"], 0.5)
+        self.assertNotIn("bias", metadata)
+        self.assertFalse(next_hooks._has_active_score_calibration_metadata(metadata))  # pylint: disable=protected-access
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add guarded inner score-calibration modes and margin-gated confusion blending
- add inner prior/confusion balanced-quota ensemble normalization combinations
- add workflow matrix bundles for guarded calibration, margin confusion, and quota variants

## Validation
- python -m py_compile src\\pymegdec\\_stimulus_cross_subject_legacy.py src\\pymegdec\\_stimulus_cross_subject_next.py tests\\test_stimulus_cross_subject.py tests\\test_stimulus_cross_subject_next.py
- python -m ruff check src\\pymegdec\\_stimulus_cross_subject_legacy.py src\\pymegdec\\_stimulus_cross_subject_next.py tests\\test_stimulus_cross_subject.py tests\\test_stimulus_cross_subject_next.py
- git diff --check origin/main..HEAD

Tests were not run, per request.