### PR TITLE
Add temporal pyramid and Borda workflow features

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -41,6 +41,7 @@ on:
           - windowed_logreg_lean_ranksoft_t2
           - windowed_logreg_lean_ranksoft_t3
           - windowed_logreg_lean_rankborda
+          - windowed_logreg_lean_top3_borda
           - windowed_logreg_lean_rankaware_top2vote
           - windowed_logreg_lean_rankaware_top3vote
           - windowed_logreg_lean_rankaware_top2vote_inner_prior
@@ -49,6 +50,7 @@ on:
           - windowed_logreg_175_guarded_quota
           - windowed_logreg_175_ranksoftmax_t2
           - windowed_logreg_175_margin_blend
+          - windowed_logreg_175_top3_borda
           - windowed_logreg_175_predbalance
           - windowed_logreg_175_finetune
           - windowed_logreg_175_balanced_lcb
@@ -87,6 +89,8 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w150_ranksoft_t1_5_margin_confusion_guarded
+          - windowed_logreg_175_w150_temporal_pyramid_features
           - windowed_logreg_175_w150_inner_prior
           - windowed_logreg_175_w150_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_soft_guarded_inner_prior_confusion
@@ -149,6 +153,8 @@ on:
           - rank_top2_vote
           - rank_top3_vote
           - rank_z_blend
+          - rank_top2_borda
+          - rank_top3_borda
           - rank_margin_blend
           - row_z_softmax_log_pool
           - rank_softmax_log_pool
@@ -568,6 +574,21 @@ jobs:
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_lean_top3_borda": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_borda",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_lean_rankaware_top2vote": {
                   "window_centers": "0.175,0.200",
                   "feature_modes": "sensor_flat",
