### PR TITLE
Add soft and guarded inner confusion modes

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -61,6 +61,8 @@ on:
           - windowed_logreg_lean_inner_prior
           - windowed_logreg_lean_inner_prior_quota
           - windowed_logreg_lean_inner_confusion
+          - windowed_logreg_lean_guarded_inner_confusion
+          - windowed_logreg_lean_inner_confusion_soft
           - windowed_logreg_lean_inner_confusion_quota
           - windowed_logreg_lean_inner_prior_confusion
           - windowed_logreg_lean_inner_prior_confusion_quota
@@ -73,6 +75,8 @@ on:
           - windowed_logreg_175_inner_prior
           - windowed_logreg_175_inner_prior_quota
           - windowed_logreg_175_inner_confusion
+          - windowed_logreg_175_guarded_inner_confusion
+          - windowed_logreg_175_inner_confusion_soft
           - windowed_logreg_175_inner_confusion_quota
           - windowed_logreg_175_inner_prior_confusion
           - windowed_logreg_175_inner_prior_confusion_quota
@@ -151,6 +155,23 @@ on:
           - rank_top3_vote_inner_confusion
           - rank_z_blend_inner_confusion
           - rank_z_blend_inner_confusion_soft
+          - rank_softmax_inner_confusion_soft
+          - rank_softmax_t2_inner_confusion_soft
+          - rank_softmax_t3_inner_confusion_soft
+          - rank_reciprocal_inner_confusion_soft
+          - rank_borda_inner_confusion_soft
+          - rank_top2_vote_inner_confusion_soft
+          - rank_top3_vote_inner_confusion_soft
+          - rank_softmax_inner_balanced_confusion_soft
+          - rank_softmax_inner_confusion_guarded
+          - rank_softmax_t2_inner_confusion_guarded
+          - rank_softmax_t3_inner_confusion_guarded
+          - rank_reciprocal_inner_confusion_guarded
+          - rank_borda_inner_confusion_guarded
+          - rank_top2_vote_inner_confusion_guarded
+          - rank_top3_vote_inner_confusion_guarded
+          - rank_z_blend_inner_confusion_guarded
+          - rank_z_blend_inner_confusion_soft_guarded
           - rank_softmax_inner_balanced_confusion
           - rank_reciprocal_inner_balanced_confusion
           - rank_borda_inner_balanced_confusion
@@ -787,6 +808,34 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_lean_guarded_inner_confusion": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_guarded",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_inner_confusion_soft": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_soft",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_lean_inner_confusion_quota": {
                   "window_centers": "0.175,0.200",
                   "feature_modes": "sensor_flat",
@@ -882,6 +931,34 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_confusion",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_guarded_inner_confusion": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_guarded",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_inner_confusion_soft": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_soft",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -130,9 +130,26 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_borda_inner_confusion",
     "rank_top2_vote_inner_confusion",
     "rank_top3_vote_inner_confusion",
+    "rank_softmax_inner_confusion_soft",
+    "rank_softmax_t2_inner_confusion_soft",
+    "rank_softmax_t3_inner_confusion_soft",
+    "rank_reciprocal_inner_confusion_soft",
+    "rank_borda_inner_confusion_soft",
+    "rank_top2_vote_inner_confusion_soft",
+    "rank_top3_vote_inner_confusion_soft",
     "rank_z_blend_inner_confusion",
     "rank_z_blend_inner_confusion_soft",
+    "rank_softmax_inner_confusion_guarded",
+    "rank_softmax_t2_inner_confusion_guarded",
+    "rank_softmax_t3_inner_confusion_guarded",
+    "rank_reciprocal_inner_confusion_guarded",
+    "rank_borda_inner_confusion_guarded",
+    "rank_top2_vote_inner_confusion_guarded",
+    "rank_top3_vote_inner_confusion_guarded",
+    "rank_z_blend_inner_confusion_guarded",
+    "rank_z_blend_inner_confusion_soft_guarded",
     "rank_softmax_inner_balanced_confusion",
