### PR TITLE
Add sensor DCT cross-subject features

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -51,6 +51,7 @@ on:
           - windowed_logreg_175_finetune
           - windowed_logreg_175_balanced_lcb
           - windowed_logreg_175_flat_logpower
+          - windowed_logreg_175_dct
           - windowed_logreg_175_test_prior_balance
           - windowed_logreg_175_bias_calibration
           - windowed_logreg_175_rank_bias_calibration
@@ -655,6 +656,21 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_dct": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat,sensor_dct",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,96,128,160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_bias_calibration": {

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -70,8 +70,10 @@ SCORE_CALIBRATION_MODES = (
 DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = 1.0
 DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
 DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
+DEFAULT_SENSOR_DCT_COEFFICIENTS = 8
 BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",
+    "sensor_dct",
     "sensor_time_pyramid",
     "sensor_time_pyramid_logpower",
     "sensor_time_pyramid_delta",
@@ -81,6 +83,7 @@ EXTENDED_FEATURE_MODES = (
     "sensor_logpower",
     "sensor_mean_logpower",
     "sensor_flat_logpower",
+    "sensor_dct",
     "sensor_bandpower",
     "sensor_cov_tangent",
     "sensor_time_pyramid",
@@ -185,6 +188,7 @@ def install(impl) -> None:
     impl.DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA
     impl.EXTENDED_FEATURE_MODES = EXTENDED_FEATURE_MODES
     impl.DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = DEFAULT_SENSOR_TIME_PYRAMID_LEVELS
+    impl.DEFAULT_SENSOR_DCT_COEFFICIENTS = DEFAULT_SENSOR_DCT_COEFFICIENTS
     impl.FEATURE_MODES = tuple(dict.fromkeys((*impl.FEATURE_MODES, *EXTENDED_FEATURE_MODES)))
     impl.CrossSubjectStimulusConfig = NextCrossSubjectStimulusConfig
     _install_soft_inner_confusion_score_normalizations(impl)
@@ -372,6 +376,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_logpower_feature(signal)
         elif feature_mode == "sensor_flat_logpower":
             feature = _sensor_flat_logpower_feature(signal)
+        elif feature_mode == "sensor_dct":
+            feature = _sensor_dct_feature(signal)
         elif feature_mode == "sensor_mean_logpower":
             feature = np.concatenate((np.mean(signal, axis=1), _sensor_logpower_feature(signal)))
         elif feature_mode == "sensor_bandpower":
@@ -408,6 +414,34 @@ def _sensor_flat_logpower_feature(window_signal):
 
     signal = np.asarray(window_signal, dtype=float)
     return np.concatenate((signal.reshape(-1, order="F"), _sensor_logpower_feature(signal)))
+
+
+def _sensor_dct_feature(
+    window_signal,
+    n_coefficients=DEFAULT_SENSOR_DCT_COEFFICIENTS,
+):
+    """Return low-order DCT-II waveform coefficients for each sensor."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    if signal.ndim != 2:
+        raise ValueError("window_signal must be a channel x time matrix.")
+    n_samples = int(signal.shape[1])
+    if n_samples <= 0:
+        raise ValueError("sensor_dct requires at least one time sample.")
+    n_coefficients = int(n_coefficients)
+    if n_coefficients <= 0:
+        raise ValueError("sensor_dct requires at least one coefficient.")
+
+    sample_positions = np.arange(n_samples, dtype=float) + 0.5
+    coefficient_indices = np.arange(n_coefficients, dtype=float)[:, None]
+    basis = np.cos(
+        np.pi * coefficient_indices * sample_positions[None, :] / float(n_samples)
+    )
+    basis[0] *= np.sqrt(1.0 / float(n_samples))
+    if n_coefficients > 1:
+        basis[1:] *= np.sqrt(2.0 / float(n_samples))
+    coefficients = signal @ basis.T
+    return coefficients.reshape(-1, order="F")
 
 
 def _sensor_bandpower_feature(window_signal, window_time):

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -240,6 +240,57 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(feature_set.baseline_whitening_matrix.shape, (2, 2))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
+    def test_sensor_dct_keeps_low_order_temporal_coefficients(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3, 0.4], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0, 5.0, 7.0], [0.0, 0.0, 2.0, 4.0, 6.0, 8.0]],
+            [[0.0, 0.0, 2.0, 4.0, 6.0, 8.0], [0.0, 0.0, 4.0, 8.0, 12.0, 16.0]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.25,
+            window_size=0.3,
+            feature_mode="sensor_dct",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertIn("sensor_dct", cross_subject.FEATURE_MODES)
+        self.assertEqual(feature_set.features.shape, (2, 16))
+        self.assertEqual(feature_set.n_window_samples, 4)
+        np.testing.assert_allclose(feature_set.features[0, :2], np.asarray([8.0, 10.0]))
+        np.testing.assert_allclose(feature_set.features[1, :2], np.asarray([10.0, 20.0]))
+
+    def test_sensor_dct_supports_baseline_whitening(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3, 0.4], dtype=float)
+        trials = [
+            [[-1.0, -0.8, 1.0, 1.2, 1.4, 1.6], [0.5, 0.7, 3.0, 3.2, 3.4, 3.6]],
+            [[-0.4, -0.2, 2.0, 2.2, 2.4, 2.6], [1.1, 1.3, 4.0, 4.2, 4.4, 4.6]],
+            [[0.2, 0.4, 3.0, 3.2, 3.4, 3.6], [1.7, 1.9, 5.0, 5.2, 5.4, 5.6]],
+            [[0.8, 1.0, 4.0, 4.2, 4.4, 4.6], [2.3, 2.5, 6.0, 6.2, 6.4, 6.6]],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2, 1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.25,
+            window_size=0.3,
+            feature_mode="sensor_dct",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (4, 16))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 16))
+        self.assertEqual(feature_set.baseline_whitening_matrix.shape, (2, 2))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
     def test_rank_reciprocal_score_normalization_softens_rank_probabilities(self):
         self.assertIn("rank_reciprocal", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
         scores = np.asarray(


### PR DESCRIPTION
## Summary
- Add `sensor_dct` as a cross-subject feature mode.
- Include DCT features in baseline-whitened feature modes.
- Add a workflow bundle for 0.175s sensor-DCT screening.

## Validation
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py`
- `python -m ruff check src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject.py`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check HEAD~1..HEAD`

Per request, no test suite was run.