@@ -682,6 +703,21 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_margin_blend",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_top3_borda": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_borda",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_finetune": {
@@ -1411,6 +1447,37 @@ jobs:
                   "window_centers": "0.175",
                   "window_size": "0.150",
                   "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_ranksoft_t1_5_margin_confusion_guarded": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t1_5_inner_confusion_margin_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_temporal_pyramid_features": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_time_pyramid,sensor_flat_time_pyramid_logpower",
                   "normalizations": "subject_baseline_whiten",
                   "alignments": "none",
                   "classifiers": "multinomial-logistic,multinomial-logistic-weighted",

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -74,6 +74,8 @@ DEFAULT_SENSOR_DCT_COEFFICIENTS = 8
 BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",
     "sensor_flat_delta",
+    "sensor_flat_time_pyramid",
+    "sensor_flat_time_pyramid_logpower",
     "sensor_flat_time_pyramid_delta",
     "sensor_dct",
     "sensor_time_pyramid",
@@ -86,6 +88,8 @@ EXTENDED_FEATURE_MODES = (
     "sensor_mean_logpower",
     "sensor_flat_logpower",
     "sensor_flat_delta",
+    "sensor_flat_time_pyramid",
+    "sensor_flat_time_pyramid_logpower",
     "sensor_flat_time_pyramid_delta",
     "sensor_dct",
     "sensor_bandpower",
@@ -126,6 +130,25 @@ INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES = {
     "rank_softmax_t1_5": 1.50,
     "rank_softmax_t1_75": 1.75,
 }
+INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_BASES = {
+    f"{mode}_inner_confusion_soft": mode
+    for mode in INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES
+}
+INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_MARGIN_BASES = {
+    f"{mode}_inner_confusion_margin_soft": mode
+    for mode in INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES
+}
+INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_CONFUSION_BASES = {
+    f"{mode}_guarded": base
+    for mode, base in {
+        **INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_BASES,
+        **INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_MARGIN_BASES,
+    }.items()
+}
+TOPK_BORDA_SCORE_NORMALIZATIONS = {
+    "rank_top2_borda": 2,
+    "rank_top3_borda": 3,
+}
 
 _impl = None
 _BaseConfig = None
@@ -138,6 +161,7 @@ _previous_normalize_features = None
 _previous_normalized_subject_features = None
 _previous_fit_outer_fold_model = None
 _previous_score_outer_fold_model = None
+_previous_class_score_probabilities = None
 _previous_candidate_model_scores = None
 _previous_align_training_features_by_subject = None
 _previous_align_test_features_by_subject = None
@@ -157,7 +181,7 @@ def install(impl) -> None:
     global _previous_extract_window_features, _previous_baseline_feature_statistics, _previous_normalize_features, _previous_normalized_subject_features, _previous_fit_outer_fold_model
     global _previous_score_outer_fold_model, _previous_candidate_model_scores, _previous_align_training_features_by_subject
     global _previous_align_test_features_by_subject, _previous_prediction_rows, _previous_summarize_smoke
-    global _previous_summarize_nested, _previous_rank_nested_candidates
+    global _previous_summarize_nested, _previous_rank_nested_candidates, _previous_class_score_probabilities
 
     if getattr(impl, "_next_methods_installed", False):
         return
@@ -173,6 +197,7 @@ def install(impl) -> None:
     _previous_normalized_subject_features = impl._normalized_subject_features
     _previous_fit_outer_fold_model = impl._fit_outer_fold_model
     _previous_score_outer_fold_model = impl._score_outer_fold_model
+    _previous_class_score_probabilities = impl._class_score_probabilities
     _previous_candidate_model_scores = impl._candidate_model_scores
     _previous_align_training_features_by_subject = impl._align_training_features_by_subject
     _previous_align_test_features_by_subject = impl._align_test_features_by_subject
@@ -203,6 +228,7 @@ def install(impl) -> None:
     impl.CrossSubjectStimulusConfig = NextCrossSubjectStimulusConfig
     _install_intermediate_rank_softmax_temperatures(impl)
     _install_soft_inner_confusion_score_normalizations(impl)
+    _install_topk_borda_score_normalizations(impl)
 
     impl._normalize_feature_mode = _normalize_feature_mode
     impl._normalized_config = _normalized_config
@@ -213,6 +239,7 @@ def install(impl) -> None:
     impl._normalized_subject_features = _normalized_subject_features
     impl._fit_outer_fold_model = _fit_outer_fold_model
     impl._score_outer_fold_model = _score_outer_fold_model
+    impl._class_score_probabilities = _class_score_probabilities
     impl._candidate_model_scores = _candidate_model_scores
     impl._apply_score_calibration = _apply_score_calibration
     impl._score_calibration_base_mode = _score_calibration_base_mode
@@ -250,17 +277,92 @@ def _install_soft_inner_confusion_score_normalizations(impl) -> None:
     impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
         SOFT_GUARDED_INNER_CONFUSION_SCORE_NORMALIZATION_BASES
     )
+    impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_BASES
+    )
+    impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_MARGIN_BASES
+    )
+    impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_CONFUSION_BASES
+    )
     impl.INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
         SOFT_INNER_BALANCED_CONFUSION_SCORE_NORMALIZATION_BASES
     )
     extra_modes = (
         *tuple(SOFT_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
         *tuple(SOFT_GUARDED_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
+        *tuple(INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_BASES),
+        *tuple(INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_MARGIN_BASES),
+        *tuple(INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_CONFUSION_BASES),
         *tuple(SOFT_INNER_BALANCED_CONFUSION_SCORE_NORMALIZATION_BASES),
     )
     impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
         dict.fromkeys((*impl.ENSEMBLE_SCORE_NORMALIZATION_MODES, *extra_modes))
     )
+
+
+def _install_topk_borda_score_normalizations(impl) -> None:
+    """Expose truncated-Borda rank pooling for source-only score ensembles."""
+
+    impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
+        dict.fromkeys(
+            (
+                *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+                *TOPK_BORDA_SCORE_NORMALIZATIONS,
+            )
+        )
+    )
+
+
+def _class_score_probabilities(scores, *, score_normalization=None):
+    """Return class probabilities, adding top-k Borda rank normalizers."""
+
+    if score_normalization is None:
+        score_normalization = _impl.DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
+    base_mode = _impl._base_ensemble_score_normalization(score_normalization)
+    top_k = TOPK_BORDA_SCORE_NORMALIZATIONS.get(base_mode)
+    if top_k is not None:
+        return _rank_topk_borda_probabilities(scores, top_k=top_k)
+    return _previous_class_score_probabilities(
+        scores,
+        score_normalization=score_normalization,
+    )
+
+
+def _rank_topk_borda_probabilities(scores, *, top_k):
+    """Convert class scores to a tapered top-k Borda distribution."""
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError(
+            "Nested score ensembling requires a non-empty two-dimensional "
+            "class-score matrix."
+        )
+    top_k = int(top_k)
+    if top_k < 1:
+        raise ValueError("top_k must be at least one.")
+
+    probabilities = np.empty_like(scores, dtype=float)
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        n_finite = int(np.sum(finite))
+        if n_finite == 0:
+            probabilities[row_index] = np.full(
+                row.shape[0],
+                1.0 / row.shape[0],
+                dtype=float,
+            )
+            continue
+        k = min(top_k, n_finite)
+        ordered_columns = np.argsort(
+            -np.where(finite, row, -np.inf),
+            kind="mergesort",
+        )[:k]
+        weights = np.zeros(row.shape[0], dtype=float)
+        weights[ordered_columns] = np.arange(k, 0, -1, dtype=float)
+        probabilities[row_index] = weights / np.sum(weights)
+    return probabilities
 
 
 def _prediction_group_columns(columns):
