### PR TITLE
Add flat logpower and prediction balance selection

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -28,6 +28,7 @@ on:
         options:
           - windowed_logreg_lean
           - windowed_logreg_lean_no_diversity
+          - windowed_logreg_lean_predbalance
           - windowed_logreg_lean_rankaware
           - windowed_logreg_lean_rankaware_reciprocal
           - windowed_logreg_lean_rankaware_reciprocal_inner_prior
@@ -43,7 +44,9 @@ on:
           - windowed_logreg_lean_balanced_quota
           - windowed_logreg_175_balanced_quota
           - windowed_logreg_175_ranksoftmax_t2
+          - windowed_logreg_175_predbalance
           - windowed_logreg_175_finetune
+          - windowed_logreg_175_flat_logpower
           - windowed_logreg_175_test_prior_balance
           - windowed_logreg_175_bias_calibration
           - windowed_logreg_175_rank_bias_calibration
@@ -197,6 +200,8 @@ on:
           - balanced_top2_top3
           - balanced_top2_top3_rank
           - balanced_top2_top3_rank_lcb
+          - balanced_top2_top3_rank_prediction_balance
+          - balanced_top2_top3_rank_prediction_balance_lcb
           - balanced_rank
       benchmark_preset:
         description: Screening keeps the trial cap; final-all-trials ignores it and can exceed 2h per shard.
@@ -296,6 +301,21 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_predbalance": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_prediction_balance_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_lean_test_prior_balance": {
@@ -527,6 +547,35 @@ jobs:
                   "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
                   "classifier_params": "0.1,0.2,0.3,0.5,1,2,3",
                   "components_pca_values": "96,128,160,192",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_predbalance": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_prediction_balance_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_flat_logpower": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat,sensor_flat_logpower",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128,160",
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -58,6 +58,8 @@ CROSS_SUBJECT_SELECTION_METRIC_CHOICES = (
     "balanced_top2_top3",
     "balanced_top2_top3_rank",
     "balanced_top2_top3_rank_lcb",
+    "balanced_top2_top3_rank_prediction_balance",
+    "balanced_top2_top3_rank_prediction_balance_lcb",
     "balanced_rank",
 )
 DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE = 1
@@ -1612,6 +1614,10 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=DEFAULT_CROSS_SUBJEC
         top2 = _finite_metric_values(candidate_rows, "top2_accuracy")
         top3 = _finite_metric_values(candidate_rows, "top3_accuracy")
         mean_ranks = _finite_metric_values(candidate_rows, "mean_true_label_rank")
+        prediction_balances = np.asarray(
+            [_inner_prediction_balance_score(row) for row in candidate_rows],
+            dtype=float,
+        )
         selection_scores = np.asarray([_nested_row_selection_score(row, selection_metric) for row in candidate_rows], dtype=float)
         example = candidate_rows[0]
         inner_test_label_counts = _sum_formatted_counters(candidate_rows, "test_label_counts")
@@ -1646,6 +1652,9 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=DEFAULT_CROSS_SUBJEC
             "selected_inner_mean_true_label_rank_mean": _nanmean_or_nan(mean_ranks),
             "selected_inner_mean_true_label_rank_median": _nanmedian_or_nan(mean_ranks),
             "selected_inner_mean_true_label_rank_sem": _sem_or_nan(mean_ranks),
+            "selected_inner_prediction_balance_mean": _nanmean_or_nan(prediction_balances),
+            "selected_inner_prediction_balance_median": _nanmedian_or_nan(prediction_balances),
+            "selected_inner_prediction_balance_sem": _sem_or_nan(prediction_balances),
             "selected_inner_chance_mean_rank": chance_mean_rank,
             "selected_inner_selection_score_mean": _nanmean_or_nan(selection_scores),
             "selected_inner_selection_score_median": _nanmedian_or_nan(selection_scores),
@@ -3579,10 +3588,45 @@ def _row_float(row, key):
         return np.nan
 
 
+def _finite_or(value, default=0.0):
+    value = float(value)
+    return value if np.isfinite(value) else float(default)
+
+
+def _inner_prediction_balance_score(row):
+    """Return 1 - total-variation distance between inner true and predicted priors."""
+
+    target_counts = _parse_formatted_counter(row.get("test_label_counts", ""))
+    predicted_counts = _parse_formatted_counter(row.get("predicted_label_counts", ""))
+    labels = sorted(set(target_counts) | set(predicted_counts))
+    if not labels:
+        return np.nan
+
+    target_total = float(sum(target_counts.values()))
+    predicted_total = float(sum(predicted_counts.values()))
+    if target_total <= 0.0 or predicted_total <= 0.0:
+        return np.nan
+
+    target_distribution = np.asarray(
+        [float(target_counts.get(label, 0.0)) for label in labels],
+        dtype=float,
+    ) / target_total
+    predicted_distribution = np.asarray(
+        [float(predicted_counts.get(label, 0.0)) for label in labels],
+        dtype=float,
+    ) / predicted_total
+    total_variation = 0.5 * float(
+        np.sum(np.abs(predicted_distribution - target_distribution))
+    )
+    return float(np.clip(1.0 - total_variation, 0.0, 1.0))
+
+
 def _nested_row_selection_score(row, selection_metric):
     selection_metric = _normalize_selection_metric(selection_metric)
     if selection_metric == "balanced_top2_top3_rank_lcb":
         selection_metric = "balanced_top2_top3_rank"
+    if selection_metric == "balanced_top2_top3_rank_prediction_balance_lcb":
+        selection_metric = "balanced_top2_top3_rank_prediction_balance"
     if selection_metric == "balanced_accuracy":
         return _row_float(row, "balanced_accuracy")
     if selection_metric == "accuracy":
@@ -3610,6 +3654,19 @@ def _nested_row_selection_score(row, selection_metric):
             + _row_float(row, "top3_accuracy")
             + rank_score
         ) / 4.0
