### PR TITLE
Use NeuRepTrace imports

### DIFF
--- a/src/pymegdec/_reptrace_score_overrides.py
+++ b/src/pymegdec/_reptrace_score_overrides.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import numpy as np
-from reptrace.decoding.class_scores import class_score_matrix, predict_window_class_scores
-from reptrace.metrics import rank_class_scores
+from neureptrace.decoding.class_scores import class_score_matrix, predict_window_class_scores
+from neureptrace.metrics import rank_class_scores
 
 
 def mcca_score_matrix(bundle, features):

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -20,14 +20,14 @@ from pymegdec.classifiers import (
     train_multiclass_classifier,
 )
 from pymegdec.data_config import resolve_data_folder
-from reptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
-from reptrace.decoding.windowed import (
+from neureptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
+from neureptrace.decoding.windowed import (
     predict_window_model as predict_reptrace_window_model,
 )
-from reptrace.decoding.windowed import (
+from neureptrace.decoding.windowed import (
     transform_window_features as transform_reptrace_window_features,
 )
-from reptrace.metrics.confusion import (
+from neureptrace.metrics.confusion import (
     confusion_category_enrichment,
     confusion_category_matrix,
     confusion_counts,

--- a/src/pymegdec/_stimulus_decoding_core.py
+++ b/src/pymegdec/_stimulus_decoding_core.py
@@ -23,24 +23,24 @@ from pymegdec.preprocessing import (
     extract_windows,
     filter_features,
 )
-from reptrace.decoding.temporal_generalization import (  # pylint: disable=no-name-in-module
+from neureptrace.decoding.temporal_generalization import (  # pylint: disable=no-name-in-module
     TemporalFeatureWindow,
     compute_temporal_generalization_matrix,
 )
-from reptrace.decoding.transfer import (  # pylint: disable=no-name-in-module
+from neureptrace.decoding.transfer import (  # pylint: disable=no-name-in-module
     append_null_class_features,
     evaluate_feature_transfer,
 )
-from reptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
-from reptrace.decoding.windowed import (
+from neureptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
+from neureptrace.decoding.windowed import (
     predict_window_model as predict_reptrace_window_model,
 )
-from reptrace.metrics.confusion import (  # pylint: disable=no-name-in-module
+from neureptrace.metrics.confusion import (  # pylint: disable=no-name-in-module
     confusion_counts,
     per_class_accuracy,
 )
-from reptrace.onset_detection import annotate_threshold_crossings, detect_onsets
-from reptrace.results.tables import (  # pylint: disable=no-name-in-module
+from neureptrace.onset_detection import annotate_threshold_crossings, detect_onsets
+from neureptrace.results.tables import (  # pylint: disable=no-name-in-module
     peak_metric_rows,
     summarize_metric_table,
 )

--- a/src/pymegdec/_stimulus_hyperalignment_legacy.py
+++ b/src/pymegdec/_stimulus_hyperalignment_legacy.py
@@ -9,13 +9,13 @@ from dataclasses import dataclass
 from math import comb
 
 import numpy as np
-from reptrace.decoding.hyperalignment import (
+from neureptrace.decoding.hyperalignment import (
     CLASS_ALIGNMENT_SAMPLE_MODES,
     class_alignment_matrices,
     fit_class_hyperalignment,
     fit_projection_to_hyperalignment,
 )
-from reptrace.decoding.windowed import fit_window_model, predict_window_model, transform_window_features
+from neureptrace.decoding.windowed import fit_window_model, predict_window_model, transform_window_features
 from sklearn.metrics import accuracy_score, balanced_accuracy_score
 
 from pymegdec.alignment_window import (

--- a/src/pymegdec/_stimulus_mcca_legacy.py
+++ b/src/pymegdec/_stimulus_mcca_legacy.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 from math import comb
 
 import numpy as np
-from reptrace.decoding.mcca import CLASS_ALIGNMENT_SAMPLE_MODES, fit_class_mcca
-from reptrace.decoding.mcca_target import class_alignment_matrix, fit_target_mcca_projection
-from reptrace.decoding.windowed import fit_window_model, predict_window_model, transform_window_features
+from neureptrace.decoding.mcca import CLASS_ALIGNMENT_SAMPLE_MODES, fit_class_mcca
+from neureptrace.decoding.mcca_target import class_alignment_matrix, fit_target_mcca_projection
+from neureptrace.decoding.windowed import fit_window_model, predict_window_model, transform_window_features
 from sklearn.metrics import accuracy_score, balanced_accuracy_score
 
 from pymegdec.alignment_window import (

--- a/src/pymegdec/_stimulus_summary.py
+++ b/src/pymegdec/_stimulus_summary.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pymegdec._stimulus_decoding_core as _core
-from reptrace.results.tables import summarize_metric_table
+from neureptrace.results.tables import summarize_metric_table
 
 _CHANCE_CLASS_COLUMNS = ("chance_classes", "n_chance_classes", "n_validation_classes")
 _CHANCE_SUMMARY_COLUMNS = (

--- a/src/pymegdec/_stimulus_trial_sampling.py
+++ b/src/pymegdec/_stimulus_trial_sampling.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from reptrace.decoding.sampling import (
+from neureptrace.decoding.sampling import (
     normalize_class_limit_seed,
     normalize_class_limit_selection,
     select_class_limited_indices,

--- a/src/pymegdec/alignment_window.py
+++ b/src/pymegdec/alignment_window.py
@@ -1,11 +1,11 @@
 """Compatibility layer for alignment-window helpers now provided by NeuRepTrace."""
 
-from reptrace.decoding.alignment_window import AlignmentWindow
-from reptrace.decoding.alignment_window import WindowedFeatureSet
-from reptrace.decoding.alignment_window import resolved_alignment_window
-from reptrace.decoding.alignment_window import transform_with_alignment_projection
-from reptrace.decoding.alignment_window import uses_separate_alignment_window
-from reptrace.decoding.alignment_window import validate_paired_feature_sets
+from neureptrace.decoding.alignment_window import AlignmentWindow
+from neureptrace.decoding.alignment_window import WindowedFeatureSet
+from neureptrace.decoding.alignment_window import resolved_alignment_window
+from neureptrace.decoding.alignment_window import transform_with_alignment_projection
+from neureptrace.decoding.alignment_window import uses_separate_alignment_window
+from neureptrace.decoding.alignment_window import validate_paired_feature_sets
 
 __all__ = [
     "AlignmentWindow",

--- a/src/pymegdec/classifiers.py
+++ b/src/pymegdec/classifiers.py
@@ -1,6 +1,6 @@
 """Backward-compatible classifier adapters.
 
-Classifier implementations now live in :mod:`reptrace.decoding.classifiers`.
+Classifier implementations now live in :mod:`neureptrace.decoding.classifiers`.
 This module preserves historical ``pymegdec.classifiers`` imports and adds
 PyMEGDec-local registry entries that are useful for the stimulus benchmarks.
 """
@@ -11,7 +11,7 @@ from typing import Any, cast
 import warnings
 
 import numpy as np
-import reptrace.decoding.classifiers as reptrace_classifiers
+import neureptrace.decoding.classifiers as reptrace_classifiers
 from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import LinearSVC
@@ -19,7 +19,7 @@ from sklearn.multiclass import OneVsRestClassifier
 from sklearn.naive_bayes import GaussianNB
 from sklearn.pipeline import Pipeline
 
-from reptrace.decoding.classifiers import (
+from neureptrace.decoding.classifiers import (
     ClassifierSpec,
     CorrelationPrototypeClassifier,
     DecodedLabelClassifier,
@@ -33,13 +33,13 @@ from reptrace.decoding.classifiers import (
     train_gradient_boosting,
     train_lasso_logistic,
 )
-from reptrace.decoding.classifiers import (
+from neureptrace.decoding.classifiers import (
     CLASSIFIER_REGISTRY as REPTRACE_CLASSIFIER_REGISTRY,
 )
-from reptrace.decoding.classifiers import (
+from neureptrace.decoding.classifiers import (
     DEFAULT_CLASSIFIER_PARAMS as REPTRACE_DEFAULT_CLASSIFIER_PARAMS,
 )
-from reptrace.decoding.classifiers import (
+from neureptrace.decoding.classifiers import (
     get_default_classifier_param as get_reptrace_default_classifier_param,
 )
 
@@ -416,7 +416,7 @@ def train_multiclass_classifier(
 
 def __getattr__(name: str) -> Any:
     if name == "MLPClassifierTorch":
-        from reptrace.decoding.torch_models import MLPClassifierTorch
+        from neureptrace.decoding.torch_models import MLPClassifierTorch
 
         return MLPClassifierTorch
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/pymegdec/cross_validation.py
+++ b/src/pymegdec/cross_validation.py
@@ -7,7 +7,7 @@ from pymegdec.classifiers import (
 )
 from pymegdec.data_config import resolve_data_folder
 from pymegdec.preprocessing import preprocess_features
-from reptrace.decoding.transfer import cross_validate_feature_decoding
+from neureptrace.decoding.transfer import cross_validate_feature_decoding
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments

--- a/src/pymegdec/model_transfer.py
+++ b/src/pymegdec/model_transfer.py
@@ -9,7 +9,7 @@ from pymegdec.classifiers import (
 )
 from pymegdec.data_config import resolve_data_folder
 from pymegdec.preprocessing import preprocess_features
-from reptrace.decoding.transfer import evaluate_feature_transfer
+from neureptrace.decoding.transfer import evaluate_feature_transfer
 
 
 def _trialinfo_labels(data):

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -86,7 +86,7 @@ from pymegdec.stimulus_decoding import (
     summarize_stimulus_prediction_diagnostics,
     window_centers_from_range,
 )
-from reptrace.decoding.robustness import (
+from neureptrace.decoding.robustness import (
     RobustnessCondition,
     run_participant_robustness_conditions,
 )

--- a/src/pymegdec/stimulus_cue_calibration.py
+++ b/src/pymegdec/stimulus_cue_calibration.py
@@ -23,7 +23,7 @@ from pymegdec.stimulus_cross_subject import (
     CrossSubjectStimulusConfig,
     ParticipantFeatureSet,
 )
-from reptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
+from neureptrace.decoding.windowed import fit_window_model as fit_reptrace_window_model
 
 DEFAULT_CUE_CALIBRATION_ALIGNMENT = "cue_class_procrustes"
 DEFAULT_CUE_CALIBRATION_DATA = "cue"

--- a/src/pymegdec/torch_models.py
+++ b/src/pymegdec/torch_models.py
@@ -1,5 +1,5 @@
 """Backward-compatible imports for optional PyTorch classifiers."""
 
-from reptrace.decoding.torch_models import MLPClassifierTorch
+from neureptrace.decoding.torch_models import MLPClassifierTorch
 
 __all__ = ["MLPClassifierTorch"]

--- a/tests/test_classifier_registry.py
+++ b/tests/test_classifier_registry.py
@@ -3,7 +3,7 @@ import unittest
 import warnings
 
 import numpy as np
-from reptrace.decoding.classifiers import (
+from neureptrace.decoding.classifiers import (
     CLASSIFIER_REGISTRY,
     should_use_default_classifier_param,
     train_multiclass_classifier,
@@ -34,6 +34,7 @@ class TestClassifierRegistry(unittest.TestCase):
                 "knn",
                 "mostFrequentDummy",
                 "multinomial-logistic",
+                "multinomial-logistic-weighted",
                 "multiclass-svm",
                 "multiclass-svm-weighted",
                 "pytorch-mlp",

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -53,7 +53,7 @@ class TestClassifiers(unittest.TestCase):
             seen["labels"] = np.asarray(labels, dtype=int).copy()
             return EncodedBinaryModel()
 
-        with patch("reptrace.decoding.classifiers.train_classifier", side_effect=fake_train_classifier):
+        with patch("neureptrace.decoding.classifiers.train_classifier", side_effect=fake_train_classifier):
             model = train_multiclass_classifier(
                 self.features[:2],
                 np.asarray([10, 20], dtype=int),

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -7,7 +7,7 @@ import numpy as np
 class TestMLPClassifierTorch(unittest.TestCase):
     def test_configured_learning_rate_is_used_by_optimizer(self):
         try:
-            from reptrace.decoding.torch_models import MLPClassifierTorch
+            from neureptrace.decoding.torch_models import MLPClassifierTorch
         except ImportError as exc:
             self.skipTest(f"PyTorch dependencies are not installed: {exc}")
 
@@ -25,7 +25,7 @@ class TestMLPClassifierTorch(unittest.TestCase):
     def test_seeded_data_loaders_are_reproducible(self):
         if importlib.util.find_spec("torch") is None:
             self.skipTest("PyTorch dependencies are not installed: No module named 'torch'")
-        from reptrace.decoding.classifiers import _build_pytorch_data_loaders
+        from neureptrace.decoding.classifiers import _build_pytorch_data_loaders
 
         features = np.arange(40).reshape(20, 2)
         labels = np.arange(20)


### PR DESCRIPTION
## Summary
- switch PyMEGDec compatibility imports from the removed `reptrace` namespace to `neureptrace`
- update affected tests and the classifier-registry expectation for the current NeuRepTrace registry

## Validation
- `$env:PYTHONPATH='C:\\Users\\emper\\Documents\\Codex\\2026-05-16\\ips-stuttgart-pymegdec-https-github-com\\NeuRepTrace\\src;src'; python -m pytest tests/test_classifier_registry.py tests/test_classifiers.py tests/test_torch_models.py tests/test_stimulus_decoding.py -q`
- `$env:PYTHONPATH='C:\\Users\\emper\\Documents\\Codex\\2026-05-16\\ips-stuttgart-pymegdec-https-github-com\\NeuRepTrace\\src;src;.'; python -m unittest tests.test_stimulus_decoding.TestStimulusDecoding.test_evaluate_participant_time_resolved_stimulus_transfer tests.test_stimulus_decoding.TestStimulusDecoding.test_evaluate_participant_stimulus_temporal_generalization tests.test_stimulus_decoding.TestStimulusDecoding.test_evaluate_participant_stimulus_onset_scan`
- `git diff --check`