@@ -409,6 +511,10 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_flat_logpower_feature(signal)
         elif feature_mode == "sensor_flat_delta":
             feature = _sensor_flat_delta_feature(signal)
+        elif feature_mode == "sensor_flat_time_pyramid":
+            feature = _sensor_flat_time_pyramid_feature(signal)
+        elif feature_mode == "sensor_flat_time_pyramid_logpower":
+            feature = _sensor_flat_time_pyramid_logpower_feature(signal)
         elif feature_mode == "sensor_flat_time_pyramid_delta":
             feature = _sensor_flat_time_pyramid_delta_feature(signal)
         elif feature_mode == "sensor_dct":
@@ -460,6 +566,26 @@ def _sensor_flat_delta_feature(window_signal):
         return flat
     deltas = np.diff(signal, axis=1).reshape(-1, order="F")
     return np.concatenate((flat, deltas))
+
+
+def _sensor_flat_time_pyramid_feature(window_signal):
+    """Return raw evoked samples plus compact multiscale temporal summaries."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    flat = signal.reshape(-1, order="F")
+    return np.concatenate((flat, _sensor_time_pyramid_feature(signal)))
+
+
+def _sensor_flat_time_pyramid_logpower_feature(window_signal):
+    """Return raw evoked samples, temporal-pyramid summaries, and log-power."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    return np.concatenate(
+        (
+            _sensor_flat_time_pyramid_feature(signal),
+            _sensor_logpower_feature(signal),
+        )
+    )
 
 
 def _sensor_flat_time_pyramid_delta_feature(window_signal):
@@ -604,6 +730,22 @@ def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
         return _sensor_flat_logpower_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_delta":
         return _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial_indices)
