### PR TITLE
Add Borda rank normalization

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -35,6 +35,7 @@ on:
           - windowed_logreg_lean_rankaware_t2_inner_prior
           - windowed_logreg_lean_ranksoft_t2
           - windowed_logreg_lean_ranksoft_t3
+          - windowed_logreg_lean_rankborda
           - windowed_logreg_lean_rankaware_top2vote
           - windowed_logreg_lean_rankaware_top3vote
           - windowed_logreg_lean_rankaware_top2vote_inner_prior
@@ -49,6 +50,7 @@ on:
           - windowed_logreg_175_confusion_blend
           - windowed_logreg_175_margin_confusion_blend
           - windowed_logreg_175_guarded_calibration
+          - windowed_logreg_175_rankborda_inner_confusion
           - windowed_logreg_175_train_scorecal
           - windowed_logreg_lean_reciprocal_inner_prior
           - windowed_logreg_lean_inner_prior
@@ -92,23 +94,28 @@ on:
           - rank_softmax_t2
           - rank_softmax_t3
           - rank_reciprocal
+          - rank_borda
           - rank_top2_vote
           - rank_top3_vote
           - rank_z_blend
           - rank_softmax_balanced_quota
           - rank_softmax_t2_balanced_quota
           - rank_softmax_t3_balanced_quota
+          - rank_borda_balanced_quota
           - rank_z_blend_balanced_quota
           - rank_softmax_inner_balanced_balanced_quota
           - rank_reciprocal_inner_balanced_balanced_quota
+          - rank_borda_inner_balanced_balanced_quota
           - rank_z_blend_inner_balanced_balanced_quota
           - rank_softmax_inner_confusion_balanced_quota
           - rank_reciprocal_inner_confusion_balanced_quota
+          - rank_borda_inner_confusion_balanced_quota
           - rank_z_blend_inner_confusion_balanced_quota
           - rank_softmax_inner_balanced
           - rank_softmax_t2_inner_balanced
           - rank_softmax_t3_inner_balanced
           - rank_reciprocal_inner_balanced
+          - rank_borda_inner_balanced
           - rank_top2_vote_inner_balanced
           - rank_top3_vote_inner_balanced
           - rank_z_blend_inner_balanced
@@ -116,6 +123,7 @@ on:
           - rank_softmax_t2_inner_confusion
           - rank_softmax_t3_inner_confusion
           - rank_reciprocal_inner_confusion
+          - rank_borda_inner_confusion
           - rank_top2_vote_inner_confusion
           - rank_top3_vote_inner_confusion
           - rank_z_blend_inner_confusion
@@ -341,6 +349,21 @@ jobs:
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_lean_rankborda": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_borda",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_lean_rankaware_top2vote": {
                   "window_centers": "0.175,0.200",
                   "feature_modes": "sensor_flat",
@@ -563,6 +586,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
                   "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_rankborda_inner_confusion": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_borda_inner_confusion",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -78,23 +78,28 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_softmax_t2",
     "rank_softmax_t3",
     "rank_reciprocal",
+    "rank_borda",
     "rank_top2_vote",
     "rank_top3_vote",
     "rank_z_blend",
     "rank_softmax_balanced_quota",
     "rank_softmax_t2_balanced_quota",
     "rank_softmax_t3_balanced_quota",
+    "rank_borda_balanced_quota",
     "rank_z_blend_balanced_quota",
     "rank_softmax_inner_balanced_balanced_quota",
     "rank_reciprocal_inner_balanced_balanced_quota",
+    "rank_borda_inner_balanced_balanced_quota",
     "rank_z_blend_inner_balanced_balanced_quota",
     "rank_softmax_inner_confusion_balanced_quota",
     "rank_reciprocal_inner_confusion_balanced_quota",
+    "rank_borda_inner_confusion_balanced_quota",
     "rank_z_blend_inner_confusion_balanced_quota",
     "rank_softmax_inner_balanced",
     "rank_softmax_t2_inner_balanced",
     "rank_softmax_t3_inner_balanced",
     "rank_reciprocal_inner_balanced",
+    "rank_borda_inner_balanced",
     "rank_top2_vote_inner_balanced",
     "rank_top3_vote_inner_balanced",
     "rank_z_blend_inner_balanced",
@@ -102,6 +107,7 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_softmax_t2_inner_confusion",
     "rank_softmax_t3_inner_confusion",
     "rank_reciprocal_inner_confusion",
+    "rank_borda_inner_confusion",
     "rank_top2_vote_inner_confusion",
     "rank_top3_vote_inner_confusion",
     "rank_z_blend_inner_confusion",
@@ -111,6 +117,7 @@ INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_t2_inner_balanced": "rank_softmax_t2",
     "rank_softmax_t3_inner_balanced": "rank_softmax_t3",
     "rank_reciprocal_inner_balanced": "rank_reciprocal",
