### PR TITLE
Add BUSH rank consensus and sensor delta options

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -52,6 +52,7 @@ on:
           - windowed_logreg_175_finetune
           - windowed_logreg_175_balanced_lcb
           - windowed_logreg_175_flat_logpower
+          - windowed_logreg_175_flat_delta
           - windowed_logreg_175_dct
           - windowed_logreg_175_test_prior_balance
           - windowed_logreg_175_bias_calibration
@@ -67,6 +68,7 @@ on:
           - windowed_logreg_175_rank_confusion_guarded
           - windowed_logreg_lean_rank_confusion_guarded
           - windowed_logreg_175_rankz_inner_confusion_margin_soft
+          - windowed_logreg_175_rankmargin_inner_confusion_soft_guarded
           - windowed_logreg_lean_reciprocal_inner_prior
           - windowed_logreg_lean_inner_prior
           - windowed_logreg_lean_inner_prior_quota
@@ -81,6 +83,7 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w150_rank_consensus
           - windowed_logreg_175_w125_w150
           - windowed_logreg_w150_size_center_grid
           - windowed_logreg_175_temporal_delta_features
@@ -133,6 +136,9 @@ on:
           - rank_top3_vote
           - rank_z_blend
           - rank_margin_blend
+          - rank_margin_blend_inner_confusion_soft
+          - rank_margin_blend_inner_confusion_soft_guarded
+          - rank_consensus
           - rank_softmax_test_prior_balance
           - rank_softmax_t2_test_prior_balance
           - rank_softmax_t3_test_prior_balance