+    if selection_metric == "balanced_top2_top3_rank_prediction_balance":
+        chance_mean_rank = float(row.get("chance_mean_rank", 0.5 * (row.get("chance_classes", DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES) + 1)))
+        rank_score = _inner_rank_score(
+            _row_float(row, "mean_true_label_rank"),
+            chance_mean_rank=chance_mean_rank,
+        )
+        return (
+            _row_float(row, "balanced_accuracy")
+            + _row_float(row, "top2_accuracy")
+            + _row_float(row, "top3_accuracy")
+            + _finite_or(rank_score)
+            + _finite_or(_inner_prediction_balance_score(row))
+        ) / 5.0
     if selection_metric == "balanced_rank":
         chance_mean_rank = float(row.get("chance_mean_rank", 0.5 * (row.get("chance_classes", DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES) + 1)))
         rank_score = _inner_rank_score(_row_float(row, "mean_true_label_rank"), chance_mean_rank=chance_mean_rank)
@@ -3619,7 +3676,10 @@ def _nested_row_selection_score(row, selection_metric):
 
 def _nested_selection_score(summary, selection_metric):
     selection_metric = _normalize_selection_metric(selection_metric)
-    if selection_metric == "balanced_top2_top3_rank_lcb":
+    if selection_metric in {
+        "balanced_top2_top3_rank_lcb",
+        "balanced_top2_top3_rank_prediction_balance_lcb",
+    }:
         mean = float(summary["selected_inner_selection_score_mean"])
         sem = float(summary.get("selected_inner_selection_score_sem", 0.0))
         return mean - (sem if np.isfinite(sem) else 0.0)
@@ -3648,6 +3708,17 @@ def _nested_selection_score(summary, selection_metric):
         top3 = float(summary["selected_inner_top3_accuracy_mean"])
         rank_score = float(summary["selected_inner_rank_score_mean"])
         return (balanced + top2 + top3 + rank_score) / 4.0
+    if selection_metric == "balanced_top2_top3_rank_prediction_balance":
+        balanced = float(summary["selected_inner_balanced_accuracy_mean"])
+        top2 = float(summary["selected_inner_top2_accuracy_mean"])
+        top3 = float(summary["selected_inner_top3_accuracy_mean"])
+        rank_score = float(summary["selected_inner_rank_score_mean"])
+        prediction_balance = _finite_or(
+            summary.get("selected_inner_prediction_balance_mean", np.nan)
+        )
+        return (
+            balanced + top2 + top3 + _finite_or(rank_score) + prediction_balance
+        ) / 5.0
     if selection_metric == "balanced_rank":
         balanced = float(summary["selected_inner_balanced_accuracy_mean"])
         rank_score = float(summary["selected_inner_rank_score_mean"])
@@ -3667,6 +3738,7 @@ def _nested_selection_sort_key(row):
         _finite_sort_value(row["selected_inner_top2_accuracy_mean"]),
         _finite_sort_value(row["selected_inner_top3_accuracy_mean"]),
         _finite_sort_value(-float(row["selected_inner_mean_true_label_rank_mean"])),
+        _finite_sort_value(row.get("selected_inner_prediction_balance_mean", np.nan)),
         _finite_sort_value(row["selected_inner_accuracy_mean"]),
         -int(row["selected_candidate_index"]),
     )

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -71,6 +71,7 @@ DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = 1.0
 DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
 DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
 BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
+    "sensor_flat_logpower",
     "sensor_time_pyramid",
     "sensor_time_pyramid_logpower",
     "sensor_time_pyramid_delta",
