### PR TITLE
Add soft inner confusion blend

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -51,6 +51,7 @@ on:
           - windowed_logreg_175_margin_confusion_blend
           - windowed_logreg_175_guarded_calibration
           - windowed_logreg_175_rankborda_inner_confusion
+          - windowed_logreg_175_rankz_inner_confusion_soft
           - windowed_logreg_175_train_scorecal
           - windowed_logreg_lean_reciprocal_inner_prior
           - windowed_logreg_lean_inner_prior
@@ -133,6 +134,7 @@ on:
           - rank_top2_vote_inner_confusion
           - rank_top3_vote_inner_confusion
           - rank_z_blend_inner_confusion
+          - rank_z_blend_inner_confusion_soft
           - rank_softmax_inner_balanced_confusion
           - rank_reciprocal_inner_balanced_confusion
           - rank_borda_inner_balanced_confusion
@@ -614,6 +616,21 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_borda_inner_confusion",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_rankz_inner_confusion_soft": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_z_blend_inner_confusion_soft",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -115,6 +115,7 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top2_vote_inner_confusion",
     "rank_top3_vote_inner_confusion",
     "rank_z_blend_inner_confusion",
+    "rank_z_blend_inner_confusion_soft",
     "rank_softmax_inner_balanced_confusion",
     "rank_reciprocal_inner_balanced_confusion",
     "rank_borda_inner_balanced_confusion",
@@ -139,6 +140,7 @@ INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_top2_vote_inner_confusion": "rank_top2_vote",
     "rank_top3_vote_inner_confusion": "rank_top3_vote",
     "rank_z_blend_inner_confusion": "rank_z_blend",
+    "rank_z_blend_inner_confusion_soft": "rank_z_blend",
 }
 INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_inner_balanced_confusion": "rank_softmax",
@@ -148,6 +150,7 @@ INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
 }
 INNER_CONFUSION_CORRECTION_SMOOTHING = 1.0
 INNER_CONFUSION_CORRECTION_IDENTITY_BLEND = 0.20
+INNER_CONFUSION_CORRECTION_SOFT_BLEND = 0.35
 RANK_SOFTMAX_TEMPERATURES = {
     "rank_softmax": 1.0,
     "rank_softmax_t2": 2.0,
@@ -2319,6 +2322,16 @@ def _balanced_quota_predictions(probabilities, class_order):
     return class_order[prediction_columns], quotas, "applied"
 
 
+def _inner_confusion_correction_blend(inner_mode):
+    """Return the outer posterior blend used by an inner-confusion mode."""
+
+    return (
+        float(INNER_CONFUSION_CORRECTION_SOFT_BLEND)
+        if str(inner_mode).endswith("_soft")
+        else 1.0
+    )
+
+
 def _finite_assignment_scores(probabilities):
     scores = np.asarray(probabilities, dtype=float).copy()
     if scores.ndim != 2:
@@ -2393,7 +2406,7 @@ def _inner_confusion_correction_metadata(
 
     smoothing = float(INNER_CONFUSION_CORRECTION_SMOOTHING)
     identity_blend = float(INNER_CONFUSION_CORRECTION_IDENTITY_BLEND)
-    blend = 1.0
+    blend = _inner_confusion_correction_blend(inner_mode)
     smoothed = counts + smoothing
     predicted_totals = np.sum(smoothed, axis=0, keepdims=True)
     true_given_predicted = np.divide(

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1803,6 +1803,46 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertGreater(adjusted[1, 0], probabilities[1, 0])
         np.testing.assert_allclose(np.sum(adjusted, axis=1), np.ones(2))
 
+    def test_soft_inner_confusion_correction_uses_conservative_blend(self):
+        class_order = np.asarray([0, 1], dtype=int)
+        selected_rows = [
+            {
+                "selected_inner_true_predicted_label_pair_counts": (
+                    "1001:1;1002:9;2001:9;2002:1"
+                )
+            }
+        ]
+        probabilities = np.asarray([[0.8, 0.2], [0.2, 0.8]], dtype=float)
+
+        hard_metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            selected_rows,
+            class_order,
+            np.ones(1),
+            "rank_z_blend_inner_confusion",
+        )
+        soft_metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            selected_rows,
+            class_order,
+            np.ones(1),
+            "rank_z_blend_inner_confusion_soft",
+        )
+        hard_adjusted = cross_subject._apply_inner_confusion_correction(  # pylint: disable=protected-access
+            probabilities,
+            hard_metadata,
+        )
+        soft_adjusted = cross_subject._apply_inner_confusion_correction(  # pylint: disable=protected-access
+            probabilities,
+            soft_metadata,
+        )
+
+        self.assertEqual(soft_metadata["mode"], "rank_z_blend_inner_confusion_soft")
+        self.assertAlmostEqual(soft_metadata["blend"], 0.35)
+        self.assertGreater(hard_metadata["blend"], soft_metadata["blend"])
+        np.testing.assert_allclose(
+            soft_adjusted, 0.65 * probabilities + 0.35 * hard_adjusted
+        )
+        np.testing.assert_allclose(np.sum(soft_adjusted, axis=1), np.ones(2))
+
     def test_confusion_counter_round_trips_pair_counts(self):
         counter = Counter({(1, 2): 3, (2, 1): 1})
 
@@ -1818,11 +1858,21 @@ class TestStimulusCrossSubject(unittest.TestCase):
             "rank_reciprocal_inner_confusion",
             cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES,
         )
+        self.assertIn(
+            "rank_z_blend_inner_confusion_soft",
+            cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+        )
         self.assertEqual(
             cross_subject._base_ensemble_score_normalization(  # pylint: disable=protected-access
                 "rank_reciprocal_inner_confusion"
             ),
             "rank_reciprocal",
+        )
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(  # pylint: disable=protected-access
+                "rank_z_blend_inner_confusion_soft"
+            ),
+            "rank_z_blend",
         )
 
     def test_inner_confusion_correction_uses_source_validation_map(self):


### PR DESCRIPTION
## Summary
- Add `rank_z_blend_inner_confusion_soft` as a conservative inner-confusion correction mode
- Blend the source-validation true-given-predicted map with uncorrected ensemble probabilities for soft modes
- Expose the mode through the nested matrix workflow bundle and override list

## Validation
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py`
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check`

Tests were not run per request.