### PR TITLE
Add w150 center grid bundle

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -65,6 +65,7 @@ on:
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
           - windowed_logreg_175_w150_finetune_small
+          - windowed_logreg_w150_center_grid
           - windowed_logreg_175_inner_prior
           - windowed_logreg_175_inner_prior_quota
           - windowed_logreg_175_inner_confusion
@@ -930,6 +931,21 @@ jobs:
                   "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
                   "classifier_params": "0.3,0.5,1,2",
                   "components_pca_values": "128,160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_w150_center_grid": {
+                  "window_centers": "0.150,0.175,0.200",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",


### PR DESCRIPTION
## Summary
- add `windowed_logreg_w150_center_grid` to the nested matrix workflow
- test 150 ms windows centered at 0.150, 0.175, and 0.200 s
- keep classifier family, C values, PCA, normalization, and ensemble settings fixed around the current best source-only regime

## Verification
- git diff --check