@@ -79,6 +80,7 @@ BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
 EXTENDED_FEATURE_MODES = (
     "sensor_logpower",
     "sensor_mean_logpower",
+    "sensor_flat_logpower",
     "sensor_bandpower",
     "sensor_cov_tangent",
     "sensor_time_pyramid",
@@ -360,6 +362,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
         signal = _impl._trial_signal(data, trial_idx)[:, mask]
         if feature_mode == "sensor_logpower":
             feature = _sensor_logpower_feature(signal)
+        elif feature_mode == "sensor_flat_logpower":
+            feature = _sensor_flat_logpower_feature(signal)
         elif feature_mode == "sensor_mean_logpower":
             feature = np.concatenate((np.mean(signal, axis=1), _sensor_logpower_feature(signal)))
         elif feature_mode == "sensor_bandpower":
@@ -382,6 +386,20 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
 
 def _sensor_logpower_feature(window_signal):
     return np.log(np.mean(np.square(np.asarray(window_signal, dtype=float)), axis=1) + 1e-12)
+
+
+def _sensor_flat_logpower_feature(window_signal):
+    """Return raw evoked samples plus one per-sensor log-power block.
+
+    The flattened evoked block uses the same channel-block layout as
+    ``sensor_flat``: all channels for sample 1, all channels for sample 2, etc.
+    Appending log-power as another all-channel block keeps the feature width a
+    multiple of the channel count, so subject_baseline_whiten can apply the same
+    per-channel whitening matrix blockwise.
+    """
+
+    signal = np.asarray(window_signal, dtype=float)
+    return np.concatenate((signal.reshape(-1, order="F"), _sensor_logpower_feature(signal)))
 
 
 def _sensor_bandpower_feature(window_signal, window_time):
@@ -481,7 +499,10 @@ def _sensor_cov_tangent_feature(window_signal):
 
 
 def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
-    if _normalize_feature_mode(config.feature_mode) in EXTENDED_FEATURE_MODES:
+    feature_mode = _normalize_feature_mode(config.feature_mode)
+    if feature_mode == "sensor_flat_logpower":
+        return _sensor_flat_logpower_baseline_statistics(data, config, n_window_samples, trial_indices)
+    if feature_mode in EXTENDED_FEATURE_MODES:
         baseline_features, n_baseline_samples = _extract_window_features(data, config.baseline_window, feature_mode=config.feature_mode, trial_indices=trial_indices)
         mean = np.mean(baseline_features, axis=0, keepdims=True)
         std = np.std(baseline_features, axis=0, keepdims=True)
@@ -489,11 +510,39 @@ def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
     return _previous_baseline_feature_statistics(data, config, n_window_samples, trial_indices)
 
 
+def _sensor_flat_logpower_baseline_statistics(data, config, n_window_samples, trial_indices):
+    """Baseline statistics for sensor_flat plus a same-channel log-power block.
+
+    The decode window and the baseline window usually have different durations.
+    For the raw ``sensor_flat`` part we therefore mirror the legacy behavior:
+    estimate one baseline mean/std per channel and tile it over the number of
+    decode-window samples.  For the appended log-power block, estimate a
+    per-channel baseline log-power distribution over baseline trials.
+    """
+
+    channel_mean, channel_std, n_baseline_samples = _impl._baseline_channel_statistics(
+        data,
+        config.baseline_window,
+        trial_indices,
+    )
+    logpower_features, _ = _extract_window_features(
+        data,
+        config.baseline_window,
+        feature_mode="sensor_logpower",
+        trial_indices=trial_indices,
+    )
+    flat_mean = np.tile(channel_mean, int(n_window_samples))
+    flat_std = np.tile(channel_std, int(n_window_samples))
+    mean = np.concatenate((flat_mean, np.mean(logpower_features, axis=0)))[None, :]
+    std = np.concatenate((flat_std, np.std(logpower_features, axis=0)))[None, :]
+    return mean, _impl._nonzero_std(std), n_baseline_samples
+
+
 def _normalize_features(features, config, baseline_feature_mean, baseline_feature_std, baseline_whitening_matrix):
     feature_mode = _normalize_feature_mode(config.feature_mode)
     if feature_mode in BASELINE_WHITENED_EXTENDED_FEATURE_MODES and config.normalization == "subject_baseline_whiten":
         if baseline_feature_mean is None or baseline_whitening_matrix is None:
-            raise ValueError("sensor_time_pyramid requires baseline feature statistics and a whitening matrix for subject_baseline_whiten.")
+            raise ValueError(f"{feature_mode} requires baseline feature statistics and a whitening matrix for subject_baseline_whiten.")
         centered = np.asarray(features, dtype=float) - baseline_feature_mean
         return _impl._baseline_whiten_sensor_flat_features(centered, baseline_whitening_matrix)
     if feature_mode in EXTENDED_FEATURE_MODES and config.normalization == "subject_baseline_whiten":
@@ -509,7 +558,7 @@ def _normalized_subject_features(feature_set, config):
         if feature_set.normalization == config.normalization:
             return feature_set.features
         if feature_set.baseline_feature_mean is None or feature_set.baseline_whitening_matrix is None:
-            raise ValueError("sensor_time_pyramid requires baseline feature statistics and a whitening matrix for subject_baseline_whiten.")
+            raise ValueError(f"{feature_mode} requires baseline feature statistics and a whitening matrix for subject_baseline_whiten.")
         centered = np.asarray(feature_set.features, dtype=float) - feature_set.baseline_feature_mean
         return _impl._baseline_whiten_sensor_flat_features(centered, feature_set.baseline_whitening_matrix)
     if feature_mode in EXTENDED_FEATURE_MODES and config.normalization == "subject_baseline_whiten":

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -282,6 +282,36 @@ class TestStimulusCrossSubject(unittest.TestCase):
         np.testing.assert_allclose(np.sum(top2, axis=1), np.ones(3))
         np.testing.assert_allclose(np.sum(top3, axis=1), np.ones(3))
 
+    def test_prediction_balance_selection_metric_penalizes_collapsed_predictions(self):
+        metric = "balanced_top2_top3_rank_prediction_balance"
+        collapsed = {
+            "balanced_accuracy": 0.55,
+            "accuracy": 0.55,
+            "top2_accuracy": 0.90,
+            "top3_accuracy": 1.00,
+            "mean_true_label_rank": 1.20,
+            "chance_mean_rank": 1.50,
+            "chance_classes": 2,
+            "test_label_counts": "1:10;2:10",
+            "predicted_label_counts": "1:20",
+        }
+        balanced = dict(collapsed)
+        balanced["predicted_label_counts"] = "1:10;2:10"
+
+        self.assertIn(metric, cross_subject.CROSS_SUBJECT_SELECTION_METRIC_CHOICES)
+        self.assertAlmostEqual(
+            cross_subject._inner_prediction_balance_score(balanced),
+            1.0,
+        )
+        self.assertLess(
+            cross_subject._inner_prediction_balance_score(collapsed),
+            1.0,
+        )
+        self.assertGreater(
+            cross_subject._nested_row_selection_score(balanced, metric),
+            cross_subject._nested_row_selection_score(collapsed, metric),
+        )
+
     def test_inner_balanced_suffix_is_valid_for_soft_rank_normalizations(self):
         scores = np.asarray([[3.0, 1.0, 2.0], [0.0, 2.0, 1.0]], dtype=float)
         balanced_to_base = {

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -12,6 +12,7 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
     def test_extended_feature_modes_are_exported(self):
         self.assertIn("sensor_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_mean_logpower", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_flat_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_bandpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_cov_tangent", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_time_pyramid", cross_subject.FEATURE_MODES)
@@ -42,6 +43,55 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_allclose(feature_set.features[0, :2], np.asarray([2.0, 4.0]))
         np.testing.assert_allclose(feature_set.features[1, :2], np.asarray([3.0, 6.0]))
         self.assertTrue(np.all(np.isfinite(feature_set.features[:, 2:])))
+
+    def test_sensor_flat_logpower_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0], [0.0, 0.0, 2.0, 6.0]],
+            [[0.0, 0.0, 2.0, 4.0], [0.0, 0.0, 4.0, 8.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            feature_mode="sensor_flat_logpower",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        np.testing.assert_allclose(feature_set.features[0, :4], np.asarray([1.0, 2.0, 3.0, 6.0]))
+        np.testing.assert_allclose(feature_set.features[0, 4:], np.log(np.asarray([5.0, 20.0]) + 1e-12))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_logpower_baseline_whiten_allows_different_baseline_duration(self):
+        time = np.asarray([-0.3, -0.2, -0.1, 0.1, 0.2], dtype=float)
+        trials = [
+            [[0.1, 0.2, 0.3, 1.0, 3.0], [0.4, 0.5, 0.6, 2.0, 6.0]],
+            [[0.2, 0.3, 0.4, 2.0, 4.0], [0.5, 0.6, 0.7, 4.0, 8.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            baseline_window=(-0.3, -0.1),
+            feature_mode="sensor_flat_logpower",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 6))
+        self.assertEqual(feature_set.baseline_feature_std.shape, (1, 6))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
     def test_cov_tangent_feature_width(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)


### PR DESCRIPTION
## Summary
- add `sensor_flat_logpower` feature extraction with baseline whitening support
- add prediction-balance nested selection metrics and summary fields
- expose new workflow bundles for flat-logpower and prediction-balance screening

## Validation
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\_stimulus_cross_subject_legacy.py`
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject.py`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check`

Per request, no test suite was run.