### PR TITLE
Add Borda workflow bundles

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -57,6 +57,7 @@ on:
           - windowed_logreg_lean_inner_prior_quota
           - windowed_logreg_lean_inner_confusion
           - windowed_logreg_lean_inner_confusion_quota
+          - windowed_logreg_lean_borda_inner_confusion_quota
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
@@ -64,6 +65,7 @@ on:
           - windowed_logreg_175_inner_prior_quota
           - windowed_logreg_175_inner_confusion
           - windowed_logreg_175_inner_confusion_quota
+          - windowed_logreg_175_borda_inner_confusion_quota
           - windowed_logreg_175_reciprocal_inner_prior
           - windowed_logreg_core
           - feature_check
@@ -690,6 +692,20 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_lean_borda_inner_confusion_quota": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_borda_inner_confusion_balanced_quota",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_inner_prior": {
                   "window_centers": "0.175",
                   "feature_modes": "sensor_flat",
@@ -743,6 +759,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_balanced_quota",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_borda_inner_confusion_quota": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_borda_inner_confusion_balanced_quota",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1021,6 +1021,32 @@ class TestStimulusCrossSubject(unittest.TestCase):
         np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(2))
         np.testing.assert_allclose(balanced, probabilities)
 
+    def test_rank_borda_score_normalization_uses_full_rank_order(self):
+        scores = np.asarray(
+            [
+                [4.0, 3.0, 1.0, 0.0],
+                [0.0, 2.0, 5.0, 1.0],
+                [np.nan, np.nan, np.nan, np.nan],
+            ],
+            dtype=float,
+        )
+
+        probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_borda",
+        )
+
+        np.testing.assert_allclose(
+            probabilities[0],
+            np.asarray([4.0, 3.0, 2.0, 1.0]) / 10.0,
+        )
+        np.testing.assert_allclose(
+            probabilities[1],
+            np.asarray([1.0, 3.0, 4.0, 2.0]) / 10.0,
+        )
+        np.testing.assert_allclose(probabilities[2], np.full(4, 0.25))
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(3))
+
     def test_nested_ensemble_can_prefer_diverse_candidate_windows(self):
         configs = (
             CrossSubjectStimulusConfig(window_center=0.10, window_size=0.1, normalization="none", classifier="multiclass-svm", classifier_param=0.5),


### PR DESCRIPTION
## Summary
- add Borda inner-confusion quota workflow bundles
- add a full-rank-order Borda normalization regression check

## Validation
- python -m py_compile tests\test_stimulus_cross_subject.py
- python -m ruff check tests\test_stimulus_cross_subject.py
- git diff --check origin/main..HEAD

Tests were not run per request.