### PR TITLE
Add nested window sizes and guarded quotas

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -45,6 +45,7 @@ on:
           - windowed_logreg_lean_rankaware_top2vote_inner_prior
           - windowed_logreg_lean_balanced_quota
           - windowed_logreg_175_balanced_quota
+          - windowed_logreg_175_guarded_quota
           - windowed_logreg_175_ranksoftmax_t2
           - windowed_logreg_175_margin_blend
           - windowed_logreg_175_predbalance
@@ -80,6 +81,8 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w125_w150
+          - windowed_logreg_w150_size_center_grid
           - windowed_logreg_175_temporal_delta_features
           - windowed_logreg_175_w150_finetune_small
           - windowed_logreg_w150_center_grid
@@ -141,6 +144,11 @@ on:
           - rank_softmax_t3_balanced_quota
           - rank_borda_balanced_quota
           - rank_z_blend_balanced_quota
+          - rank_softmax_guarded_balanced_quota
+          - rank_softmax_t2_guarded_balanced_quota
+          - rank_softmax_t3_guarded_balanced_quota
+          - rank_borda_guarded_balanced_quota
+          - rank_z_blend_guarded_balanced_quota
           - rank_softmax_inner_balanced_balanced_quota
           - rank_reciprocal_inner_balanced_balanced_quota
           - rank_borda_inner_balanced_balanced_quota
@@ -587,6 +595,21 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_balanced_quota",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_guarded_quota": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_z_blend_guarded_balanced_quota",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_ranksoftmax_t2": {
@@ -1280,6 +1303,36 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w125_w150": {
+                  "window_centers": "0.175",
+                  "window_sizes": "0.125,0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_w150_size_center_grid": {
+                  "window_centers": "0.150,0.175,0.200",
+                  "window_sizes": "0.125,0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_temporal_delta_features": {
                   "window_centers": "0.175",
                   "window_size": "0.100",
@@ -1439,6 +1492,7 @@ jobs:
                       **bundles[bundle_id],
                   }
                   row.setdefault("window_size", "0.1")
+                  row.setdefault("window_sizes", "")
                   row.setdefault("sample_weightings", "none")
                   row.setdefault("score_calibrations", "none")
                   row.setdefault("alignment_alphas", "1.0")
@@ -1505,6 +1559,7 @@ jobs:
       OUTER_PARTICIPANTS: ${{ matrix.outer_participants }}
       WINDOW_CENTERS: ${{ matrix.window_centers }}
       WINDOW_SIZE: ${{ matrix.window_size }}
+      WINDOW_SIZES: ${{ matrix.window_sizes }}
       BASELINE_WINDOW: "-0.35,-0.05"
       FEATURE_MODES: ${{ matrix.feature_modes }}
       NORMALIZATIONS: ${{ matrix.normalizations }}
@@ -1592,7 +1647,6 @@ jobs:
             --participants "${PARTICIPANTS}"
             --outer-participants "${OUTER_PARTICIPANTS}"
             --window-centers "${WINDOW_CENTERS}"
-            --window-size "${WINDOW_SIZE}"
             --baseline-window "${BASELINE_WINDOW}"
             --feature-modes "${FEATURE_MODES}"
             --normalizations "${NORMALIZATIONS}"
@@ -1619,6 +1673,12 @@ jobs:
             --confusion-pairs-output "${output_prefix}_confusion_pairs.csv"
             --write-incremental
           )
+          if [[ -n "${WINDOW_SIZES}" ]]; then
+            echo "Window sizes: ${WINDOW_SIZES}"
+            args+=(--window-sizes "${WINDOW_SIZES}")
+          else
+            args+=(--window-size "${WINDOW_SIZE}")
+          fi
           if [[ -n "${effective_trial_cap}" ]]; then
             args+=(--max-trials-per-class-per-participant "${effective_trial_cap}")
           fi
@@ -1696,12 +1756,12 @@ jobs:
               "",
               f"Aggregated {len(rows)} completed config bundle(s).",
               "",
-              "| config bundle | outer folds | candidates | selection metric | balanced accuracy | top-2 | top-3 | selected classifiers | selected windows |",
-              "| --- | ---: | ---: | --- | ---: | ---: | ---: | --- | --- |",
+              "| config bundle | outer folds | candidates | selection metric | balanced accuracy | top-2 | top-3 | selected classifiers | selected windows | selected window sizes |",
+              "| --- | ---: | ---: | --- | ---: | ---: | ---: | --- | --- | --- |",
           ]
           for row in rows:
               lines.append(
-                  "| {bundle} | {folds} | {candidates} | {metric} | {balanced:.2f}% | {top2:.2f}% | {top3:.2f}% | {classifiers} | {windows} |".format(
+                  "| {bundle} | {folds} | {candidates} | {metric} | {balanced:.2f}% | {top2:.2f}% | {top3:.2f}% | {classifiers} | {windows} | {window_sizes} |".format(
                       bundle=row.get("matrix_config_bundle", ""),
                       folds=row.get("n_outer_folds", ""),
                       candidates=row.get("n_candidates", ""),
@@ -1711,6 +1771,7 @@ jobs:
                       top3=float(row.get("top3_percent_mean", "nan")),
                       classifiers=row.get("selected_classifier_counts", ""),
                       windows=row.get("selected_window_center_counts", ""),
+                      window_sizes=row.get("selected_window_size_counts", ""),
                   )
               )
           Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/src/pymegdec/_stimulus_cross_subject_core.py
+++ b/src/pymegdec/_stimulus_cross_subject_core.py
@@ -185,6 +185,7 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
     *,
     window_centers=_impl.DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS,
     window_size=_impl.DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
+    window_sizes=None,
     baseline_window=_impl.DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW,
     feature_modes=(_impl.DEFAULT_CROSS_SUBJECT_FEATURE_MODE,),
     normalizations=(_impl.DEFAULT_CROSS_SUBJECT_NORMALIZATION,),
@@ -202,10 +203,14 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
 ):
     """Build a candidate grid for nested cross-subject model selection."""
 