+    "rank_borda_inner_balanced": "rank_borda",
     "rank_top2_vote_inner_balanced": "rank_top2_vote",
     "rank_top3_vote_inner_balanced": "rank_top3_vote",
     "rank_z_blend_inner_balanced": "rank_z_blend",
@@ -120,6 +127,7 @@ INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_t2_inner_confusion": "rank_softmax_t2",
     "rank_softmax_t3_inner_confusion": "rank_softmax_t3",
     "rank_reciprocal_inner_confusion": "rank_reciprocal",
+    "rank_borda_inner_confusion": "rank_borda",
     "rank_top2_vote_inner_confusion": "rank_top2_vote",
     "rank_top3_vote_inner_confusion": "rank_top3_vote",
     "rank_z_blend_inner_confusion": "rank_z_blend",
@@ -1992,6 +2000,8 @@ def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJ
         return _rank_softmax_probabilities(scores, temperature=RANK_SOFTMAX_TEMPERATURES[score_normalization])
     if score_normalization == "rank_reciprocal":
         return _rank_reciprocal_probabilities(scores)
+    if score_normalization == "rank_borda":
+        return _rank_borda_probabilities(scores)
     if score_normalization == "rank_top2_vote":
         return _rank_topk_vote_probabilities(scores, top_k=2)
     if score_normalization == "rank_top3_vote":
@@ -2051,6 +2061,48 @@ def _rank_reciprocal_probabilities(scores):
         weights = np.zeros(row.shape[0], dtype=float)
         weights[finite] = 1.0 / (ranks[finite] + 1.0)
         probabilities[row_index] = weights / np.sum(weights)
+    return probabilities
+
+
+def _rank_borda_probabilities(scores):
+    """Convert class scores to a Borda-count rank distribution.
+
+    The BUSH-MEG source-only runs repeatedly show useful top-2/top-3 signal,
+    but hard top-k voting can over-flatten near-top classes and rank-softmax can
+    be too top-heavy.  Borda weights give the top class ``n``, the runner-up
+    ``n-1``, ..., and the last finite class ``1`` before row normalization.  The
+    transform is score-scale invariant like the other rank normalizers, while
+    still preserving an ordered preference among all finite classes.
+    """
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError(
+            "Nested score ensembling requires a non-empty two-dimensional "
+            "class-score matrix."
+        )
+    probabilities = np.empty_like(scores, dtype=float)
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        n_finite = int(np.sum(finite))
+        if n_finite == 0:
+            probabilities[row_index] = np.full(
+                row.shape[0], 1.0 / row.shape[0], dtype=float
+            )
+            continue
+        rank_scores = np.where(finite, row, -np.inf)
+        descending_columns = np.argsort(-rank_scores, kind="mergesort")
+        ranks = np.empty(row.shape[0], dtype=float)
+        ranks[descending_columns] = np.arange(row.shape[0], dtype=float)
+        weights = np.zeros(row.shape[0], dtype=float)
+        weights[finite] = n_finite - ranks[finite]
+        weight_sum = float(np.sum(weights))
+        probabilities[row_index] = np.divide(
+            weights,
+            weight_sum,
+            out=np.full(row.shape[0], 1.0 / row.shape[0], dtype=float),
+            where=weight_sum > 0.0,
+        )
     return probabilities
 
 

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -287,6 +287,7 @@ class TestStimulusCrossSubject(unittest.TestCase):
         balanced_to_base = {
             "rank_softmax_inner_balanced": "rank_softmax",
             "rank_reciprocal_inner_balanced": "rank_reciprocal",
+            "rank_borda_inner_balanced": "rank_borda",
             "rank_top2_vote_inner_balanced": "rank_top2_vote",
             "rank_top3_vote_inner_balanced": "rank_top3_vote",
             "rank_z_blend_inner_balanced": "rank_z_blend",
@@ -994,6 +995,31 @@ class TestStimulusCrossSubject(unittest.TestCase):
             ),
             "rank_softmax_t2",
         )
+
+    def test_rank_borda_score_normalization_uses_linear_rank_weights(self):
+        scores = np.asarray(
+            [
+                [4.0, 3.0, 2.0, 1.0],
+                [1.0, np.nan, 3.0, 2.0],
+            ],
+            dtype=float,
+        )
+
+        probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_borda",
+        )
+        balanced = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_borda_inner_balanced",
+        )
+
+        np.testing.assert_allclose(probabilities[0], [0.4, 0.3, 0.2, 0.1])
+        np.testing.assert_allclose(
+            probabilities[1], [1.0 / 6.0, 0.0, 0.5, 1.0 / 3.0]
+        )
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(2))
+        np.testing.assert_allclose(balanced, probabilities)
 
     def test_nested_ensemble_can_prefer_diverse_candidate_windows(self):
         configs = (


### PR DESCRIPTION
## Summary
- add Borda-count rank score normalization and inner/balanced quota variants
- add BUSH-MEG workflow matrix entries for rank Borda configurations
- cover rank Borda probabilities and inner-balanced base normalization

## Validation
- python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py
- python -m ruff check src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py
- git diff --check

Tests were not run per request.