### PR TITLE
Fix PyMEGDec mypy failures

### DIFF
--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -2975,7 +2975,7 @@ def _format_compact_count(value):
 
 
 def _parse_confusion_counter(value):
-    counter: Counter[tuple[int, int]] = Counter()
+    counter: dict[tuple[int, int], float] = {}
     if value in (None, ""):
         return counter
     for token in str(value).split(";"):
@@ -2985,16 +2985,18 @@ def _parse_confusion_counter(value):
         pair, count = token.rsplit(":", 1)
         true_label, predicted_label = pair.split(">", 1)
         try:
-            counter[(int(true_label), int(predicted_label))] += float(count)
+            key = (int(true_label), int(predicted_label))
+            counter[key] = counter.get(key, 0.0) + float(count)
         except ValueError:
             continue
     return counter
 
 
 def _sum_formatted_confusion_counters(rows, key):
-    counter: Counter[tuple[int, int]] = Counter()
+    counter: dict[tuple[int, int], float] = {}
     for row in rows:
-        counter.update(_parse_confusion_counter(row.get(key, "")))
+        for pair, count in _parse_confusion_counter(row.get(key, "")).items():
+            counter[pair] = counter.get(pair, 0.0) + count
     return counter
 
 

--- a/src/pymegdec/stimulus_onset_neureptrace.py
+++ b/src/pymegdec/stimulus_onset_neureptrace.py
@@ -11,7 +11,7 @@ import argparse
 import glob
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pandas as pd
 
@@ -52,7 +52,7 @@ def _paths(paths: Sequence[str | Path]) -> list[Path]:
 def _read_records(path: str | Path | None) -> list[dict[str, Any]]:
     if path is None or not Path(path).exists():
         return []
-    return pd.read_csv(path).to_dict(orient="records")
+    return cast(list[dict[str, Any]], pd.read_csv(path).to_dict(orient="records"))
 
 
 def _copy_column(frame: pd.DataFrame, target: str, source: str) -> None:
@@ -73,7 +73,7 @@ def _compat_thresholded_observations(path: str | Path | None) -> list[dict[str, 
     _copy_column(frame, "stimulus_score", "confidence")
     _copy_column(frame, "correct", "is_correct")
     frame.to_csv(path, index=False)
-    return frame.to_dict(orient="records")
+    return cast(list[dict[str, Any]], frame.to_dict(orient="records"))
 
 
 def _compat_events(path: str | Path | None) -> list[dict[str, Any]]:
@@ -93,7 +93,7 @@ def _compat_events(path: str | Path | None) -> list[dict[str, Any]]:
     _copy_column(frame, "detection_run_stop_time_s", "detection_run_stop_time")
     _copy_column(frame, "stimulus_score_peak_in_run", "score_peak_in_run")
     frame.to_csv(path, index=False)
-    return frame.to_dict(orient="records")
+    return cast(list[dict[str, Any]], frame.to_dict(orient="records"))
 
 
 def _time_window(value: str | Sequence[float]) -> tuple[float, float]:


### PR DESCRIPTION
## Summary
- keep parsed confusion counters typed as float-valued mappings
- cast pandas record outputs at NeuRepTrace onset compatibility boundaries

## Verification
- python -m ruff check .
- python -m mypy src

Pytest collection was not run locally because this environment is missing the NeuRepTrace dependency import.