### PR TITLE
Add small w150 finetune bundle

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -64,6 +64,7 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w150_finetune_small
           - windowed_logreg_175_inner_prior
           - windowed_logreg_175_inner_prior_quota
           - windowed_logreg_175_inner_confusion
@@ -914,6 +915,21 @@ jobs:
                   "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
                   "classifier_params": "0.3,1",
                   "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_finetune_small": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5,1,2",
+                  "components_pca_values": "128,160",
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",


### PR DESCRIPTION
## Summary
- add `windowed_logreg_175_w150_finetune_small` to the nested matrix workflow
- keep the current best 175 ms / 150 ms source-only regime fixed
- tune only logistic/weighted-logistic C values `0.3,0.5,1,2` and PCA `128,160` for 16 candidates

## Verification
- git diff --check