### PR TITLE
Add rank confusion calibration and test prior balance

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -31,6 +31,7 @@ on:
           - windowed_logreg_lean_rankaware
           - windowed_logreg_lean_rankaware_reciprocal
           - windowed_logreg_lean_rankaware_reciprocal_inner_prior
+          - windowed_logreg_lean_test_prior_balance
           - windowed_logreg_lean_rankaware_t2
           - windowed_logreg_lean_rankaware_t2_inner_prior
           - windowed_logreg_lean_ranksoft_t2
@@ -43,6 +44,7 @@ on:
           - windowed_logreg_175_balanced_quota
           - windowed_logreg_175_ranksoftmax_t2
           - windowed_logreg_175_finetune
+          - windowed_logreg_175_test_prior_balance
           - windowed_logreg_175_bias_calibration
           - windowed_logreg_175_rank_bias_calibration
           - windowed_logreg_175_probability_map
@@ -53,6 +55,8 @@ on:
           - windowed_logreg_175_rankborda_inner_confusion
           - windowed_logreg_175_rankz_inner_confusion_soft
           - windowed_logreg_175_train_scorecal
+          - windowed_logreg_175_rank_confusion_guarded
+          - windowed_logreg_lean_rank_confusion_guarded
           - windowed_logreg_lean_reciprocal_inner_prior
           - windowed_logreg_lean_inner_prior
           - windowed_logreg_lean_inner_prior_quota
@@ -107,6 +111,12 @@ on:
           - rank_top2_vote
           - rank_top3_vote
           - rank_z_blend
+          - rank_softmax_test_prior_balance
+          - rank_softmax_t2_test_prior_balance
+          - rank_softmax_t3_test_prior_balance
+          - rank_reciprocal_test_prior_balance
+          - rank_borda_test_prior_balance
+          - rank_z_blend_test_prior_balance
           - rank_softmax_balanced_quota
           - rank_softmax_t2_balanced_quota
           - rank_softmax_t3_balanced_quota
@@ -128,6 +138,10 @@ on:
           - rank_top2_vote_inner_balanced
           - rank_top3_vote_inner_balanced
           - rank_z_blend_inner_balanced
+          - rank_softmax_inner_balanced_test_prior_balance
+          - rank_softmax_t2_inner_balanced_test_prior_balance
+          - rank_borda_inner_balanced_test_prior_balance
+          - rank_softmax_inner_balanced_confusion_test_prior_balance
           - rank_softmax_inner_confusion
           - rank_softmax_t2_inner_confusion
           - rank_softmax_t3_inner_confusion
@@ -259,6 +273,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_test_prior_balance": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_test_prior_balance",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -553,6 +581,20 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_test_prior_balance": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_test_prior_balance",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_confusion_blend": {
                   "window_centers": "0.175",
                   "feature_modes": "sensor_flat",
@@ -633,6 +675,42 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_z_blend_inner_confusion_soft",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_rank_confusion_guarded": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_rank_confusion_blend_guarded,inner_rank_margin_confusion_blend_guarded",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_rank_confusion_guarded": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_rank_confusion_blend_guarded,inner_rank_margin_confusion_blend_guarded",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -82,6 +82,12 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top2_vote",
     "rank_top3_vote",
     "rank_z_blend",
+    "rank_softmax_test_prior_balance",
+    "rank_softmax_t2_test_prior_balance",
+    "rank_softmax_t3_test_prior_balance",
+    "rank_reciprocal_test_prior_balance",
+    "rank_borda_test_prior_balance",
+    "rank_z_blend_test_prior_balance",
     "rank_softmax_balanced_quota",
     "rank_softmax_t2_balanced_quota",
     "rank_softmax_t3_balanced_quota",
@@ -107,6 +113,16 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top2_vote_inner_balanced",
     "rank_top3_vote_inner_balanced",
     "rank_z_blend_inner_balanced",
+    "rank_softmax_inner_balanced_test_prior_balance",
+    "rank_softmax_t2_inner_balanced_test_prior_balance",
+    "rank_softmax_t3_inner_balanced_test_prior_balance",
+    "rank_reciprocal_inner_balanced_test_prior_balance",
+    "rank_borda_inner_balanced_test_prior_balance",
+    "rank_z_blend_inner_balanced_test_prior_balance",
+    "rank_softmax_inner_confusion_test_prior_balance",
+    "rank_borda_inner_confusion_test_prior_balance",
+    "rank_softmax_inner_balanced_confusion_test_prior_balance",
+    "rank_borda_inner_balanced_confusion_test_prior_balance",
     "rank_softmax_inner_confusion",
     "rank_softmax_t2_inner_confusion",
     "rank_softmax_t3_inner_confusion",
