### PR TITLE
Add inner balanced confusion priors

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -57,6 +57,8 @@ on:
           - windowed_logreg_lean_inner_prior_quota
           - windowed_logreg_lean_inner_confusion
           - windowed_logreg_lean_inner_confusion_quota
+          - windowed_logreg_lean_inner_prior_confusion
+          - windowed_logreg_lean_inner_prior_confusion_quota
           - windowed_logreg_lean_borda_inner_confusion_quota
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
@@ -65,6 +67,8 @@ on:
           - windowed_logreg_175_inner_prior_quota
           - windowed_logreg_175_inner_confusion
           - windowed_logreg_175_inner_confusion_quota
+          - windowed_logreg_175_inner_prior_confusion
+          - windowed_logreg_175_inner_prior_confusion_quota
           - windowed_logreg_175_borda_inner_confusion_quota
           - windowed_logreg_175_reciprocal_inner_prior
           - windowed_logreg_core
@@ -129,6 +133,14 @@ on:
           - rank_top2_vote_inner_confusion
           - rank_top3_vote_inner_confusion
           - rank_z_blend_inner_confusion
+          - rank_softmax_inner_balanced_confusion
+          - rank_reciprocal_inner_balanced_confusion
+          - rank_borda_inner_balanced_confusion
+          - rank_z_blend_inner_balanced_confusion
+          - rank_softmax_inner_balanced_confusion_balanced_quota
+          - rank_reciprocal_inner_balanced_confusion_balanced_quota
+          - rank_borda_inner_balanced_confusion_balanced_quota
+          - rank_z_blend_inner_balanced_confusion_balanced_quota
       selection_metric_override:
         description: Override the bundle's nested inner-LOSO selection metric.
         required: true
@@ -692,6 +704,34 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_lean_inner_prior_confusion": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_balanced_confusion",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_inner_prior_confusion_quota": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_balanced_confusion_balanced_quota",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_lean_borda_inner_confusion_quota": {
                   "window_centers": "0.175,0.200",
                   "feature_modes": "sensor_flat",
@@ -759,6 +799,34 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_balanced_quota",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_inner_prior_confusion": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_balanced_confusion",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_inner_prior_confusion_quota": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_balanced_confusion_balanced_quota",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -95,6 +95,10 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_reciprocal_inner_confusion_balanced_quota",
     "rank_borda_inner_confusion_balanced_quota",
     "rank_z_blend_inner_confusion_balanced_quota",
+    "rank_softmax_inner_balanced_confusion_balanced_quota",
+    "rank_reciprocal_inner_balanced_confusion_balanced_quota",
+    "rank_borda_inner_balanced_confusion_balanced_quota",
+    "rank_z_blend_inner_balanced_confusion_balanced_quota",
     "rank_softmax_inner_balanced",
     "rank_softmax_t2_inner_balanced",
     "rank_softmax_t3_inner_balanced",
@@ -111,6 +115,10 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top2_vote_inner_confusion",
     "rank_top3_vote_inner_confusion",
     "rank_z_blend_inner_confusion",
+    "rank_softmax_inner_balanced_confusion",
+    "rank_reciprocal_inner_balanced_confusion",
+    "rank_borda_inner_balanced_confusion",
+    "rank_z_blend_inner_balanced_confusion",
 )
 INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_inner_balanced": "rank_softmax",
@@ -131,6 +139,12 @@ INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_top2_vote_inner_confusion": "rank_top2_vote",
     "rank_top3_vote_inner_confusion": "rank_top3_vote",
     "rank_z_blend_inner_confusion": "rank_z_blend",
+}
+INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
+    "rank_softmax_inner_balanced_confusion": "rank_softmax",
+    "rank_reciprocal_inner_balanced_confusion": "rank_reciprocal",
+    "rank_borda_inner_balanced_confusion": "rank_borda",
+    "rank_z_blend_inner_balanced_confusion": "rank_z_blend",
 }
 INNER_CONFUSION_CORRECTION_SMOOTHING = 1.0
 INNER_CONFUSION_CORRECTION_IDENTITY_BLEND = 0.20
@@ -2172,6 +2186,7 @@ def _inner_class_prior_balance_mode(score_normalization):
     return (
         inner_mode
         if inner_mode in INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        or inner_mode in INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES
         else None
     )
 
@@ -2181,6 +2196,7 @@ def _inner_confusion_correction_mode(score_normalization):
     return (
         inner_mode
         if inner_mode in INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        or inner_mode in INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES
         else None
     )
 
@@ -2188,11 +2204,11 @@ def _inner_confusion_correction_mode(score_normalization):
 def _base_ensemble_score_normalization(score_normalization):
     score_normalization = _normalize_ensemble_score_normalization(score_normalization)
     inner_mode = _without_balanced_quota_suffix(score_normalization)
-    return INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(
-        inner_mode,
-        INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(
-            inner_mode, inner_mode
-        ),
+    return (
+        INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(inner_mode)
+        or INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(inner_mode)
+        or INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(inner_mode)
+        or inner_mode
     )
 
 

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -674,6 +674,19 @@ class TestStimulusCrossSubject(unittest.TestCase):
 
         self.assertEqual(tuple(config.components_pca for config in candidate_configs), (32, 64, 128, 256))
 
+    def test_combined_inner_prior_confusion_score_normalization_is_supported(self):
+        mode = "rank_softmax_inner_balanced_confusion"
+        quota_mode = "rank_softmax_inner_balanced_confusion_balanced_quota"
+
+        self.assertEqual(cross_subject._normalize_ensemble_score_normalization(mode), mode)  # pylint: disable=protected-access
+        self.assertEqual(cross_subject._normalize_ensemble_score_normalization(quota_mode), quota_mode)  # pylint: disable=protected-access
+        self.assertEqual(cross_subject._base_ensemble_score_normalization(mode), "rank_softmax")  # pylint: disable=protected-access
+        self.assertEqual(cross_subject._base_ensemble_score_normalization(quota_mode), "rank_softmax")  # pylint: disable=protected-access
+        self.assertEqual(cross_subject._inner_class_prior_balance_mode(mode), mode)  # pylint: disable=protected-access
+        self.assertEqual(cross_subject._inner_class_prior_balance_mode(quota_mode), mode)  # pylint: disable=protected-access
+        self.assertEqual(cross_subject._inner_confusion_correction_mode(mode), mode)  # pylint: disable=protected-access
+        self.assertEqual(cross_subject._inner_confusion_correction_mode(quota_mode), mode)  # pylint: disable=protected-access
+
     def test_evaluate_cross_subject_stimulus_smoke(self):
         data_by_participant = {
             1: _mat_data([1, 2, 1, 2], [-1.2, 1.2, -1.1, 1.1]),


### PR DESCRIPTION
## Summary
- Add inner-balanced-confusion score normalization modes and quota variants
- Expose the new modes through the manual nested matrix workflow bundles and override options
- Add focused coverage for the combined inner-prior/confusion normalization helpers

## Validation
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py`
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check`

Tests were not run per request.