### PR TITLE
Add inner confusion complement selection

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -28,6 +28,7 @@ on:
         options:
           - windowed_logreg_lean
           - windowed_logreg_lean_no_diversity
+          - windowed_logreg_lean_confusion_complement
           - windowed_logreg_lean_log_pool
           - windowed_logreg_lean_margin_blend
           - windowed_logreg_lean_balanced_lcb
@@ -98,6 +99,9 @@ on:
           - windowed_logreg_175_w150_ranksoft_t1_25
           - windowed_logreg_175_w150_ranksoft_t1_5
           - windowed_logreg_175_w150_ranksoft_t1_75
+          - windowed_logreg_175_w150_ranksoft_t1_25_soft_guarded_inner_confusion
+          - windowed_logreg_175_w150_ranksoft_t1_5_soft_guarded_inner_confusion
+          - windowed_logreg_175_w150_ranksoft_t1_75_soft_guarded_inner_confusion
           - windowed_logreg_175_w125_w150
           - windowed_logreg_w150_size_center_grid
           - windowed_logreg_175_temporal_delta_features
@@ -132,6 +136,7 @@ on:
           - window
           - classifier
           - window_classifier
+          - inner_confusion_complement
           - window_feature_classifier_score_calibration
           - full_config
       selection_ensemble_score_normalization_override:
@@ -213,6 +218,9 @@ on:
           - rank_z_blend_inner_confusion
           - rank_z_blend_inner_confusion_soft
           - rank_softmax_inner_confusion_soft
+          - rank_softmax_t1_25_inner_confusion_soft
+          - rank_softmax_t1_5_inner_confusion_soft
+          - rank_softmax_t1_75_inner_confusion_soft
           - rank_softmax_t2_inner_confusion_soft
           - rank_softmax_inner_confusion_margin_soft
           - rank_softmax_t2_inner_confusion_margin_soft
@@ -228,6 +236,9 @@ on:
           - rank_top2_vote_inner_confusion_soft
           - rank_top3_vote_inner_confusion_soft
           - rank_softmax_inner_confusion_soft_guarded
+          - rank_softmax_t1_25_inner_confusion_soft_guarded
+          - rank_softmax_t1_5_inner_confusion_soft_guarded
+          - rank_softmax_t1_75_inner_confusion_soft_guarded
           - rank_softmax_t2_inner_confusion_soft_guarded
           - rank_softmax_t3_inner_confusion_soft_guarded
           - rank_reciprocal_inner_confusion_soft_guarded
@@ -378,6 +389,20 @@ jobs:
                   "components_pca_values": "64,128",
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_confusion_complement": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "inner_confusion_complement",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
@@ -1592,6 +1617,54 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_t1_75",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_ranksoft_t1_25_soft_guarded_inner_confusion": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t1_25_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_ranksoft_t1_5_soft_guarded_inner_confusion": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t1_5_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_ranksoft_t1_75_soft_guarded_inner_confusion": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t1_75_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_w125_w150": {

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -271,6 +271,7 @@ INNER_CONFUSION_CORRECTION_IDENTITY_BLEND = 0.20
 INNER_CONFUSION_CORRECTION_SOFT_BLEND = 0.35
 INNER_CONFUSION_CORRECTION_MARGIN_QUANTILE = 0.50
 INNER_CONFUSION_CORRECTION_GUARDED_POWER = 0.5
+INNER_CONFUSION_COMPLEMENTARITY_PENALTY = 0.0025
 LOG_POOL_SUFFIX = "_log_pool"
 ENSEMBLE_LOG_POOL_EPSILON = 1e-12
 BALANCED_QUOTA_SUFFIX = "_balanced_quota"
@@ -297,6 +298,7 @@ SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "window_feature_classifier_sample_weighting_score_calibration",
     "window_feature_classifier_sample_weighting_score_calibration_pca",
     "window_feature_classifier_param_sample_weighting_score_calibration_pca",
