### PR TITLE
Add temporal delta BUSH-MEG features

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -70,6 +70,7 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_temporal_delta_features
           - windowed_logreg_175_w150_finetune_small
           - windowed_logreg_w150_center_grid
           - windowed_logreg_175_inner_prior
@@ -1075,6 +1076,25 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_temporal_delta_features": {
+                  "window_centers": "0.175",
+                  "window_size": "0.100",
+                  "feature_modes": "sensor_flat,sensor_time_pyramid_delta,sensor_time_pyramid_delta_logpower",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_w150_finetune_small": {

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -70,7 +70,12 @@ SCORE_CALIBRATION_MODES = (
 DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = 1.0
 DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
 DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
-BASELINE_WHITENED_EXTENDED_FEATURE_MODES = ("sensor_time_pyramid", "sensor_time_pyramid_logpower")
+BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
+    "sensor_time_pyramid",
+    "sensor_time_pyramid_logpower",
+    "sensor_time_pyramid_delta",
+    "sensor_time_pyramid_delta_logpower",
+)
 EXTENDED_FEATURE_MODES = (
     "sensor_logpower",
     "sensor_mean_logpower",
@@ -78,6 +83,8 @@ EXTENDED_FEATURE_MODES = (
     "sensor_cov_tangent",
     "sensor_time_pyramid",
     "sensor_time_pyramid_logpower",
+    "sensor_time_pyramid_delta",
+    "sensor_time_pyramid_delta_logpower",
 )
 SCORE_CALIBRATION_L2 = 1e-3
 SCORE_CALIBRATION_MIN_INNER_GAIN = 1e-12
@@ -363,6 +370,10 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_time_pyramid_feature(signal)
         elif feature_mode == "sensor_time_pyramid_logpower":
             feature = np.concatenate((_sensor_time_pyramid_feature(signal), _sensor_logpower_feature(signal)))
+        elif feature_mode == "sensor_time_pyramid_delta":
+            feature = _sensor_time_pyramid_delta_feature(signal)
+        elif feature_mode == "sensor_time_pyramid_delta_logpower":
+            feature = np.concatenate((_sensor_time_pyramid_delta_feature(signal), _sensor_logpower_feature(signal)))
         else:
             raise ValueError(f"Unsupported feature_mode: {feature_mode}")
         features.append(feature)
@@ -416,6 +427,35 @@ def _sensor_time_pyramid_feature(window_signal, levels=DEFAULT_SENSOR_TIME_PYRAM
         for indices in np.array_split(sample_indices, level):
             pieces.append(np.mean(signal[:, indices], axis=1) if indices.size else np.zeros(signal.shape[0], dtype=float))
     return np.concatenate(pieces)
+
+
+def _sensor_time_pyramid_delta_feature(
+    window_signal, levels=DEFAULT_SENSOR_TIME_PYRAMID_LEVELS
+):
+    """Concatenate temporal-pyramid means and adjacent-bin deltas per sensor."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    if signal.ndim != 2:
+        raise ValueError("window_signal must be a channel x time matrix.")
+    sample_indices = np.arange(signal.shape[1])
+    mean_pieces = []
+    delta_pieces = []
+    for level in levels:
+        level = int(level)
+        if level <= 0:
+            raise ValueError("Temporal-pyramid levels must be positive.")
+        level_means = [
+            np.mean(signal[:, indices], axis=1)
+            if indices.size
+            else np.zeros(signal.shape[0], dtype=float)
+            for indices in np.array_split(sample_indices, level)
+        ]
+        mean_pieces.extend(level_means)
+        delta_pieces.extend(
+            level_means[index + 1] - level_means[index]
+            for index in range(len(level_means) - 1)
+        )
+    return np.concatenate([*mean_pieces, *delta_pieces])
 
 
 def _sensor_cov_tangent_feature(window_signal):

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -16,6 +16,8 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertIn("sensor_cov_tangent", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_time_pyramid", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_time_pyramid_logpower", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_time_pyramid_delta", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_time_pyramid_delta_logpower", cross_subject.FEATURE_MODES)
 
     def test_sensor_mean_logpower_feature(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
@@ -89,6 +91,37 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
                 4.0, 5.0,
                 2.0, 3.0, 6.0, 7.0,
                 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+            ]),
+        )
+
+    def test_sensor_time_pyramid_delta_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 1.0, 3.0, 5.0, 7.0], [0.0, 2.0, 4.0, 6.0, 8.0]],
+            [[0.0, 2.0, 4.0, 6.0, 8.0], [0.0, 1.0, 3.0, 5.0, 7.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.3,
+            feature_mode="sensor_time_pyramid_delta",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 22))
+        np.testing.assert_allclose(
+            feature_set.features[0],
+            np.asarray([
+                4.0, 5.0,
+                2.0, 3.0, 6.0, 7.0,
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+                4.0, 4.0,
+                2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
             ]),
         )
 


### PR DESCRIPTION
## Summary
- add sensor temporal-pyramid delta feature modes and baseline-whitened exports
- add a BUSH-MEG nested matrix variant for temporal-delta features
- cover the new feature extraction shape and values

## Checks
- python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject_next.py
- python -m ruff check src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject_next.py
- python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"
- git diff --check origin/main...HEAD

No test suite was run, per request.