+    "rank_softmax_inner_balanced_confusion_soft",
     "rank_reciprocal_inner_balanced_confusion",
     "rank_borda_inner_balanced_confusion",
     "rank_z_blend_inner_balanced_confusion",
@@ -155,11 +172,28 @@ INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_borda_inner_confusion": "rank_borda",
     "rank_top2_vote_inner_confusion": "rank_top2_vote",
     "rank_top3_vote_inner_confusion": "rank_top3_vote",
+    "rank_softmax_inner_confusion_soft": "rank_softmax",
+    "rank_softmax_t2_inner_confusion_soft": "rank_softmax_t2",
+    "rank_softmax_t3_inner_confusion_soft": "rank_softmax_t3",
+    "rank_reciprocal_inner_confusion_soft": "rank_reciprocal",
+    "rank_borda_inner_confusion_soft": "rank_borda",
+    "rank_top2_vote_inner_confusion_soft": "rank_top2_vote",
+    "rank_top3_vote_inner_confusion_soft": "rank_top3_vote",
     "rank_z_blend_inner_confusion": "rank_z_blend",
     "rank_z_blend_inner_confusion_soft": "rank_z_blend",
+    "rank_softmax_inner_confusion_guarded": "rank_softmax",
+    "rank_softmax_t2_inner_confusion_guarded": "rank_softmax_t2",
+    "rank_softmax_t3_inner_confusion_guarded": "rank_softmax_t3",
+    "rank_reciprocal_inner_confusion_guarded": "rank_reciprocal",
+    "rank_borda_inner_confusion_guarded": "rank_borda",
+    "rank_top2_vote_inner_confusion_guarded": "rank_top2_vote",
+    "rank_top3_vote_inner_confusion_guarded": "rank_top3_vote",
+    "rank_z_blend_inner_confusion_guarded": "rank_z_blend",
+    "rank_z_blend_inner_confusion_soft_guarded": "rank_z_blend",
 }
 INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_inner_balanced_confusion": "rank_softmax",
+    "rank_softmax_inner_balanced_confusion_soft": "rank_softmax",
     "rank_reciprocal_inner_balanced_confusion": "rank_reciprocal",
     "rank_borda_inner_balanced_confusion": "rank_borda",
     "rank_z_blend_inner_balanced_confusion": "rank_z_blend",
