### PR TITLE
Add ensemble pooling and rank-softmax workflow options

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -28,6 +28,7 @@ on:
         options:
           - windowed_logreg_lean
           - windowed_logreg_lean_no_diversity
+          - windowed_logreg_lean_log_pool
           - windowed_logreg_lean_margin_blend
           - windowed_logreg_lean_balanced_lcb
           - windowed_logreg_lean_predbalance
@@ -53,6 +54,7 @@ on:
           - windowed_logreg_175_balanced_lcb
           - windowed_logreg_175_flat_logpower
           - windowed_logreg_175_flat_delta
+          - windowed_logreg_175_log_pool
           - windowed_logreg_175_dct
           - windowed_logreg_175_test_prior_balance
           - windowed_logreg_175_bias_calibration
@@ -84,6 +86,9 @@ on:
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
           - windowed_logreg_175_w150_rank_consensus
+          - windowed_logreg_175_w150_ranksoft_t1_25
+          - windowed_logreg_175_w150_ranksoft_t1_5
+          - windowed_logreg_175_w150_ranksoft_t1_75
           - windowed_logreg_175_w125_w150
           - windowed_logreg_w150_size_center_grid
           - windowed_logreg_175_temporal_delta_features
@@ -128,6 +133,9 @@ on:
           - bundle-default
           - row_z_softmax
           - rank_softmax
+          - rank_softmax_t1_25
+          - rank_softmax_t1_5
+          - rank_softmax_t1_75
           - rank_softmax_t2
           - rank_softmax_t3
           - rank_reciprocal
@@ -136,6 +144,14 @@ on:
           - rank_top3_vote
           - rank_z_blend
           - rank_margin_blend
+          - row_z_softmax_log_pool
+          - rank_softmax_log_pool
+          - rank_softmax_t2_log_pool
+          - rank_softmax_t3_log_pool
+          - rank_reciprocal_log_pool
+          - rank_borda_log_pool
+          - rank_z_blend_log_pool
+          - rank_margin_blend_log_pool
           - rank_margin_blend_inner_confusion_soft
           - rank_margin_blend_inner_confusion_soft_guarded
           - rank_consensus
@@ -349,6 +365,20 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_log_pool": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_log_pool",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -716,6 +746,21 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_log_pool": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_log_pool",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -1351,6 +1396,51 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_consensus",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_ranksoft_t1_25": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t1_25",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_ranksoft_t1_5": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t1_5",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_ranksoft_t1_75": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t1_75",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -86,6 +86,14 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_top3_vote",
     "rank_z_blend",
     "rank_margin_blend",
+    "row_z_softmax_log_pool",
+    "rank_softmax_log_pool",
+    "rank_softmax_t2_log_pool",
+    "rank_softmax_t3_log_pool",
+    "rank_reciprocal_log_pool",
+    "rank_borda_log_pool",
+    "rank_z_blend_log_pool",
+    "rank_margin_blend_log_pool",
     "rank_consensus",
     "rank_softmax_test_prior_balance",
     "rank_softmax_t2_test_prior_balance",
@@ -245,6 +253,8 @@ INNER_CONFUSION_CORRECTION_IDENTITY_BLEND = 0.20
 INNER_CONFUSION_CORRECTION_SOFT_BLEND = 0.35
 INNER_CONFUSION_CORRECTION_MARGIN_QUANTILE = 0.50
 INNER_CONFUSION_CORRECTION_GUARDED_POWER = 0.5
+LOG_POOL_SUFFIX = "_log_pool"
+ENSEMBLE_LOG_POOL_EPSILON = 1e-12
 BALANCED_QUOTA_SUFFIX = "_balanced_quota"
 GUARDED_BALANCED_QUOTA_SUFFIX = "_guarded_balanced_quota"
 TEST_PRIOR_BALANCE_MAX_ITERATIONS = 50