+    "inner_confusion_complement",
     "full_config",
 )
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
@@ -1563,6 +1565,10 @@ def _select_diverse_nested_rows(ranked_rows, *, requested_size, candidate_config
     diversity = _normalize_selection_ensemble_diversity(diversity)
     if diversity == "none":
         return tuple(ranked_rows[:requested_size])
+    if diversity == "inner_confusion_complement":
+        return _select_inner_confusion_complement_rows(
+            ranked_rows, requested_size=requested_size
+        )
 
     selected = []
     selected_indices = set()
@@ -1585,6 +1591,90 @@ def _select_diverse_nested_rows(ranked_rows, *, requested_size, candidate_config
         if len(selected) == requested_size:
             break
     return tuple(selected)
+
+
+def _select_inner_confusion_complement_rows(ranked_rows, *, requested_size):
+    """Greedily select high-scoring candidates with complementary inner errors."""
+
+    ranked_rows = tuple(ranked_rows)
+    requested_size = min(
+        _normalize_selection_ensemble_size(requested_size), len(ranked_rows)
+    )
+    if requested_size <= 1 or not ranked_rows:
+        return tuple(ranked_rows[:requested_size])
+
+    selected = [ranked_rows[0]]
+    selected_indices = {int(ranked_rows[0]["selected_candidate_index"])}
+    while len(selected) < requested_size:
+        best_row = None
+        best_key = None
+        for row in ranked_rows:
+            candidate_index = int(row["selected_candidate_index"])
+            if candidate_index in selected_indices:
+                continue
+            max_similarity = max(
+                _inner_confusion_error_similarity(row, selected_row)
+                for selected_row in selected
+            )
+            adjusted_score = _inner_selection_score_for_complement(row) - (
+                float(INNER_CONFUSION_COMPLEMENTARITY_PENALTY) * max_similarity
+            )
+            key = (adjusted_score, *_nested_selection_sort_key(row))
+            if best_key is None or key > best_key:
+                best_key = key
+                best_row = row
+        if best_row is None:
+            break
+        selected.append(best_row)
+        selected_indices.add(int(best_row["selected_candidate_index"]))
+    return tuple(selected)
+
+
+def _inner_selection_score_for_complement(row):
+    return _finite_sort_value(
+        row.get(
+            "selected_inner_selection_ranking_score",
+            row.get("selected_inner_selection_score_mean", np.nan),
+        )
+    )
+
+
+def _inner_confusion_error_similarity(left_row, right_row):
+    labels = _inner_confusion_labels(left_row, right_row)
+    if not labels:
+        return 0.0
+    left = _inner_confusion_error_vector(left_row, labels)
+    right = _inner_confusion_error_vector(right_row, labels)
+    left_norm = float(np.linalg.norm(left))
+    right_norm = float(np.linalg.norm(right))
+    if left_norm <= 1e-12 or right_norm <= 1e-12:
+        return 0.0
+    return float(np.clip(np.dot(left, right) / (left_norm * right_norm), 0.0, 1.0))
+
+
+def _inner_confusion_labels(*rows):
+    labels = set()
+    for row in rows:
+        counter = _parse_confusion_counter(row.get("selected_inner_confusion_counts", ""))
+        for true_label, predicted_label in counter:
+            labels.add(int(true_label))
+            labels.add(int(predicted_label))
+    return tuple(sorted(labels))
+
+
+def _inner_confusion_error_vector(row, labels):
+    matrix = _confusion_counter_matrix(
+        _parse_confusion_counter(row.get("selected_inner_confusion_counts", "")),
+        labels,
+    )
+    if matrix.size == 0:
+        return np.zeros(0, dtype=float)
+    matrix = np.asarray(matrix, dtype=float)
+    np.fill_diagonal(matrix, 0.0)
+    total = float(np.sum(matrix))
+    if total <= 0.0 or not np.isfinite(total):
+        return np.zeros(matrix.size, dtype=float)
+    return (matrix / total).ravel()
 
 
 def _ensemble_diversity_key(config, diversity):
@@ -1632,6 +1722,8 @@ def _ensemble_diversity_key(config, diversity):
             f"score_calibration={getattr(config, 'score_calibration', 'none')},"
             f"pca={config.components_pca}"
         )
+    if diversity == "inner_confusion_complement":
+        return "inner_confusion_complement"
     return (
         f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
         f"feature={config.feature_mode},norm={config.normalization},alignment={config.alignment},"

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -105,6 +105,9 @@ SCORE_CALIBRATION_PROBABILITY_MAP_L2 = 1e-2
 SCORE_CALIBRATION_PROBABILITY_MAP_IDENTITY_BLEND = 0.20
 SOFT_INNER_CONFUSION_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_inner_confusion_soft": "rank_softmax",
+    "rank_softmax_t1_25_inner_confusion_soft": "rank_softmax_t1_25",
+    "rank_softmax_t1_5_inner_confusion_soft": "rank_softmax_t1_5",
+    "rank_softmax_t1_75_inner_confusion_soft": "rank_softmax_t1_75",
     "rank_softmax_t2_inner_confusion_soft": "rank_softmax_t2",
     "rank_softmax_t3_inner_confusion_soft": "rank_softmax_t3",
     "rank_reciprocal_inner_confusion_soft": "rank_reciprocal",

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -240,6 +240,66 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertEqual(feature_set.baseline_whitening_matrix.shape, (2, 2))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
+    def test_inner_confusion_complement_diversity_prefers_distinct_errors(self):
+        configs = make_cross_subject_candidate_configs(
+            window_centers=(0.175,),
+            window_size=0.1,
+            feature_modes=("sensor_flat",),
+            normalizations=("subject_baseline_whiten",),
+            alignments=("none",),
+            classifiers=("multinomial-logistic",),
+            classifier_params=(0.3, 1.0, 2.0),
+            components_pca_values=(128,),
+            chance_classes=4,
+        )
+        ranked_rows = [
+            {
+                "selected_candidate_index": 1,
+                "selected_inner_selection_ranking_score": 0.1200,
+                "selected_inner_selection_score_mean": 0.1200,
+                "selected_inner_balanced_accuracy_mean": 0.1200,
+                "selected_inner_top2_accuracy_mean": 0.2200,
+                "selected_inner_top3_accuracy_mean": 0.3200,
+                "selected_inner_mean_true_label_rank_mean": 2.0,
+                "selected_inner_accuracy_mean": 0.1200,
+                "selected_inner_confusion_counts": "1>2:10;2>1:10",
+            },
+            {
+                "selected_candidate_index": 2,
+                "selected_inner_selection_ranking_score": 0.1190,
+                "selected_inner_selection_score_mean": 0.1190,
+                "selected_inner_balanced_accuracy_mean": 0.1190,
+                "selected_inner_top2_accuracy_mean": 0.2190,
+                "selected_inner_top3_accuracy_mean": 0.3190,
+                "selected_inner_mean_true_label_rank_mean": 2.1,
+                "selected_inner_accuracy_mean": 0.1190,
+                "selected_inner_confusion_counts": "1>2:10;2>1:10",
+            },
+            {
+                "selected_candidate_index": 3,
+                "selected_inner_selection_ranking_score": 0.1180,
+                "selected_inner_selection_score_mean": 0.1180,
+                "selected_inner_balanced_accuracy_mean": 0.1180,
+                "selected_inner_top2_accuracy_mean": 0.2180,
+                "selected_inner_top3_accuracy_mean": 0.3180,
+                "selected_inner_mean_true_label_rank_mean": 2.2,
+                "selected_inner_accuracy_mean": 0.1180,
+                "selected_inner_confusion_counts": "3>4:10;4>3:10",
+            },
+        ]
+
+        selected = cross_subject._select_diverse_nested_rows(  # pylint: disable=protected-access
+            ranked_rows,
+            requested_size=2,
+            candidate_configs=configs,
+            diversity="inner_confusion_complement",
+        )
+
+        self.assertEqual(
+            [row["selected_candidate_index"] for row in selected],
+            [1, 3],
+        )
+
     def test_sensor_dct_keeps_low_order_temporal_coefficients(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3, 0.4], dtype=float)
         trials = [
@@ -924,6 +984,9 @@ class TestStimulusCrossSubject(unittest.TestCase):
     def test_soft_inner_confusion_score_normalizations_are_supported(self):
         expected_bases = {
             "rank_softmax_inner_confusion_soft": "rank_softmax",
+            "rank_softmax_t1_25_inner_confusion_soft": "rank_softmax_t1_25",
+            "rank_softmax_t1_5_inner_confusion_soft": "rank_softmax_t1_5",
+            "rank_softmax_t1_75_inner_confusion_soft": "rank_softmax_t1_75",
             "rank_softmax_t2_inner_confusion_soft": "rank_softmax_t2",
             "rank_softmax_t3_inner_confusion_soft": "rank_softmax_t3",
             "rank_reciprocal_inner_confusion_soft": "rank_reciprocal",
@@ -954,6 +1017,9 @@ class TestStimulusCrossSubject(unittest.TestCase):
     def test_soft_guarded_inner_confusion_score_normalizations_are_supported(self):
         expected_bases = {
             "rank_softmax_inner_confusion_soft_guarded": "rank_softmax",
+            "rank_softmax_t1_25_inner_confusion_soft_guarded": "rank_softmax_t1_25",
+            "rank_softmax_t1_5_inner_confusion_soft_guarded": "rank_softmax_t1_5",
+            "rank_softmax_t1_75_inner_confusion_soft_guarded": "rank_softmax_t1_75",
             "rank_softmax_t2_inner_confusion_soft_guarded": "rank_softmax_t2",
             "rank_softmax_t3_inner_confusion_soft_guarded": "rank_softmax_t3",
             "rank_reciprocal_inner_confusion_soft_guarded": "rank_reciprocal",


### PR DESCRIPTION
## Summary
- add inner-confusion complement diversity selection for nested score ensembles
- expose intermediate rank-softmax inner-confusion soft modes
- add workflow matrix entries for complement selection and intermediate soft guarded confusion bundles

## Verification
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject.py`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check`

Test suites were not run per request.