@@ -151,6 +167,9 @@ INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
 INNER_CONFUSION_CORRECTION_SMOOTHING = 1.0
 INNER_CONFUSION_CORRECTION_IDENTITY_BLEND = 0.20
 INNER_CONFUSION_CORRECTION_SOFT_BLEND = 0.35
+TEST_PRIOR_BALANCE_MAX_ITERATIONS = 50
+TEST_PRIOR_BALANCE_TOLERANCE = 1e-6
+TEST_PRIOR_BALANCE_EPSILON = 1e-12
 RANK_SOFTMAX_TEMPERATURES = {
     "rank_softmax": 1.0,
     "rank_softmax_t2": 2.0,
@@ -1880,6 +1899,12 @@ def _score_outer_fold_ensemble_models(
     ensemble_probabilities = _apply_inner_confusion_correction(
         ensemble_probabilities, confusion_correction_metadata
     )
+    test_prior_balance_metadata = _test_class_prior_balance_metadata(
+        ensemble_probabilities, class_order, ensemble_score_normalization
+    )
+    ensemble_probabilities = _apply_test_class_prior_balance(
+        ensemble_probabilities, test_prior_balance_metadata
+    )
     balanced_quota_metadata = _balanced_quota_metadata(
         ensemble_probabilities, class_order, ensemble_score_normalization
     )
@@ -1933,6 +1958,7 @@ def _score_outer_fold_ensemble_models(
     )
     _add_inner_class_prior_balance_fields(outer_row, prior_balance_metadata)
     _add_inner_confusion_correction_fields(outer_row, confusion_correction_metadata)
+    _add_test_class_prior_balance_fields(outer_row, test_prior_balance_metadata)
     _add_balanced_quota_fields(outer_row, balanced_quota_metadata)
 
     prediction_rows = []
@@ -1959,6 +1985,7 @@ def _score_outer_fold_ensemble_models(
             )
             _add_inner_class_prior_balance_fields(row, prior_balance_metadata)
             _add_inner_confusion_correction_fields(row, confusion_correction_metadata)
+            _add_test_class_prior_balance_fields(row, test_prior_balance_metadata)
             _add_balanced_quota_fields(row, balanced_quota_metadata)
     return outer_row, prediction_rows
 
@@ -2177,11 +2204,25 @@ def _align_score_columns(probabilities, score_classes, class_order):
     return aligned
 
 
+def _without_test_prior_balance_suffix(score_normalization):
+    score_normalization = str(score_normalization).strip()
+    if score_normalization.endswith("_test_prior_balance"):
+        return score_normalization.removesuffix("_test_prior_balance")
+    return score_normalization
+
+
 def _without_balanced_quota_suffix(score_normalization):
     score_normalization = str(score_normalization).strip()
     if score_normalization.endswith("_balanced_quota"):
-        return score_normalization.removesuffix("_balanced_quota")
-    return score_normalization
+        score_normalization = score_normalization.removesuffix("_balanced_quota")
+    return _without_test_prior_balance_suffix(score_normalization)
+
+
+def _test_class_prior_balance_mode(score_normalization):
+    normalized = str(score_normalization).strip().lower().replace("-", "_")
+    if normalized not in ENSEMBLE_SCORE_NORMALIZATION_MODES:
+        return None
+    return normalized if normalized.endswith("_test_prior_balance") else None
 
 
 def _inner_class_prior_balance_mode(score_normalization):
@@ -2268,6 +2309,131 @@ def _apply_inner_class_prior_balance(probabilities, metadata):
         row_sums,
         out=np.full_like(adjusted, 1.0 / adjusted.shape[1]),
         where=row_sums > 0.0,
+    )
+
+
+def _test_class_prior_balance_metadata(probabilities, class_order, score_normalization):
+    """Return optional unlabeled held-out-batch prior-balancing metadata.
+
+    BUSH main-task folds are designed as balanced 16-way decoding problems. This
+    postprocessor uses that protocol-level prior, but not held-out labels: it
+    rescales the ensemble probability matrix so each class receives equal total
+    probability mass across the held-out subject. It is softer than the existing
+    balanced-quota assignment because argmax decisions are still made from a
+    probability matrix rather than from a one-to-one linear assignment.
+    """
+
+    mode = _test_class_prior_balance_mode(score_normalization)
+    if mode is None:
+        return {"mode": "none"}
+
+    adjusted, target_mass, iterations, status = _test_class_prior_balanced_probabilities(
+        probabilities
+    )
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    probabilities = np.asarray(probabilities, dtype=float)
+    observed_mass = (
+        np.sum(probabilities, axis=0)
+        if probabilities.ndim == 2
+        else np.asarray((), dtype=float)
+    )
+    adjusted_mass = (
+        np.sum(adjusted, axis=0) if adjusted.ndim == 2 else np.asarray((), dtype=float)
+    )
+    return {
+        "mode": mode,
+        "status": status,
+        "iterations": iterations,
+        "class_order": class_order,
+        "target_mass": target_mass,
+        "observed_mass": observed_mass,
+        "adjusted_mass": adjusted_mass,
+        "probabilities": adjusted,
+    }
+
+
+def _test_class_prior_balanced_probabilities(probabilities):
+    probabilities = np.asarray(probabilities, dtype=float)
+    if (
+        probabilities.ndim != 2
+        or probabilities.shape[0] == 0
+        or probabilities.shape[1] == 0
+    ):
+        return (
+            probabilities,
+            np.asarray((), dtype=float),
+            0,
+            "skipped_empty_scores",
+        )
+
+    n_trials, n_classes = probabilities.shape
+    epsilon = float(TEST_PRIOR_BALANCE_EPSILON)
+    adjusted = np.where(
+        np.isfinite(probabilities) & (probabilities > 0.0), probabilities, epsilon
+    )
+    adjusted = np.maximum(adjusted, epsilon)
+    row_sums = np.sum(adjusted, axis=1, keepdims=True)
+    adjusted = np.divide(
+        adjusted,
+        row_sums,
+        out=np.full_like(adjusted, 1.0 / n_classes),
+        where=row_sums > 0.0,
+    )
+
+    target_mass = np.full(n_classes, float(n_trials) / float(n_classes), dtype=float)
+    status = "applied_max_iterations"
+    iterations = 0
+    for iteration in range(1, int(TEST_PRIOR_BALANCE_MAX_ITERATIONS) + 1):
+        column_sums = np.sum(adjusted, axis=0, keepdims=True)
+        scale = np.divide(
+            target_mass[None, :],
+            column_sums,
+            out=np.ones_like(column_sums),
+            where=column_sums > epsilon,
+        )
+        adjusted *= scale
+        row_sums = np.sum(adjusted, axis=1, keepdims=True)
+        adjusted = np.divide(
+            adjusted,
+            row_sums,
+            out=np.full_like(adjusted, 1.0 / n_classes),
+            where=row_sums > 0.0,
+        )
+        iterations = iteration
+        if (
+            float(np.max(np.abs(np.sum(adjusted, axis=0) - target_mass)))
+            <= float(TEST_PRIOR_BALANCE_TOLERANCE)
+        ):
+            status = "applied"
+            break
+
+    return adjusted, target_mass, iterations, status
+
+
+def _apply_test_class_prior_balance(probabilities, metadata):
+    if _test_class_prior_balance_mode(metadata.get("mode")) is None:
+        return np.asarray(probabilities, dtype=float)
+    adjusted = np.asarray(metadata.get("probabilities", ()), dtype=float)
+    probabilities = np.asarray(probabilities, dtype=float)
+    if adjusted.shape != probabilities.shape:
+        return probabilities
+    return adjusted
+
+
+def _add_test_class_prior_balance_fields(row, metadata):
+    row["ensemble_test_class_prior_balance"] = metadata.get("mode", "none")
+    row["ensemble_test_class_prior_status"] = metadata.get("status", "")
+    row["ensemble_test_class_prior_iterations"] = metadata.get("iterations", "")
+    class_order = np.asarray(metadata.get("class_order", ()), dtype=int)
+    labels_one_based = class_order + 1
+    row["ensemble_test_class_prior_target_mass"] = _format_float_mapping(
+        zip(labels_one_based, metadata.get("target_mass", ()))
+    )
+    row["ensemble_test_class_prior_observed_mass"] = _format_float_mapping(
+        zip(labels_one_based, metadata.get("observed_mass", ()))
+    )
+    row["ensemble_test_class_prior_adjusted_mass"] = _format_float_mapping(
+        zip(labels_one_based, metadata.get("adjusted_mass", ()))
     )
 
 

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -28,6 +28,8 @@ INNER_SCORE_CALIBRATION_MODES = frozenset(
         "inner_rank_probability_map",
         "inner_confusion_blend",
         "inner_margin_confusion_blend",
+        "inner_rank_confusion_blend",
+        "inner_rank_margin_confusion_blend",
     )
 )
 GUARDED_INNER_SCORE_CALIBRATION_MODES = frozenset(
@@ -57,6 +59,10 @@ SCORE_CALIBRATION_MODES = (
     "inner_confusion_blend_guarded",
     "inner_margin_confusion_blend",
     "inner_margin_confusion_blend_guarded",
+    "inner_rank_confusion_blend",
+    "inner_rank_confusion_blend_guarded",
+    "inner_rank_margin_confusion_blend",
+    "inner_rank_margin_confusion_blend_guarded",
     "train_class_bias",
     "train_class_affine",
     "train_rank_bias",
@@ -592,13 +598,16 @@ def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_
             baseline_balanced,
             guarded=guarded,
         )
-    if base_mode == "inner_confusion_blend":
+    if base_mode in {"inner_confusion_blend", "inner_rank_confusion_blend"}:
+        score_space = "rank" if base_mode == "inner_rank_confusion_blend" else "raw"
+        calibration_scores = _rank_score_matrix(scores) if score_space == "rank" else scores
         confusion_matrix, blend_alpha, inner_balanced = _fit_confusion_blend(
-            scores, labels, class_order
+            calibration_scores, labels, class_order
         )
         return _guard_inner_score_calibration_metadata(
             {
                 "mode": mode,
+                "score_space": score_space,
                 "classes": class_order,
                 "confusion_matrix": confusion_matrix,
                 "blend_alpha": blend_alpha,
@@ -609,13 +618,18 @@ def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_
             baseline_balanced,
             guarded=guarded,
         )
-    if base_mode == "inner_margin_confusion_blend":
+    if base_mode in {"inner_margin_confusion_blend", "inner_rank_margin_confusion_blend"}:
+        score_space = (
+            "rank" if base_mode == "inner_rank_margin_confusion_blend" else "raw"
+        )
+        calibration_scores = _rank_score_matrix(scores) if score_space == "rank" else scores
         confusion_matrix, blend_alpha, margin_threshold, inner_balanced = (
-            _fit_margin_confusion_blend(scores, labels, class_order)
+            _fit_margin_confusion_blend(calibration_scores, labels, class_order)
         )
         return _guard_inner_score_calibration_metadata(
             {
                 "mode": mode,
+                "score_space": score_space,
                 "classes": class_order,
                 "confusion_matrix": confusion_matrix,
                 "blend_alpha": blend_alpha,
@@ -1131,7 +1145,12 @@ def _has_active_score_calibration_metadata(metadata):
     if mode not in ACTIVE_SCORE_CALIBRATION_MODES:
         return False
     base_mode = _score_calibration_base_mode(mode)
-    if base_mode in {"inner_confusion_blend", "inner_margin_confusion_blend"}:
+    if base_mode in {
+        "inner_confusion_blend",
+        "inner_margin_confusion_blend",
+        "inner_rank_confusion_blend",
+        "inner_rank_margin_confusion_blend",
+    }:
         return "classes" in metadata and "confusion_matrix" in metadata
     return "bias" in metadata or "probability_map" in metadata
 
@@ -1142,8 +1161,10 @@ def _apply_score_calibration(scores, classes, fitted_model):
         return scores, classes
     calibration_classes = np.asarray(metadata["classes"], dtype=int)
     base_mode = _score_calibration_base_mode(metadata.get("mode", "none"))
-    if base_mode == "inner_confusion_blend":
+    if base_mode in {"inner_confusion_blend", "inner_rank_confusion_blend"}:
         aligned = _align_class_score_columns(scores, classes, calibration_classes)
+        if metadata.get("score_space") == "rank":
+            aligned = _rank_score_matrix(aligned)
         return (
             _confusion_blend_scores(
                 aligned,
@@ -1152,8 +1173,10 @@ def _apply_score_calibration(scores, classes, fitted_model):
             ),
             calibration_classes,
         )
-    if base_mode == "inner_margin_confusion_blend":
+    if base_mode in {"inner_margin_confusion_blend", "inner_rank_margin_confusion_blend"}:
         aligned = _align_class_score_columns(scores, classes, calibration_classes)
+        if metadata.get("score_space") == "rank":
+            aligned = _rank_score_matrix(aligned)
         return (
             _margin_confusion_blend_scores(
                 aligned,

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1008,6 +1008,52 @@ class TestStimulusCrossSubject(unittest.TestCase):
             ),
             "rank_softmax_t2",
         )
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(  # pylint: disable=protected-access
+                "rank-softmax-t2-test-prior-balance"
+            ),
+            "rank_softmax_t2",
+        )
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(  # pylint: disable=protected-access
+                "rank-softmax-inner-balanced-test-prior-balance"
+            ),
+            "rank_softmax",
+        )
+
+    def test_test_class_prior_balance_equalizes_unlabeled_class_mass(self):
+        probabilities = np.asarray(
+            [
+                [0.90, 0.10],
+                [0.80, 0.20],
+                [0.70, 0.30],
+                [0.60, 0.40],
+            ],
+            dtype=float,
+        )
+
+        adjusted, target_mass, iterations, status = cross_subject._test_class_prior_balanced_probabilities(  # pylint: disable=protected-access
+            probabilities
+        )
+
+        self.assertIn(status, {"applied", "applied_max_iterations"})
+        self.assertGreater(iterations, 0)
+        np.testing.assert_allclose(np.sum(adjusted, axis=1), np.ones(4))
+        np.testing.assert_allclose(np.sum(adjusted, axis=0), target_mass, atol=1e-5)
+        np.testing.assert_allclose(target_mass, np.asarray([2.0, 2.0]))
+
+        metadata = cross_subject._test_class_prior_balance_metadata(  # pylint: disable=protected-access
+            probabilities,
+            np.asarray([0, 1], dtype=int),
+            "rank_softmax_test_prior_balance",
+        )
+        applied = cross_subject._apply_test_class_prior_balance(  # pylint: disable=protected-access
+            probabilities,
+            metadata,
+        )
+        np.testing.assert_allclose(applied, adjusted)
+        self.assertEqual(metadata["mode"], "rank_softmax_test_prior_balance")
+        self.assertEqual(metadata["class_order"].tolist(), [0, 1])
 
     def test_rank_borda_score_normalization_uses_linear_rank_weights(self):
         scores = np.asarray(

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -226,6 +226,32 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
             "inner_margin_confusion_blend",
         )
 
+    def test_candidate_grid_accepts_rank_confusion_blend_score_calibration_modes(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            score_calibrations=(
+                "inner_rank_confusion_blend",
+                "inner_rank_margin_confusion_blend",
+                "inner_rank_confusion_blend_guarded",
+            ),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 3)
+        self.assertEqual(
+            {config.score_calibration for config in configs},
+            {
+                "inner_rank_confusion_blend",
+                "inner_rank_margin_confusion_blend",
+                "inner_rank_confusion_blend_guarded",
+            },
+        )
+
     def test_candidate_grid_accepts_guarded_inner_score_calibration_modes(self):
         configs = make_cross_subject_candidate_configs(
             window_centers=(0.175,),
@@ -544,6 +570,34 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_array_equal(classes, np.asarray([0, 1]))
         self.assertGreater(calibrated[0, 1], calibrated[0, 0])
         self.assertGreater(calibrated[1, 0], calibrated[1, 1])
+
+    def test_rank_confusion_blend_score_calibration_uses_rank_space(self):
+        scores = np.asarray([[100.0, 99.0, 0.0], [1.0, 0.0, 100.0]], dtype=float)
+        fitted_model = {
+            "score_calibration_metadata": {
+                "mode": "inner_rank_confusion_blend",
+                "score_space": "rank",
+                "classes": np.asarray([0, 1, 2]),
+                "confusion_matrix": np.asarray(
+                    [
+                        [0.0, 1.0, 0.0],
+                        [1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    dtype=float,
+                ),
+                "blend_alpha": 1.0,
+            }
+        }
+
+        calibrated, classes = cross_subject._apply_score_calibration(  # pylint: disable=protected-access
+            scores,
+            np.asarray([0, 1, 2]),
+            fitted_model,
+        )
+
+        np.testing.assert_array_equal(classes, np.asarray([0, 1, 2]))
+        np.testing.assert_array_equal(np.argmax(calibrated, axis=1), np.asarray([1, 2]))
 
     def test_inner_margin_confusion_blend_only_reranks_low_margin_trials(self):
         scores = np.asarray(


### PR DESCRIPTION
## Summary
- add rank-space inner confusion and margin-confusion calibration modes to the next cross-subject pipeline
- add unlabeled held-out test-prior balancing modes to the legacy ensemble path
- expose new nested-matrix workflow bundles and score-normalization choices
- add focused coverage for the new calibration and balancing helpers

## Validation
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject.py`
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject.py`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check`

Tests were not run, per request.