+    if feature_mode == "sensor_flat_time_pyramid":
+        return _sensor_flat_time_pyramid_baseline_statistics(
+            data,
+            config,
+            n_window_samples,
+            trial_indices,
+            include_logpower=False,
+        )
+    if feature_mode == "sensor_flat_time_pyramid_logpower":
+        return _sensor_flat_time_pyramid_baseline_statistics(
+            data,
+            config,
+            n_window_samples,
+            trial_indices,
+            include_logpower=True,
+        )
     if feature_mode == "sensor_flat_time_pyramid_delta":
         return _sensor_flat_time_pyramid_delta_baseline_statistics(
             data,
@@ -679,6 +821,49 @@ def _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial
     delta_std_tiled = np.tile(delta_std, n_delta_samples)
     mean = np.concatenate((flat_mean, delta_mean_tiled))[None, :]
     std = np.concatenate((flat_std, delta_std_tiled))[None, :]
+    return mean, _impl._nonzero_std(std), n_baseline_samples
+
+
+def _sensor_flat_time_pyramid_baseline_statistics(
+    data,
+    config,
+    n_window_samples,
+    trial_indices,
+    *,
+    include_logpower,
+):
+    """Baseline statistics for raw samples plus temporal-pyramid blocks."""
+
+    channel_mean, channel_std, n_baseline_samples = _impl._baseline_channel_statistics(
+        data,
+        config.baseline_window,
+        trial_indices,
+    )
+    pyramid_features, _ = _extract_window_features(
+        data,
+        config.baseline_window,
+        feature_mode="sensor_time_pyramid",
+        trial_indices=trial_indices,
+    )
+    mean_pieces = [
+        np.tile(channel_mean, int(n_window_samples)),
+        np.mean(pyramid_features, axis=0),
+    ]
+    std_pieces = [
+        np.tile(channel_std, int(n_window_samples)),
+        np.std(pyramid_features, axis=0),
+    ]
+    if include_logpower:
+        logpower_features, _ = _extract_window_features(
+            data,
+            config.baseline_window,
+            feature_mode="sensor_logpower",
+            trial_indices=trial_indices,
+        )
+        mean_pieces.append(np.mean(logpower_features, axis=0))
+        std_pieces.append(np.std(logpower_features, axis=0))
+    mean = np.concatenate(mean_pieces)[None, :]
+    std = np.concatenate(std_pieces)[None, :]
     return mean, _impl._nonzero_std(std), n_baseline_samples
 
 

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -90,11 +90,56 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_allclose(adjusted[1], probabilities[1])
         self.assertAlmostEqual(metadata["margin_threshold"], 0.46)
 
+    def test_intermediate_rank_softmax_inner_confusion_margin_modes_are_exported(self):
+        mode = "rank_softmax_t1_5_inner_confusion_margin_soft_guarded"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_softmax_t1_5",
+        )
+
+        metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            [{"selected_inner_true_predicted_label_pair_counts": "1001:3;1002:2;2002:4"}],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertTrue(metadata["guarded"])
+        self.assertTrue(metadata["margin_gated"])
+        self.assertEqual(metadata["margin_quantile"], 0.5)
+        self.assertLess(metadata["blend"], 1.0)
+
+    def test_topk_borda_score_normalizations_are_exported(self):
+        self.assertIn("rank_top2_borda", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertIn("rank_top3_borda", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+
+        scores = np.asarray(
+            [
+                [4.0, 3.0, 2.0, 1.0],
+                [0.0, 5.0, 4.0, 3.0],
+            ],
+            dtype=float,
+        )
+
+        probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_top3_borda",
+        )
+
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(2))
+        np.testing.assert_allclose(probabilities[0], np.asarray([3.0, 2.0, 1.0, 0.0]) / 6.0)
+        np.testing.assert_allclose(probabilities[1], np.asarray([0.0, 3.0, 2.0, 1.0]) / 6.0)
+
     def test_extended_feature_modes_are_exported(self):
         self.assertIn("sensor_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_mean_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_delta", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_flat_time_pyramid", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_flat_time_pyramid_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_time_pyramid_delta", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_bandpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_cov_tangent", cross_subject.FEATURE_MODES)
@@ -202,6 +247,37 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(feature_set.baseline_feature_std.shape, (1, 10))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
+    def test_sensor_flat_time_pyramid_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 1.0, 3.0, 5.0, 7.0], [0.0, 2.0, 4.0, 6.0, 8.0]],
+            [[0.0, 2.0, 4.0, 6.0, 8.0], [0.0, 1.0, 3.0, 5.0, 7.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.3,
+            feature_mode="sensor_flat_time_pyramid",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 22))
+        np.testing.assert_allclose(
+            feature_set.features[0],
+            np.asarray([
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+                4.0, 5.0,
+                2.0, 3.0, 6.0, 7.0,
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+            ]),
+        )
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
     def test_sensor_flat_time_pyramid_delta_feature(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
         trials = [
@@ -251,6 +327,31 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(feature_set.features.shape, (2, 26))
         self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 26))
         self.assertEqual(feature_set.baseline_feature_std.shape, (1, 26))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_time_pyramid_logpower_baseline_whiten_allows_different_baseline_duration(self):
+        time = np.asarray([-0.3, -0.2, -0.1, 0.1, 0.2], dtype=float)
+        trials = [
+            [[0.1, 0.2, 0.3, 1.0, 3.0], [0.4, 0.5, 0.6, 2.0, 6.0]],
+            [[0.2, 0.3, 0.4, 2.0, 4.0], [0.5, 0.6, 0.7, 4.0, 8.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            baseline_window=(-0.3, -0.1),
+            feature_mode="sensor_flat_time_pyramid_logpower",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 20))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 20))
+        self.assertEqual(feature_set.baseline_feature_std.shape, (1, 20))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
     def test_sensor_flat_logpower_baseline_whiten_allows_different_baseline_duration(self):


### PR DESCRIPTION
## Summary
- add raw temporal-pyramid feature modes and baseline whitening stats
- expose top-k Borda score normalizations and intermediate rank-softmax confusion variants
- add workflow matrix entries for the new feature and ranking variants

## Verification
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject_next.py`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check`

Test suites were not run per request.