@@ -698,6 +704,21 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_flat_delta": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat,sensor_flat_delta",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128,192",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_dct": {
                   "window_centers": "0.175",
                   "feature_modes": "sensor_flat,sensor_dct",
@@ -892,6 +913,21 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_z_blend_inner_confusion_margin_soft",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_rankmargin_inner_confusion_soft_guarded": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_margin_blend_inner_confusion_soft_guarded",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -1300,6 +1336,21 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_rank_consensus": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_consensus",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -86,6 +86,7 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top3_vote",
     "rank_z_blend",
     "rank_margin_blend",
+    "rank_consensus",
     "rank_softmax_test_prior_balance",
     "rank_softmax_t2_test_prior_balance",
     "rank_softmax_t3_test_prior_balance",
@@ -256,6 +257,8 @@ RANK_SOFTMAX_TEMPERATURES = {
 }
 RANK_MARGIN_BLEND_LOW = 0.25
 RANK_MARGIN_BLEND_HIGH = 1.25
+RANK_CONSENSUS_TEMPERATURE = 1.0
+RANK_CONSENSUS_DISAGREEMENT_PENALTY = 0.5
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
     "window",
@@ -1976,14 +1979,23 @@ def _score_outer_fold_ensemble_models(
     ensemble_score_normalization = _normalize_ensemble_score_normalization(ensemble_score_normalization)
     base_score_normalization = _base_ensemble_score_normalization(ensemble_score_normalization)
     probability_matrices = []
+    aligned_score_matrices = []
     actual_components = []
     for fitted_model, test_set, config in zip(fitted_models, test_sets, configs):
         class_scores, score_classes = _candidate_model_scores(fitted_model, test_set, config)
-        probabilities = _class_score_probabilities(class_scores, score_normalization=base_score_normalization)
-        probability_matrices.append(_align_score_columns(probabilities, score_classes, class_order))
+        if base_score_normalization == "rank_consensus":
+            aligned_score_matrices.append(
+                _align_class_score_columns(class_scores, score_classes, class_order)
+            )
+        else:
+            probabilities = _class_score_probabilities(class_scores, score_normalization=base_score_normalization)
+            probability_matrices.append(_align_score_columns(probabilities, score_classes, class_order))
         actual_components.append(fitted_model["model_bundle"].actual_components_pca)
 
-    ensemble_probabilities = np.tensordot(weights, np.stack(probability_matrices, axis=0), axes=(0, 0))
+    if base_score_normalization == "rank_consensus":
+        ensemble_probabilities = _rank_consensus_ensemble_probabilities(aligned_score_matrices, weights)
+    else:
+        ensemble_probabilities = np.tensordot(weights, np.stack(probability_matrices, axis=0), axes=(0, 0))
     prior_balance_metadata = _inner_class_prior_balance_metadata(
         selected_rows, class_order, weights, ensemble_score_normalization
     )
@@ -2151,6 +2163,8 @@ def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJ
         return _rank_z_blend_probabilities(scores)
     if score_normalization == "rank_margin_blend":
         return _rank_margin_blend_probabilities(scores)
+    if score_normalization == "rank_consensus":
+        return _rank_softmax_probabilities(scores)
     raise ValueError(f"Unsupported ensemble score normalization: {score_normalization}")
 
 
@@ -2335,6 +2349,73 @@ def _rank_margin_blend_confidence(scores):
         margin = float(ordered[0] - ordered[1])
         confidence[row_index] = float(np.clip((margin - low) / denom, 0.0, 1.0))
     return confidence
+
+
+def _rank_consensus_ensemble_probabilities(score_matrices, weights):
+    """Return probabilities from cross-model rank agreement."""
+
+    score_tensor = np.asarray(tuple(score_matrices), dtype=float)
+    if score_tensor.ndim != 3 or score_tensor.shape[0] == 0 or score_tensor.shape[2] == 0:
+        raise ValueError("Rank-consensus ensembling requires non-empty model x trial x class scores.")
+
+    weights = _normalized_ensemble_weights(weights, score_tensor.shape[0])
+    rank_tensor = _rank_consensus_model_ranks(score_tensor)
+    mean_ranks = np.tensordot(weights, rank_tensor, axes=(0, 0))
+    rank_variance = np.tensordot(weights, (rank_tensor - mean_ranks[None, :, :]) ** 2, axes=(0, 0))
+    rank_std = np.sqrt(np.maximum(rank_variance, 0.0))
+    logits = (
+        -mean_ranks / float(RANK_CONSENSUS_TEMPERATURE)
+        - float(RANK_CONSENSUS_DISAGREEMENT_PENALTY) * rank_std
+    )
+    logits -= np.max(logits, axis=1, keepdims=True)
+    exp_logits = np.exp(np.clip(logits, -50.0, 50.0))
+    row_sums = np.sum(exp_logits, axis=1, keepdims=True)
+    return np.divide(
+        exp_logits,
+        row_sums,
+        out=np.full_like(exp_logits, 1.0 / exp_logits.shape[1]),
+        where=row_sums > 0.0,
+    )
+
+
+def _rank_consensus_model_ranks(score_tensor):
+    """Return per-model ranks where 0 is the highest finite score."""
+
+    score_tensor = np.asarray(score_tensor, dtype=float)
+    if score_tensor.ndim != 3:
+        raise ValueError("Rank-consensus ranks require model x trial x class scores.")
+    n_models, n_trials, n_classes = score_tensor.shape
+    ranks = np.full((n_models, n_trials, n_classes), float(n_classes), dtype=float)
+    fallback_rank = 0.5 * float(max(n_classes - 1, 0))
+    for model_index in range(n_models):
+        for trial_index in range(n_trials):
+            row = score_tensor[model_index, trial_index]
+            finite = np.isfinite(row)
+            n_finite = int(np.sum(finite))
+            if n_finite == 0:
+                ranks[model_index, trial_index, :] = fallback_rank
+                continue
+            ordered = np.argsort(-np.where(finite, row, -np.inf), kind="mergesort")[:n_finite]
+            ranks[model_index, trial_index, ordered] = np.arange(n_finite, dtype=float)
+    return ranks
+
+
+def _align_class_score_columns(scores, score_classes, class_order):
+    """Align raw score columns without row-normalizing them."""
+
+    scores = np.asarray(scores, dtype=float)
+    score_classes = np.asarray(score_classes, dtype=int).ravel()
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    aligned = np.full((scores.shape[0], class_order.shape[0]), -np.inf, dtype=float)
+    class_to_column = {
+        int(class_label): column
+        for column, class_label in enumerate(class_order.tolist())
+    }
+    for source_column, class_label in enumerate(score_classes.tolist()):
+        target_column = class_to_column.get(int(class_label))
+        if target_column is not None:
+            aligned[:, target_column] = scores[:, source_column]
+    return aligned
 
 
 def _align_score_columns(probabilities, score_classes, class_order):
@@ -2753,7 +2834,11 @@ def _inner_confusion_correction_is_margin_gated(inner_mode):
     mode = str(inner_mode)
     if mode.endswith("_guarded"):
         mode = mode.removesuffix("_guarded")
-    return "_margin_" in mode or mode.endswith("_margin")
+    return (
+        "_inner_confusion_margin" in mode
+        or mode.endswith("_inner_confusion_margin")
+        or "_margin_confusion" in mode
+    )
 
 
 def _inner_confusion_correction_reliability_metadata(counts):

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -73,6 +73,7 @@ DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
 DEFAULT_SENSOR_DCT_COEFFICIENTS = 8
 BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",
+    "sensor_flat_delta",
     "sensor_dct",
     "sensor_time_pyramid",
     "sensor_time_pyramid_logpower",
@@ -83,6 +84,7 @@ EXTENDED_FEATURE_MODES = (
     "sensor_logpower",
     "sensor_mean_logpower",
     "sensor_flat_logpower",
+    "sensor_flat_delta",
     "sensor_dct",
     "sensor_bandpower",
     "sensor_cov_tangent",
@@ -101,6 +103,7 @@ SOFT_INNER_CONFUSION_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_t3_inner_confusion_soft": "rank_softmax_t3",
     "rank_reciprocal_inner_confusion_soft": "rank_reciprocal",
     "rank_borda_inner_confusion_soft": "rank_borda",
+    "rank_margin_blend_inner_confusion_soft": "rank_margin_blend",
     "rank_top2_vote_inner_confusion_soft": "rank_top2_vote",
     "rank_top3_vote_inner_confusion_soft": "rank_top3_vote",
 }
@@ -382,6 +385,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_logpower_feature(signal)
         elif feature_mode == "sensor_flat_logpower":
             feature = _sensor_flat_logpower_feature(signal)
+        elif feature_mode == "sensor_flat_delta":
+            feature = _sensor_flat_delta_feature(signal)
         elif feature_mode == "sensor_dct":
             feature = _sensor_dct_feature(signal)
         elif feature_mode == "sensor_mean_logpower":
@@ -420,6 +425,17 @@ def _sensor_flat_logpower_feature(window_signal):
 
     signal = np.asarray(window_signal, dtype=float)
     return np.concatenate((signal.reshape(-1, order="F"), _sensor_logpower_feature(signal)))
+
+
+def _sensor_flat_delta_feature(window_signal):
+    """Return raw evoked samples plus adjacent temporal differences."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    flat = signal.reshape(-1, order="F")
+    if signal.shape[1] < 2:
+        return flat
+    deltas = np.diff(signal, axis=1).reshape(-1, order="F")
+    return np.concatenate((flat, deltas))
 
 
 def _sensor_dct_feature(
@@ -550,6 +566,8 @@ def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
     feature_mode = _normalize_feature_mode(config.feature_mode)
     if feature_mode == "sensor_flat_logpower":
         return _sensor_flat_logpower_baseline_statistics(data, config, n_window_samples, trial_indices)
+    if feature_mode == "sensor_flat_delta":
+        return _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode in EXTENDED_FEATURE_MODES:
         baseline_features, n_baseline_samples = _extract_window_features(data, config.baseline_window, feature_mode=config.feature_mode, trial_indices=trial_indices)
         mean = np.mean(baseline_features, axis=0, keepdims=True)
@@ -583,6 +601,41 @@ def _sensor_flat_logpower_baseline_statistics(data, config, n_window_samples, tr
     flat_std = np.tile(channel_std, int(n_window_samples))
     mean = np.concatenate((flat_mean, np.mean(logpower_features, axis=0)))[None, :]
     std = np.concatenate((flat_std, np.std(logpower_features, axis=0)))[None, :]
+    return mean, _impl._nonzero_std(std), n_baseline_samples
+
+
+def _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial_indices):
+    """Baseline statistics for sensor_flat plus adjacent temporal differences."""
+
+    channel_mean, channel_std, n_baseline_samples = _impl._baseline_channel_statistics(
+        data,
+        config.baseline_window,
+        trial_indices,
+    )
+    time_vector = _impl._time_vector(data, 0)
+    mask = _impl._time_mask(time_vector, config.baseline_window)
+    delta_blocks = []
+    for trial_idx in _impl._iter_trial_indices(data, trial_indices):
+        signal = _impl._trial_signal(data, trial_idx)[:, mask]
+        if signal.shape[1] >= 2:
+            delta_blocks.append(np.diff(signal, axis=1))
+
+    if delta_blocks:
+        baseline_deltas = np.concatenate(delta_blocks, axis=1)
+        delta_mean = np.mean(baseline_deltas, axis=1)
+        delta_std = np.std(baseline_deltas, axis=1)
+    else:
+        delta_mean = np.zeros_like(channel_mean, dtype=float)
+        delta_std = np.ones_like(channel_std, dtype=float)
+
+    n_window_samples = int(n_window_samples)
+    n_delta_samples = max(n_window_samples - 1, 0)
+    flat_mean = np.tile(channel_mean, n_window_samples)
+    flat_std = np.tile(channel_std, n_window_samples)
+    delta_mean_tiled = np.tile(delta_mean, n_delta_samples)
+    delta_std_tiled = np.tile(delta_std, n_delta_samples)
+    mean = np.concatenate((flat_mean, delta_mean_tiled))[None, :]
+    std = np.concatenate((flat_std, delta_std_tiled))[None, :]
     return mean, _impl._nonzero_std(std), n_baseline_samples
 
 

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -333,6 +333,28 @@ class TestStimulusCrossSubject(unittest.TestCase):
         np.testing.assert_allclose(np.sum(top2, axis=1), np.ones(3))
         np.testing.assert_allclose(np.sum(top3, axis=1), np.ones(3))
 
+    def test_rank_consensus_ensemble_score_normalization_rewards_agreement(self):
+        self.assertIn("rank_consensus", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        score_matrices = np.asarray(
+            [
+                [[4.0, 3.9, 1.0], [4.0, 1.0, 3.9]],
+                [[1.0, 4.0, 3.0], [1.0, 3.8, 4.0]],
+                [[1.0, 4.0, 3.0], [1.0, 3.7, 4.0]],
+            ],
+            dtype=float,
+        )
+
+        probabilities = cross_subject._rank_consensus_ensemble_probabilities(  # pylint: disable=protected-access
+            score_matrices,
+            np.full(3, 1.0 / 3.0, dtype=float),
+        )
+
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(2))
+        self.assertGreater(probabilities[0, 1], probabilities[0, 0])
+        self.assertGreater(probabilities[0, 1], probabilities[0, 2])
+        self.assertGreater(probabilities[1, 2], probabilities[1, 0])
+        self.assertGreater(probabilities[1, 2], probabilities[1, 1])
+
     def test_prediction_balance_selection_metric_penalizes_collapsed_predictions(self):
         metric = "balanced_top2_top3_rank_prediction_balance"
         collapsed = {

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -50,6 +50,27 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(metadata["margin_quantile"], 0.5)
         self.assertLess(metadata["blend"], 1.0)
 
+    def test_rank_margin_blend_inner_confusion_soft_is_exported_without_margin_gate(self):
+        mode = "rank_margin_blend_inner_confusion_soft_guarded"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_margin_blend",
+        )
+
+        metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            [{"selected_inner_true_predicted_label_pair_counts": "1001:4;1002:2;2002:5"}],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertTrue(metadata["guarded"])
+        self.assertFalse(metadata["margin_gated"])
+        self.assertLess(metadata["blend"], 1.0)
+
     def test_margin_gated_inner_confusion_leaves_high_margin_rows_unchanged(self):
         probabilities = np.asarray([[0.51, 0.49], [0.95, 0.05]], dtype=float)
         metadata = {
@@ -73,6 +94,7 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertIn("sensor_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_mean_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_logpower", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_flat_delta", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_bandpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_cov_tangent", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_time_pyramid", cross_subject.FEATURE_MODES)
@@ -126,6 +148,57 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(feature_set.features.shape, (2, 6))
         np.testing.assert_allclose(feature_set.features[0, :4], np.asarray([1.0, 2.0, 3.0, 6.0]))
         np.testing.assert_allclose(feature_set.features[0, 4:], np.log(np.asarray([5.0, 20.0]) + 1e-12))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_delta_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0, 6.0], [0.0, 0.0, 2.0, 5.0, 9.0]],
+            [[0.0, 0.0, 2.0, 4.0, 7.0], [0.0, 0.0, 4.0, 7.0, 11.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            feature_mode="sensor_flat_delta",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 10))
+        np.testing.assert_allclose(
+            feature_set.features[0],
+            np.asarray([1.0, 2.0, 3.0, 5.0, 6.0, 9.0, 2.0, 3.0, 3.0, 4.0]),
+        )
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_delta_baseline_whiten_allows_different_baseline_duration(self):
+        time = np.asarray([-0.4, -0.3, -0.2, -0.1, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 0.1, 0.2, 0.3, 1.0, 3.0, 6.0], [0.0, 0.4, 0.5, 0.6, 2.0, 5.0, 9.0]],
+            [[0.0, 0.2, 0.3, 0.4, 2.0, 4.0, 7.0], [0.0, 0.5, 0.6, 0.7, 4.0, 7.0, 11.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            baseline_window=(-0.3, -0.1),
+            feature_mode="sensor_flat_delta",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 10))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 10))
+        self.assertEqual(feature_set.baseline_feature_std.shape, (1, 10))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
     def test_sensor_flat_logpower_baseline_whiten_allows_different_baseline_duration(self):


### PR DESCRIPTION
## Summary
- add `sensor_flat_delta` feature extraction and baseline-whitening support
- add `rank_consensus` ensemble score normalization and workflow option
- add rank-margin inner-confusion soft guarded workflow support without margin-gating the base rank-margin normalizer

## Validation
- `git diff --check`
- `python -m py_compile src/pymegdec/_stimulus_cross_subject_legacy.py src/pymegdec/_stimulus_cross_subject_next.py tests/test_stimulus_cross_subject.py tests/test_stimulus_cross_subject_next.py`

Test suites were not run per request.