### PR TITLE
Add rank margin blend score normalization

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -28,6 +28,7 @@ on:
         options:
           - windowed_logreg_lean
           - windowed_logreg_lean_no_diversity
+          - windowed_logreg_lean_margin_blend
           - windowed_logreg_lean_balanced_lcb
           - windowed_logreg_lean_predbalance
           - windowed_logreg_lean_rankaware
@@ -45,6 +46,7 @@ on:
           - windowed_logreg_lean_balanced_quota
           - windowed_logreg_175_balanced_quota
           - windowed_logreg_175_ranksoftmax_t2
+          - windowed_logreg_175_margin_blend
           - windowed_logreg_175_predbalance
           - windowed_logreg_175_finetune
           - windowed_logreg_175_balanced_lcb
@@ -123,6 +125,7 @@ on:
           - rank_top2_vote
           - rank_top3_vote
           - rank_z_blend
+          - rank_margin_blend
           - rank_softmax_test_prior_balance
           - rank_softmax_t2_test_prior_balance
           - rank_softmax_t3_test_prior_balance
@@ -312,6 +315,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_margin_blend": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_margin_blend",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -563,6 +580,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_t2",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_margin_blend": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_margin_blend",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -85,6 +85,7 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top2_vote",
     "rank_top3_vote",
     "rank_z_blend",
+    "rank_margin_blend",
     "rank_softmax_test_prior_balance",
     "rank_softmax_t2_test_prior_balance",
     "rank_softmax_t3_test_prior_balance",
@@ -213,6 +214,8 @@ RANK_SOFTMAX_TEMPERATURES = {
     "rank_softmax_t2": 2.0,
     "rank_softmax_t3": 3.0,
 }
+RANK_MARGIN_BLEND_LOW = 0.25
+RANK_MARGIN_BLEND_HIGH = 1.25
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
     "window",
@@ -2097,6 +2100,8 @@ def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJ
         return _rank_topk_vote_probabilities(scores, top_k=3)
     if score_normalization == "rank_z_blend":
         return _rank_z_blend_probabilities(scores)
+    if score_normalization == "rank_margin_blend":
+        return _rank_margin_blend_probabilities(scores)
     raise ValueError(f"Unsupported ensemble score normalization: {score_normalization}")
 
 
@@ -2230,6 +2235,57 @@ def _rank_z_blend_probabilities(scores):
         out=np.full_like(blended, 1.0 / blended.shape[1]),
         where=row_sums > 0.0,
     )
+
+
+def _rank_margin_blend_probabilities(scores):
+    """Blend top-heavy and soft rank posteriors by per-trial score margin."""
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError(
+            "Nested score ensembling requires a non-empty two-dimensional "
+            "class-score matrix."
+        )
+
+    sharp = _rank_softmax_probabilities(scores)
+    soft = _rank_borda_probabilities(scores)
+    confidence = _rank_margin_blend_confidence(scores)[:, None]
+    blended = confidence * sharp + (1.0 - confidence) * soft
+    row_sums = np.sum(blended, axis=1, keepdims=True)
+    return np.divide(
+        blended,
+        row_sums,
+        out=np.full_like(blended, 1.0 / blended.shape[1]),
+        where=row_sums > 0.0,
+    )
+
+
+def _rank_margin_blend_confidence(scores):
+    """Return 0..1 confidence from z-scored top-1/top-2 score separation."""
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2:
+        raise ValueError(
+            "Rank-margin blending requires a two-dimensional class-score matrix."
+        )
+    low = float(RANK_MARGIN_BLEND_LOW)
+    high = float(RANK_MARGIN_BLEND_HIGH)
+    denom = max(high - low, 1e-12)
+    confidence = np.ones(scores.shape[0], dtype=float)
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        if int(np.sum(finite)) < 2:
+            confidence[row_index] = 1.0
+            continue
+        finite_scores = np.asarray(row[finite], dtype=float)
+        centered = finite_scores - np.mean(finite_scores)
+        scale = float(np.std(centered))
+        if scale > 1e-12:
+            centered = centered / scale
+        ordered = np.sort(centered)[::-1]
+        margin = float(ordered[0] - ordered[1])
+        confidence[row_index] = float(np.clip((margin - low) / denom, 0.0, 1.0))
+    return confidence
 
 
 def _align_score_columns(probabilities, score_classes, class_order):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -1191,6 +1191,33 @@ class TestStimulusCrossSubject(unittest.TestCase):
             "rank_softmax",
         )
 
+    def test_rank_margin_blend_softens_only_low_margin_trials(self):
+        scores = np.asarray(
+            [
+                [1.00, 0.99, 0.00],
+                [3.00, 0.00, -1.00],
+            ],
+            dtype=float,
+        )
+
+        sharp = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax",
+        )
+        blended = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_margin_blend",
+        )
+
+        self.assertEqual(blended.shape, scores.shape)
+        np.testing.assert_allclose(np.sum(blended, axis=1), np.ones(scores.shape[0]))
+        self.assertGreater(
+            blended[0, 1],
+            sharp[0, 1],
+            "low-margin rows should give the runner-up more mass than rank_softmax",
+        )
+        self.assertGreater(blended[1, 0], blended[0, 0])
+
     def test_test_class_prior_balance_equalizes_unlabeled_class_mass(self):
         probabilities = np.asarray(
             [


### PR DESCRIPTION
## Summary
- Add `rank_margin_blend` as an ensemble score normalization mode.
- Blend rank-softmax and Borda probabilities based on per-trial score margin.
- Add workflow bundle options for lean and 0.175s margin-blend runs.

## Validation
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py`
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check`

Per request, no test suite was run.