+    if window_sizes is None:
+        window_sizes = (window_size,)
+    window_sizes = tuple(float(value) for value in window_sizes)
+
     return tuple(
         CrossSubjectStimulusConfig(
             window_center=window_center,
-            window_size=window_size,
+            window_size=grid_window_size,
             baseline_window=baseline_window,
             feature_mode=feature_mode,
             normalization=normalization,
@@ -221,8 +226,9 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
             signflip_permutations=signflip_permutations,
             signflip_seed=signflip_seed,
         )
-        for window_center, feature_mode, normalization, alignment, classifier, components_pca in _impl.product(
+        for window_center, grid_window_size, feature_mode, normalization, alignment, classifier, components_pca in _impl.product(
             window_centers,
+            window_sizes,
             feature_modes,
             normalizations,
             alignments,

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -97,6 +97,11 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_softmax_t3_balanced_quota",
     "rank_borda_balanced_quota",
     "rank_z_blend_balanced_quota",
+    "rank_softmax_guarded_balanced_quota",
+    "rank_softmax_t2_guarded_balanced_quota",
+    "rank_softmax_t3_guarded_balanced_quota",
+    "rank_borda_guarded_balanced_quota",
+    "rank_z_blend_guarded_balanced_quota",
     "rank_softmax_inner_balanced_balanced_quota",
     "rank_reciprocal_inner_balanced_balanced_quota",
     "rank_borda_inner_balanced_balanced_quota",
@@ -239,6 +244,8 @@ INNER_CONFUSION_CORRECTION_IDENTITY_BLEND = 0.20
 INNER_CONFUSION_CORRECTION_SOFT_BLEND = 0.35
 INNER_CONFUSION_CORRECTION_MARGIN_QUANTILE = 0.50
 INNER_CONFUSION_CORRECTION_GUARDED_POWER = 0.5
+BALANCED_QUOTA_SUFFIX = "_balanced_quota"
+GUARDED_BALANCED_QUOTA_SUFFIX = "_guarded_balanced_quota"
 TEST_PRIOR_BALANCE_MAX_ITERATIONS = 50
 TEST_PRIOR_BALANCE_TOLERANCE = 1e-6
 TEST_PRIOR_BALANCE_EPSILON = 1e-12
@@ -465,6 +472,7 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
     *,
     window_centers=DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS,
     window_size=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE,
+    window_sizes=None,
     baseline_window=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW,
     feature_modes=(DEFAULT_CROSS_SUBJECT_FEATURE_MODE,),
     normalizations=(DEFAULT_CROSS_SUBJECT_NORMALIZATION,),
@@ -480,10 +488,14 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
 ):
     """Build a candidate grid for nested cross-subject model selection."""
 
+    if window_sizes is None:
+        window_sizes = (window_size,)
+    window_sizes = tuple(float(value) for value in window_sizes)
+
     return tuple(
         CrossSubjectStimulusConfig(
             window_center=window_center,
-            window_size=window_size,
+            window_size=grid_window_size,
             baseline_window=baseline_window,
             feature_mode=feature_mode,
             normalization=normalization,
@@ -497,8 +509,9 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
             signflip_permutations=signflip_permutations,
             signflip_seed=signflip_seed,
         )
-        for window_center, feature_mode, normalization, alignment, classifier, classifier_param, components_pca in product(
+        for window_center, grid_window_size, feature_mode, normalization, alignment, classifier, classifier_param, components_pca in product(
             window_centers,
+            window_sizes,
             feature_modes,
             normalizations,
             alignments,
@@ -646,6 +659,7 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
     selected_counts = Counter(int(row["selected_candidate_index"]) for row in outer_rows)
     classifier_counts = _row_value_counts(outer_rows, "selected_classifier", fallback_key="classifier")
     window_counts = _row_value_counts(outer_rows, "selected_window_center_s", fallback_key="window_center_s", transform=float)
+    window_size_counts = _row_value_counts(outer_rows, "selected_window_size_s", fallback_key="window_size_s", transform=float)
     feature_mode_counts = _row_value_counts(outer_rows, "selected_feature_mode", fallback_key="feature_mode")
     normalization_counts = _row_value_counts(outer_rows, "selected_normalization", fallback_key="normalization")
     alignment_counts = _row_value_counts(outer_rows, "selected_alignment", fallback_key="alignment")
@@ -697,6 +711,7 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
             "selected_ensemble_candidate_counts": _format_counter(ensemble_candidate_counts),
             "selected_classifier_counts": _format_counter(classifier_counts),
             "selected_window_center_counts": _format_counter(window_counts),
+            "selected_window_size_counts": _format_counter(window_size_counts),
             "selected_feature_mode_counts": _format_counter(feature_mode_counts),
             "selected_normalization_counts": _format_counter(normalization_counts),
             "selected_alignment_counts": _format_counter(alignment_counts),
@@ -1497,6 +1512,7 @@ def _select_nested_candidate_ensemble(
     selected["selected_ensemble_classifier_counts"] = _format_counter(Counter(config.classifier for config in selected_configs))
     selected["selected_ensemble_classifier_param_counts"] = _format_counter(Counter(str(_resolved_classifier_param(config)) for config in selected_configs))
     selected["selected_ensemble_window_center_counts"] = _format_counter(Counter(float(config.window_center) for config in selected_configs))
+    selected["selected_ensemble_window_size_counts"] = _format_counter(Counter(float(config.window_size) for config in selected_configs))
     selected["selected_ensemble_feature_mode_counts"] = _format_counter(Counter(config.feature_mode for config in selected_configs))
     selected["selected_ensemble_normalization_counts"] = _format_counter(Counter(config.normalization for config in selected_configs))
     selected["selected_ensemble_alignment_counts"] = _format_counter(Counter(config.alignment for config in selected_configs))
@@ -2347,8 +2363,10 @@ def _without_test_prior_balance_suffix(score_normalization):
 
 def _without_balanced_quota_suffix(score_normalization):
     score_normalization = str(score_normalization).strip()
-    if score_normalization.endswith("_balanced_quota"):
-        score_normalization = score_normalization.removesuffix("_balanced_quota")
+    if score_normalization.endswith(GUARDED_BALANCED_QUOTA_SUFFIX):
+        score_normalization = score_normalization.removesuffix(GUARDED_BALANCED_QUOTA_SUFFIX)
+    elif score_normalization.endswith(BALANCED_QUOTA_SUFFIX):
+        score_normalization = score_normalization.removesuffix(BALANCED_QUOTA_SUFFIX)
     return _without_test_prior_balance_suffix(score_normalization)
 
 
@@ -2571,15 +2589,34 @@ def _add_test_class_prior_balance_fields(row, metadata):
     )
 
 
+def _balanced_quota_mode(score_normalization):
+    mode = _normalize_ensemble_score_normalization(score_normalization)
+    if mode.endswith(GUARDED_BALANCED_QUOTA_SUFFIX) or mode.endswith(BALANCED_QUOTA_SUFFIX):
+        return mode
+    return None
+
+
+def _balanced_quota_is_guarded(mode):
+    return str(mode).endswith(GUARDED_BALANCED_QUOTA_SUFFIX)
+
+
 def _balanced_quota_metadata(probabilities, class_order, score_normalization):
     """Return optional test-batch balanced assignment metadata."""
 
-    mode = _normalize_ensemble_score_normalization(score_normalization)
-    if not mode.endswith("_balanced_quota"):
+    mode = _balanced_quota_mode(score_normalization)
+    if mode is None:
         return {"mode": "none"}
-    predictions, quota_counts, status = _balanced_quota_predictions(
-        probabilities, class_order
-    )
+    if _balanced_quota_is_guarded(mode):
+        predictions, quota_counts, status, guarded_fixed_trials = _guarded_balanced_quota_predictions(
+            probabilities,
+            class_order,
+        )
+    else:
+        predictions, quota_counts, status = _balanced_quota_predictions(
+            probabilities,
+            class_order,
+        )
+        guarded_fixed_trials = ""
     class_order = np.asarray(class_order, dtype=int).ravel()
     return {
         "mode": mode,
@@ -2587,6 +2624,7 @@ def _balanced_quota_metadata(probabilities, class_order, score_normalization):
         "class_order": class_order,
         "quota_counts": quota_counts,
         "predictions": predictions,
+        "guarded_fixed_trials": guarded_fixed_trials,
     }
 
 
@@ -2620,6 +2658,74 @@ def _balanced_quota_predictions(probabilities, class_order):
     prediction_columns = np.empty(sanitized.shape[0], dtype=int)
     prediction_columns[row_indices] = expanded_columns[slot_indices]
     return class_order[prediction_columns], quotas, "applied"
+
+
+def _guarded_balanced_quota_predictions(probabilities, class_order):
+    """Balanced quota assignment that preserves high-margin argmax trials first."""
+
+    probabilities = np.asarray(probabilities, dtype=float)
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    if (
+        probabilities.ndim != 2
+        or probabilities.shape[0] == 0
+        or probabilities.shape[1] == 0
+    ):
+        return (
+            np.asarray([], dtype=int),
+            np.zeros(class_order.shape[0], dtype=int),
+            "skipped_empty_scores",
+            "",
+        )
+    if class_order.shape[0] != probabilities.shape[1]:
+        return (
+            np.asarray([], dtype=int),
+            np.zeros(class_order.shape[0], dtype=int),
+            "skipped_class_order_mismatch",
+            "",
+        )
+
+    sanitized = _finite_assignment_scores(probabilities)
+    quotas = _balanced_quota_counts(sanitized)
+    argmax_columns = np.argmax(sanitized, axis=1)
+    margins = _assignment_score_margins(sanitized)
+    prediction_columns = np.full(sanitized.shape[0], -1, dtype=int)
+    used = np.zeros(sanitized.shape[1], dtype=int)
+
+    for row_index in np.argsort(-margins, kind="mergesort"):
+        column = int(argmax_columns[row_index])
+        if used[column] < quotas[column]:
+            prediction_columns[row_index] = column
+            used[column] += 1
+
+    remaining_rows = np.flatnonzero(prediction_columns < 0)
+    remaining_quotas = quotas - used
+    if int(np.sum(remaining_quotas)) != int(remaining_rows.shape[0]):
+        predictions, quota_counts, status = _balanced_quota_predictions(probabilities, class_order)
+        return predictions, quota_counts, f"fallback_{status}", ""
+
+    if remaining_rows.size:
+        expanded_columns = np.repeat(np.arange(sanitized.shape[1], dtype=int), remaining_quotas)
+        if expanded_columns.shape[0] != remaining_rows.shape[0]:
+            predictions, quota_counts, status = _balanced_quota_predictions(probabilities, class_order)
+            return predictions, quota_counts, f"fallback_{status}", ""
+        row_indices, slot_indices = linear_sum_assignment(-sanitized[remaining_rows][:, expanded_columns])
+        prediction_columns[remaining_rows[row_indices]] = expanded_columns[slot_indices]
+
+    if np.any(prediction_columns < 0):
+        predictions, quota_counts, status = _balanced_quota_predictions(probabilities, class_order)
+        return predictions, quota_counts, f"fallback_{status}", ""
+    guarded_fixed_trials = int(sanitized.shape[0] - remaining_rows.shape[0])
+    return class_order[prediction_columns], quotas, "applied_guarded", guarded_fixed_trials
+
+
+def _assignment_score_margins(scores):
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        return np.asarray([], dtype=float)
+    if scores.shape[1] == 1:
+        return np.full(scores.shape[0], np.inf, dtype=float)
+    ordered = np.sort(scores, axis=1)[:, ::-1]
+    return ordered[:, 0] - ordered[:, 1]
 
 
 def _inner_confusion_correction_blend(inner_mode):
@@ -2916,6 +3022,16 @@ def _add_balanced_quota_fields(row, metadata):
     row["ensemble_balanced_quota_counts"] = _format_float_mapping(
         zip(labels_one_based, metadata.get("quota_counts", ()))
     )
+    row["ensemble_balanced_quota_guarded_fixed_trials"] = metadata.get(
+        "guarded_fixed_trials",
+        "",
+    )
+    fixed_trials = metadata.get("guarded_fixed_trials", "")
+    predictions = np.asarray(metadata.get("predictions", ()), dtype=int)
+    if fixed_trials != "" and predictions.shape[0]:
+        row["ensemble_balanced_quota_guarded_fixed_fraction"] = float(fixed_trials) / float(predictions.shape[0])
+    else:
+        row["ensemble_balanced_quota_guarded_fixed_fraction"] = ""
 
 
 def _normalized_ensemble_weights(weights, expected_size):

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -294,6 +294,7 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
     *,
     window_centers=None,
     window_size=None,
+    window_sizes=None,
     baseline_window=None,
     feature_modes=None,
     normalizations=None,
@@ -324,10 +325,14 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
     trial_selection_seed = getattr(_impl, "DEFAULT_CROSS_SUBJECT_TRIAL_SELECTION_SEED", 0) if trial_selection_seed is None else trial_selection_seed
     chance_classes = _impl.DEFAULT_CROSS_SUBJECT_CHANCE_CLASSES if chance_classes is None else chance_classes
 
+    if window_sizes is None:
+        window_sizes = (window_size,)
+    window_sizes = tuple(float(value) for value in window_sizes)
+
     return tuple(
         CrossSubjectStimulusConfig(
             window_center=window_center,
-            window_size=window_size,
+            window_size=grid_window_size,
             baseline_window=baseline_window,
             feature_mode=_normalize_feature_mode(feature_mode),
             normalization=normalization,
@@ -346,8 +351,9 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
             signflip_permutations=signflip_permutations,
             signflip_seed=signflip_seed,
         )
-        for window_center, feature_mode, normalization, alignment, classifier, components_pca, sample_weighting, score_calibration, alignment_alpha in product(
+        for window_center, grid_window_size, feature_mode, normalization, alignment, classifier, components_pca, sample_weighting, score_calibration, alignment_alpha in product(
             window_centers,
+            window_sizes,
             feature_modes,
             normalizations,
             alignments,

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -576,6 +576,15 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
         help="Comma-separated candidate window centers in seconds.",
     )
     parser.add_argument("--window-size", type=float, default=DEFAULT_CROSS_SUBJECT_WINDOW_SIZE, help="Candidate window size in seconds.")
+    parser.add_argument(
+        "--window-sizes",
+        type=parse_float_list,
+        default=None,
+        help=(
+            "Optional comma-separated candidate window sizes in seconds. "
+            "Overrides --window-size when set."
+        ),
+    )
     parser.add_argument("--baseline-window", type=_parse_time_window, default=DEFAULT_CROSS_SUBJECT_BASELINE_WINDOW, help="Baseline window as start,stop in seconds.")
     parser.add_argument(
         "--feature-modes",
@@ -719,6 +728,7 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
     candidate_configs = make_cross_subject_candidate_configs(
         window_centers=args.window_centers,
         window_size=args.window_size,
+        window_sizes=args.window_sizes,
         baseline_window=args.baseline_window,
         feature_modes=args.feature_modes,
         normalizations=args.normalizations,

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -804,6 +804,49 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(cross_subject._inner_confusion_correction_mode(mode), mode)  # pylint: disable=protected-access
         self.assertEqual(cross_subject._inner_confusion_correction_mode(quota_mode), mode)  # pylint: disable=protected-access
 
+    def test_guarded_balanced_quota_preserves_high_margin_argmax_trials(self):
+        probabilities = np.asarray(
+            [
+                [0.99, 0.01],
+                [0.98, 0.02],
+                [0.51, 0.49],
+                [0.50, 0.50],
+            ],
+            dtype=float,
+        )
+        class_order = np.asarray([0, 1], dtype=int)
+
+        predictions, quotas, status, fixed_trials = cross_subject._guarded_balanced_quota_predictions(  # pylint: disable=protected-access
+            probabilities,
+            class_order,
+        )
+
+        self.assertEqual(status, "applied_guarded")
+        self.assertEqual(quotas.tolist(), [2, 2])
+        self.assertEqual(fixed_trials, 2)
+        self.assertEqual(predictions[:2].tolist(), [0, 0])
+        self.assertEqual(Counter(predictions.tolist()), Counter({0: 2, 1: 2}))
+
+    def test_guarded_balanced_quota_normalization_uses_underlying_rank_base(self):
+        mode = "rank_z_blend_guarded_balanced_quota"
+
+        self.assertEqual(
+            cross_subject._normalize_ensemble_score_normalization(mode),
+            mode,
+        )  # pylint: disable=protected-access
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),
+            "rank_z_blend",
+        )  # pylint: disable=protected-access
+        self.assertEqual(
+            cross_subject._inner_class_prior_balance_mode(mode),
+            None,
+        )  # pylint: disable=protected-access
+        self.assertEqual(
+            cross_subject._inner_confusion_correction_mode(mode),
+            None,
+        )  # pylint: disable=protected-access
+
     def test_soft_inner_confusion_score_normalizations_are_supported(self):
         expected_bases = {
             "rank_softmax_inner_confusion_soft": "rank_softmax",

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -285,6 +285,30 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual({config.score_calibration for config in configs}, {"none", "inner_class_bias"})
         self.assertEqual({config.alignment_alpha for config in configs}, {0.25, 1.0})
 
+    def test_candidate_grid_expands_window_sizes(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.150, 0.175),
+            window_sizes=(0.125, 0.150),
+            feature_modes=("sensor_mean",),
+            normalizations=("none",),
+            alignments=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(1.0,),
+            components_pca_values=(64,),
+            chance_classes=2,
+        )
+
+        self.assertEqual(len(configs), 4)
+        self.assertEqual(
+            {(config.window_center, config.window_size) for config in configs},
+            {
+                (0.150, 0.125),
+                (0.150, 0.150),
+                (0.175, 0.125),
+                (0.175, 0.150),
+            },
+        )
+
     def test_candidate_grid_accepts_inner_class_affine_score_calibration(self):
         configs = make_cross_subject_candidate_configs(
             window_centers=(0.175,),


### PR DESCRIPTION
## Summary
- Add optional nested stimulus window-size grids and wire them through CLI/workflow matrix execution.
- Report selected window-size counts in nested summaries.
- Add guarded balanced-quota ensemble normalization modes and diagnostics.

## Validation
- `git diff --check`
- Test suites not run per request.