### PR TITLE
Add rank softmax workflow aliases

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -31,6 +31,8 @@ on:
           - windowed_logreg_lean_rankaware
           - windowed_logreg_lean_rankaware_reciprocal
           - windowed_logreg_lean_rankaware_reciprocal_inner_prior
+          - windowed_logreg_lean_rankaware_t2
+          - windowed_logreg_lean_rankaware_t2_inner_prior
           - windowed_logreg_lean_ranksoft_t2
           - windowed_logreg_lean_ranksoft_t3
           - windowed_logreg_lean_rankaware_top2vote
@@ -38,6 +40,7 @@ on:
           - windowed_logreg_lean_rankaware_top2vote_inner_prior
           - windowed_logreg_lean_balanced_quota
           - windowed_logreg_175_balanced_quota
+          - windowed_logreg_175_ranksoftmax_t2
           - windowed_logreg_175_finetune
           - windowed_logreg_175_bias_calibration
           - windowed_logreg_175_rank_bias_calibration
@@ -293,6 +296,36 @@ jobs:
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_lean_rankaware_t2": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t2",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_rankaware_t2_inner_prior": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t2_inner_balanced",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_lean_ranksoft_t3": {
                   "window_centers": "0.175,0.200",
                   "feature_modes": "sensor_flat",
@@ -378,6 +411,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_balanced_quota",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_ranksoftmax_t2": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t2",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -976,6 +976,24 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertGreater(t2[0], t3[0])
         self.assertGreater(t2[1], sharp[1])
         self.assertGreater(t3[2], t2[2])
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(  # pylint: disable=protected-access
+                "rank_softmax_t2_inner_balanced"
+            ),
+            "rank_softmax_t2",
+        )
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(  # pylint: disable=protected-access
+                "rank_softmax_t3_inner_confusion"
+            ),
+            "rank_softmax_t3",
+        )
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(  # pylint: disable=protected-access
+                "rank-softmax-t2-balanced-quota"
+            ),
+            "rank_softmax_t2",
+        )
 
     def test_nested_ensemble_can_prefer_diverse_candidate_windows(self):
         configs = (


### PR DESCRIPTION
## Summary
- add workflow aliases for rank softmax temperature bundles
- cover base-normalization behavior for the alias bundles

## Validation
- python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py
- python -m ruff check src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py
- git diff --check

Tests were not run per request.