@@ -167,6 +201,7 @@ INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES = {
 INNER_CONFUSION_CORRECTION_SMOOTHING = 1.0
 INNER_CONFUSION_CORRECTION_IDENTITY_BLEND = 0.20
 INNER_CONFUSION_CORRECTION_SOFT_BLEND = 0.35
+INNER_CONFUSION_CORRECTION_GUARDED_POWER = 0.5
 TEST_PRIOR_BALANCE_MAX_ITERATIONS = 50
 TEST_PRIOR_BALANCE_TOLERANCE = 1e-6
 TEST_PRIOR_BALANCE_EPSILON = 1e-12
@@ -2491,11 +2526,54 @@ def _balanced_quota_predictions(probabilities, class_order):
 def _inner_confusion_correction_blend(inner_mode):
     """Return the outer posterior blend used by an inner-confusion mode."""
 
+    mode = str(inner_mode)
+    if mode.endswith("_guarded"):
+        mode = mode.removesuffix("_guarded")
     return (
         float(INNER_CONFUSION_CORRECTION_SOFT_BLEND)
-        if str(inner_mode).endswith("_soft")
+        if mode.endswith("_soft")
         else 1.0
     )
+
+
+def _inner_confusion_correction_is_guarded(inner_mode):
+    """Return whether an inner-confusion correction should be reliability-gated."""
+
+    return str(inner_mode).endswith("_guarded")
+
+
+def _inner_confusion_correction_reliability_metadata(counts):
+    """Estimate how trustworthy an inner confusion map is relative to chance."""
+
+    counts = np.asarray(counts, dtype=float)
+    if counts.ndim != 2 or counts.shape[0] == 0 or counts.shape[0] != counts.shape[1]:
+        return {
+            "diagonal_fraction": np.nan,
+            "chance_diagonal_fraction": np.nan,
+            "guarded_reliability": 0.0,
+        }
+    total = float(np.sum(counts))
+    if total <= 0.0 or not np.isfinite(total):
+        return {
+            "diagonal_fraction": np.nan,
+            "chance_diagonal_fraction": 1.0 / counts.shape[0],
+            "guarded_reliability": 0.0,
+        }
+    diagonal_fraction = float(np.trace(counts) / total)
+    chance_diagonal_fraction = float(1.0 / counts.shape[0])
+    if counts.shape[0] <= 1:
+        raw_reliability = 1.0
+    else:
+        raw_reliability = (diagonal_fraction - chance_diagonal_fraction) / (
+            1.0 - chance_diagonal_fraction
+        )
+    raw_reliability = float(np.clip(raw_reliability, 0.0, 1.0))
+    return {
+        "diagonal_fraction": diagonal_fraction,
+        "chance_diagonal_fraction": chance_diagonal_fraction,
+        "guarded_reliability": raw_reliability
+        ** float(INNER_CONFUSION_CORRECTION_GUARDED_POWER),
+    }
 
 
 def _finite_assignment_scores(probabilities):
@@ -2573,6 +2651,13 @@ def _inner_confusion_correction_metadata(
     smoothing = float(INNER_CONFUSION_CORRECTION_SMOOTHING)
     identity_blend = float(INNER_CONFUSION_CORRECTION_IDENTITY_BLEND)
     blend = _inner_confusion_correction_blend(inner_mode)
+    guarded = _inner_confusion_correction_is_guarded(inner_mode)
+    reliability_metadata = _inner_confusion_correction_reliability_metadata(counts)
+    if guarded:
+        blend *= float(reliability_metadata["guarded_reliability"])
+    status = "applied"
+    if guarded and float(reliability_metadata["guarded_reliability"]) <= 0.0:
+        status = "skipped_low_inner_confusion_reliability"
     smoothed = counts + smoothing
     predicted_totals = np.sum(smoothed, axis=0, keepdims=True)
     true_given_predicted = np.divide(
@@ -2595,13 +2680,19 @@ def _inner_confusion_correction_metadata(
     return {
         "mode": score_normalization,
         "inner_mode": inner_mode,
-        "status": "applied",
+        "status": status,
         "smoothing": smoothing,
         "blend": blend,
         "identity_blend": identity_blend,
+        "guarded": guarded,
         "class_order": class_order,
         "true_predicted_counts": counts,
         "true_given_predicted": true_given_predicted,
+        "diagonal_fraction": reliability_metadata["diagonal_fraction"],
+        "chance_diagonal_fraction": reliability_metadata[
+            "chance_diagonal_fraction"
+        ],
+        "guarded_reliability": reliability_metadata["guarded_reliability"],
     }
 
 
@@ -2632,6 +2723,13 @@ def _add_inner_confusion_correction_fields(row, metadata):
     row["ensemble_inner_confusion_blend"] = metadata.get("blend", "")
     row["ensemble_inner_confusion_identity_blend"] = metadata.get(
         "identity_blend", ""
+    )
+    row["ensemble_inner_confusion_guarded"] = metadata.get("guarded", "")
+    row["ensemble_inner_confusion_guarded_reliability"] = metadata.get(
+        "guarded_reliability", ""
+    )
+    row["ensemble_inner_confusion_chance_diagonal_fraction"] = metadata.get(
+        "chance_diagonal_fraction", ""
     )
     row["ensemble_inner_confusion_true_predicted_counts"] = _format_matrix_mapping(
         metadata.get("class_order", ()),

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -83,6 +83,18 @@ SCORE_CALIBRATION_L2 = 1e-3
 SCORE_CALIBRATION_MIN_INNER_GAIN = 1e-12
 SCORE_CALIBRATION_PROBABILITY_MAP_L2 = 1e-2
 SCORE_CALIBRATION_PROBABILITY_MAP_IDENTITY_BLEND = 0.20
+SOFT_INNER_CONFUSION_SCORE_NORMALIZATION_BASES = {
+    "rank_softmax_inner_confusion_soft": "rank_softmax",
+    "rank_softmax_t2_inner_confusion_soft": "rank_softmax_t2",
+    "rank_softmax_t3_inner_confusion_soft": "rank_softmax_t3",
+    "rank_reciprocal_inner_confusion_soft": "rank_reciprocal",
+    "rank_borda_inner_confusion_soft": "rank_borda",
+    "rank_top2_vote_inner_confusion_soft": "rank_top2_vote",
+    "rank_top3_vote_inner_confusion_soft": "rank_top3_vote",
+}
+SOFT_INNER_BALANCED_CONFUSION_SCORE_NORMALIZATION_BASES = {
+    "rank_softmax_inner_balanced_confusion_soft": "rank_softmax",
+}
 CONFUSION_CALIBRATION_SMOOTHING = 1.0
 CONFUSION_CALIBRATION_BLEND_GRID = tuple(
     float(value) for value in np.linspace(0.0, 1.0, 11)
@@ -162,6 +174,7 @@ def install(impl) -> None:
     impl.DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = DEFAULT_SENSOR_TIME_PYRAMID_LEVELS
     impl.FEATURE_MODES = tuple(dict.fromkeys((*impl.FEATURE_MODES, *EXTENDED_FEATURE_MODES)))
     impl.CrossSubjectStimulusConfig = NextCrossSubjectStimulusConfig
+    _install_soft_inner_confusion_score_normalizations(impl)
 
     impl._normalize_feature_mode = _normalize_feature_mode
     impl._normalized_config = _normalized_config
@@ -184,6 +197,24 @@ def install(impl) -> None:
     impl._rank_nested_candidates = _rank_nested_candidates
     impl.CROSS_SUBJECT_PREDICTION_GROUP_COLUMNS = _prediction_group_columns(impl.CROSS_SUBJECT_PREDICTION_GROUP_COLUMNS)
     impl._next_methods_installed = True
+
+
+def _install_soft_inner_confusion_score_normalizations(impl) -> None:
+    """Expose conservative inner-confusion score reranking variants."""
+
+    impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        SOFT_INNER_CONFUSION_SCORE_NORMALIZATION_BASES
+    )
+    impl.INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        SOFT_INNER_BALANCED_CONFUSION_SCORE_NORMALIZATION_BASES
+    )
+    extra_modes = (
+        tuple(SOFT_INNER_CONFUSION_SCORE_NORMALIZATION_BASES)
+        + tuple(SOFT_INNER_BALANCED_CONFUSION_SCORE_NORMALIZATION_BASES)
+    )
+    impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
+        dict.fromkeys((*impl.ENSEMBLE_SCORE_NORMALIZATION_MODES, *extra_modes))
+    )
 
 
 def _prediction_group_columns(columns):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -422,6 +422,42 @@ class TestStimulusCrossSubject(unittest.TestCase):
             np.bincount(quota["predictions"], minlength=2).tolist(), [1, 1]
         )
 
+    def test_guarded_inner_confusion_skips_near_chance_correction(self):
+        mode = "rank_softmax_inner_confusion_guarded"
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        selected_rows = (
+            {
+                "selected_inner_true_predicted_label_pair_counts": (
+                    "1001:10;1002:10;2001:10;2002:10"
+                ),
+            },
+        )
+        metadata = cross_subject._inner_confusion_correction_metadata(
+            selected_rows,
+            np.asarray([0, 1], dtype=int),
+            np.asarray([1.0], dtype=float),
+            mode,
+        )
+        probabilities = np.asarray([[0.70, 0.30], [0.20, 0.80]], dtype=float)
+        adjusted = cross_subject._apply_inner_confusion_correction(
+            probabilities,
+            metadata,
+        )
+        expected_base = cross_subject._class_score_probabilities(
+            np.asarray([[3.0, 1.0], [1.0, 3.0]], dtype=float),
+            score_normalization="rank_softmax",
+        )
+        guarded_base = cross_subject._class_score_probabilities(
+            np.asarray([[3.0, 1.0], [1.0, 3.0]], dtype=float),
+            score_normalization=mode,
+        )
+
+        self.assertEqual(metadata["status"], "skipped_low_inner_confusion_reliability")
+        self.assertTrue(metadata["guarded"])
+        self.assertEqual(metadata["guarded_reliability"], 0.0)
+        np.testing.assert_allclose(adjusted, probabilities)
+        np.testing.assert_allclose(guarded_base, expected_base)
+
     def test_balanced_quota_assignment_enforces_known_batch_balance(self):
         probabilities = np.asarray(
             [
@@ -686,6 +722,56 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(cross_subject._inner_class_prior_balance_mode(quota_mode), mode)  # pylint: disable=protected-access
         self.assertEqual(cross_subject._inner_confusion_correction_mode(mode), mode)  # pylint: disable=protected-access
         self.assertEqual(cross_subject._inner_confusion_correction_mode(quota_mode), mode)  # pylint: disable=protected-access
+
+    def test_soft_inner_confusion_score_normalizations_are_supported(self):
+        expected_bases = {
+            "rank_softmax_inner_confusion_soft": "rank_softmax",
+            "rank_softmax_t2_inner_confusion_soft": "rank_softmax_t2",
+            "rank_softmax_t3_inner_confusion_soft": "rank_softmax_t3",
+            "rank_reciprocal_inner_confusion_soft": "rank_reciprocal",
+            "rank_borda_inner_confusion_soft": "rank_borda",
+            "rank_top2_vote_inner_confusion_soft": "rank_top2_vote",
+            "rank_top3_vote_inner_confusion_soft": "rank_top3_vote",
+        }
+
+        for mode, expected_base in expected_bases.items():
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    cross_subject._normalize_ensemble_score_normalization(mode),
+                    mode,
+                )  # pylint: disable=protected-access
+                self.assertEqual(
+                    cross_subject._base_ensemble_score_normalization(mode),
+                    expected_base,
+                )  # pylint: disable=protected-access
+                self.assertEqual(
+                    cross_subject._inner_confusion_correction_mode(mode),
+                    mode,
+                )  # pylint: disable=protected-access
+                self.assertEqual(
+                    cross_subject._inner_confusion_correction_blend(mode),
+                    cross_subject.INNER_CONFUSION_CORRECTION_SOFT_BLEND,
+                )  # pylint: disable=protected-access
+
+    def test_soft_inner_balanced_confusion_score_normalization_is_supported(self):
+        mode = "rank_softmax_inner_balanced_confusion_soft"
+
+        self.assertEqual(
+            cross_subject._normalize_ensemble_score_normalization(mode),
+            mode,
+        )  # pylint: disable=protected-access
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),
+            "rank_softmax",
+        )  # pylint: disable=protected-access
+        self.assertEqual(
+            cross_subject._inner_class_prior_balance_mode(mode),
+            mode,
+        )  # pylint: disable=protected-access
+        self.assertEqual(
+            cross_subject._inner_confusion_correction_mode(mode),
+            mode,
+        )  # pylint: disable=protected-access
 
     def test_evaluate_cross_subject_stimulus_smoke(self):
         data_by_participant = {


### PR DESCRIPTION
## Summary
- add soft inner-confusion score normalization variants, including balanced-confusion support
- add guarded inner-confusion reliability gating and diagnostics
- expose guarded/soft variants in the nested matrix workflow

## Validation
- Did not run tests per request
- Ran syntax/lint/YAML/whitespace checks only