@@ -1995,7 +2005,11 @@ def _score_outer_fold_ensemble_models(
     if base_score_normalization == "rank_consensus":
         ensemble_probabilities = _rank_consensus_ensemble_probabilities(aligned_score_matrices, weights)
     else:
-        ensemble_probabilities = np.tensordot(weights, np.stack(probability_matrices, axis=0), axes=(0, 0))
+        ensemble_probabilities = _pool_ensemble_probability_matrices(
+            probability_matrices,
+            weights,
+            ensemble_score_normalization,
+        )
     prior_balance_metadata = _inner_class_prior_balance_metadata(
         selected_rows, class_order, weights, ensemble_score_normalization
     )
@@ -2097,6 +2111,36 @@ def _score_outer_fold_ensemble_models(
             _add_test_class_prior_balance_fields(row, test_prior_balance_metadata)
             _add_balanced_quota_fields(row, balanced_quota_metadata)
     return outer_row, prediction_rows
+
+
+def _pool_ensemble_probability_matrices(probability_matrices, weights, score_normalization):
+    """Pool candidate class-posteriors for a nested top-K ensemble."""
+
+    stacked = np.stack(tuple(np.asarray(matrix, dtype=float) for matrix in probability_matrices), axis=0)
+    weights = _normalized_ensemble_weights(weights, stacked.shape[0])
+    if _ensemble_log_pool_mode(score_normalization) is None:
+        return np.tensordot(weights, stacked, axes=(0, 0))
+
+    epsilon = float(ENSEMBLE_LOG_POOL_EPSILON)
+    sanitized = np.where(np.isfinite(stacked) & (stacked > 0.0), stacked, epsilon)
+    log_probabilities = np.log(np.maximum(sanitized, epsilon))
+    pooled_logits = np.tensordot(weights, log_probabilities, axes=(0, 0))
+    pooled_logits -= np.max(pooled_logits, axis=1, keepdims=True)
+    pooled = np.exp(np.clip(pooled_logits, -50.0, 50.0))
+    row_sums = np.sum(pooled, axis=1, keepdims=True)
+    return np.divide(
+        pooled,
+        row_sums,
+        out=np.full_like(pooled, 1.0 / pooled.shape[1]),
+        where=row_sums > 0.0,
+    )
+
+
+def _ensemble_log_pool_mode(score_normalization):
+    normalized = str(score_normalization).strip().lower().replace("-", "_")
+    if normalized not in ENSEMBLE_SCORE_NORMALIZATION_MODES:
+        return None
+    return normalized if normalized.endswith(LOG_POOL_SUFFIX) else None
 
 
 def _candidate_model_scores(fitted_model, test_set, config):
@@ -2435,6 +2479,13 @@ def _align_score_columns(probabilities, score_classes, class_order):
     return aligned
 
 
+def _without_log_pool_suffix(score_normalization):
+    score_normalization = str(score_normalization).strip()
+    if score_normalization.endswith(LOG_POOL_SUFFIX):
+        return score_normalization.removesuffix(LOG_POOL_SUFFIX)
+    return score_normalization
+
+
 def _without_test_prior_balance_suffix(score_normalization):
     score_normalization = str(score_normalization).strip()
     if score_normalization.endswith("_test_prior_balance"):
@@ -2480,7 +2531,7 @@ def _inner_confusion_correction_mode(score_normalization):
 
 def _base_ensemble_score_normalization(score_normalization):
     score_normalization = _normalize_ensemble_score_normalization(score_normalization)
-    inner_mode = _without_balanced_quota_suffix(score_normalization)
+    inner_mode = _without_log_pool_suffix(_without_balanced_quota_suffix(score_normalization))
     return (
         INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(inner_mode)
         or INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(inner_mode)
@@ -3159,6 +3210,7 @@ def _add_ensemble_output_fields(
     row["selection_ensemble_weighting"] = _normalize_selection_ensemble_weighting(ensemble_weighting)
     row["selection_ensemble_temperature"] = float(_normalize_selection_ensemble_temperature(ensemble_temperature))
     row["ensemble_score_normalization"] = _normalize_ensemble_score_normalization(ensemble_score_normalization)
+    row["ensemble_pooling"] = "log_pool" if _ensemble_log_pool_mode(ensemble_score_normalization) is not None else "arithmetic_mean"
     row["ensemble_candidate_indices"] = _format_sequence(candidate_indices)
     row["ensemble_weights"] = _format_float_mapping(zip(candidate_indices, weights))
     row["ensemble_classifiers"] = _format_sequence(config.classifier for config in configs)

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -119,6 +119,11 @@ CONFUSION_CALIBRATION_BLEND_GRID = tuple(
     float(value) for value in np.linspace(0.0, 1.0, 11)
 )
 CONFUSION_CALIBRATION_MARGIN_QUANTILES = (0.10, 0.25, 0.50, 0.75, 0.90, 1.0)
+INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES = {
+    "rank_softmax_t1_25": 1.25,
+    "rank_softmax_t1_5": 1.50,
+    "rank_softmax_t1_75": 1.75,
+}
 
 _impl = None
 _BaseConfig = None
@@ -194,6 +199,7 @@ def install(impl) -> None:
     impl.DEFAULT_SENSOR_DCT_COEFFICIENTS = DEFAULT_SENSOR_DCT_COEFFICIENTS
     impl.FEATURE_MODES = tuple(dict.fromkeys((*impl.FEATURE_MODES, *EXTENDED_FEATURE_MODES)))
     impl.CrossSubjectStimulusConfig = NextCrossSubjectStimulusConfig
+    _install_intermediate_rank_softmax_temperatures(impl)
     _install_soft_inner_confusion_score_normalizations(impl)
 
     impl._normalize_feature_mode = _normalize_feature_mode
@@ -217,6 +223,20 @@ def install(impl) -> None:
     impl._rank_nested_candidates = _rank_nested_candidates
     impl.CROSS_SUBJECT_PREDICTION_GROUP_COLUMNS = _prediction_group_columns(impl.CROSS_SUBJECT_PREDICTION_GROUP_COLUMNS)
     impl._next_methods_installed = True
+
+
+def _install_intermediate_rank_softmax_temperatures(impl) -> None:
+    """Expose rank-softmax temperatures between the legacy t=1/t=2/t=3 modes."""
+
+    impl.RANK_SOFTMAX_TEMPERATURES.update(INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES)
+    impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
+        dict.fromkeys(
+            (
+                *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+                *INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES,
+            )
+        )
+    )
 
 
 def _install_soft_inner_confusion_score_normalizations(impl) -> None:

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -826,6 +826,58 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(cross_subject._inner_confusion_correction_mode(mode), mode)  # pylint: disable=protected-access
         self.assertEqual(cross_subject._inner_confusion_correction_mode(quota_mode), mode)  # pylint: disable=protected-access
 
+    def test_log_pool_score_normalization_uses_geometric_probability_pool(self):
+        mode = "rank_softmax_log_pool"
+        self.assertEqual(cross_subject._normalize_ensemble_score_normalization(mode), mode)  # pylint: disable=protected-access
+        self.assertEqual(cross_subject._base_ensemble_score_normalization(mode), "rank_softmax")  # pylint: disable=protected-access
+
+        probability_matrices = (
+            np.asarray([[0.90, 0.05, 0.05]], dtype=float),
+            np.asarray([[0.05, 0.70, 0.25]], dtype=float),
+            np.asarray([[0.05, 0.65, 0.30]], dtype=float),
+        )
+        weights = np.full(3, 1.0 / 3.0, dtype=float)
+
+        arithmetic = cross_subject._pool_ensemble_probability_matrices(  # pylint: disable=protected-access
+            probability_matrices,
+            weights,
+            "rank_softmax",
+        )
+        log_pool = cross_subject._pool_ensemble_probability_matrices(  # pylint: disable=protected-access
+            probability_matrices,
+            weights,
+            mode,
+        )
+
+        np.testing.assert_allclose(np.sum(log_pool, axis=1), np.asarray([1.0]))
+        self.assertGreater(log_pool[0, 1] - log_pool[0, 0], arithmetic[0, 1] - arithmetic[0, 0])
+
+    def test_intermediate_rank_softmax_temperatures_are_supported(self):
+        scores = np.asarray([[3.0, 2.0, 1.0]], dtype=float)
+        modes = (
+            "rank_softmax",
+            "rank_softmax_t1_25",
+            "rank_softmax_t1_5",
+            "rank_softmax_t1_75",
+            "rank_softmax_t2",
+        )
+
+        top_class_probabilities = []
+        for mode in modes:
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    cross_subject._normalize_ensemble_score_normalization(mode),
+                    mode,
+                )  # pylint: disable=protected-access
+                probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+                    scores,
+                    score_normalization=mode,
+                )
+                self.assertAlmostEqual(float(np.sum(probabilities)), 1.0)
+                top_class_probabilities.append(float(probabilities[0, 0]))
+
+        self.assertEqual(top_class_probabilities, sorted(top_class_probabilities, reverse=True))
+
     def test_guarded_balanced_quota_preserves_high_margin_argmax_trials(self):
         probabilities = np.asarray(
             [


### PR DESCRIPTION
## Summary
- add log-pool ensemble score normalization modes
- add intermediate rank-softmax temperature options
- register the new workflow matrix bundles and coverage

## Validation
- git diff --check
- python -m py_compile src/pymegdec/_stimulus_cross_subject_legacy.py src/pymegdec/_stimulus_cross_subject_next.py tests/test_stimulus_cross_subject.py

Tests were not run, per request.