### PR TITLE
Split w150 center grid and extend timeout

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -79,6 +79,8 @@ on:
           - windowed_logreg_175_temporal_delta_features
           - windowed_logreg_175_w150_finetune_small
           - windowed_logreg_w150_center_grid
+          - windowed_logreg_150_w150
+          - windowed_logreg_200_w150
           - windowed_logreg_175_inner_prior
           - windowed_logreg_175_inner_prior_quota
           - windowed_logreg_175_inner_confusion
@@ -243,7 +245,7 @@ on:
         required: true
         default: "120"
         type: choice
-        options: ["60", "90", "120", "180"]
+        options: ["60", "90", "120", "180", "300"]
       max_trials_per_class_per_participant:
         description: Screening trial cap per stimulus class and participant.
         required: false
@@ -1235,6 +1237,36 @@ jobs:
               },
               "windowed_logreg_w150_center_grid": {
                   "window_centers": "0.150,0.175,0.200",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_150_w150": {
+                  "window_centers": "0.150",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_200_w150": {
+                  "window_centers": "0.200",
                   "window_size": "0.150",
                   "feature_modes": "sensor_flat",
                   "normalizations": "subject_baseline_whiten",


### PR DESCRIPTION
## Summary
- add a 300-minute shard timeout choice for slower final-all-trials shards
- split the broad w150 center-grid bundle into single-center 0.150s and 0.200s bundles
- keep the existing 0.175s w150 result as the center reference

## Why
The matching label-shuffle run completed and looks like a valid null. The small finetune exceeded the 180-minute shard limit for at least one participant, and the combined three-center ablation repeatedly hit GitHub-hosted runner shutdowns. Splitting the center ablation lowers per-shard memory/compute while preserving the comparison.