### PR TITLE
Add intermediate rank softmax workflow variants

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -95,7 +95,10 @@ on:
           - windowed_logreg_175_w150_inner_prior
           - windowed_logreg_175_w150_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_soft_guarded_inner_prior_confusion
+          - windowed_logreg_175_w150_t15_soft_guarded_inner_prior_confusion
           - windowed_logreg_175_w150_rank_consensus
+          - windowed_logreg_175_w150_ranksoft_t0_5
+          - windowed_logreg_175_w150_ranksoft_t0_75
           - windowed_logreg_175_w150_ranksoft_t1_25
           - windowed_logreg_175_w150_ranksoft_t1_5
           - windowed_logreg_175_w150_ranksoft_t1_75
@@ -148,6 +151,8 @@ on:
           - bundle-default
           - row_z_softmax
           - rank_softmax
+          - rank_softmax_t0_5
+          - rank_softmax_t0_75
           - rank_softmax_t1_25
           - rank_softmax_t1_5
           - rank_softmax_t1_75
@@ -197,6 +202,9 @@ on:
           - rank_borda_inner_confusion_balanced_quota
           - rank_z_blend_inner_confusion_balanced_quota
           - rank_softmax_inner_balanced
+          - rank_softmax_t1_25_inner_balanced
+          - rank_softmax_t1_5_inner_balanced
+          - rank_softmax_t1_75_inner_balanced
           - rank_softmax_t2_inner_balanced
           - rank_softmax_t3_inner_balanced
           - rank_reciprocal_inner_balanced
@@ -247,6 +255,9 @@ on:
           - rank_top3_vote_inner_confusion_soft_guarded
           - rank_softmax_inner_balanced_confusion_soft
           - rank_softmax_inner_balanced_confusion_soft_guarded
+          - rank_softmax_t1_25_inner_balanced_confusion_soft_guarded
+          - rank_softmax_t1_5_inner_balanced_confusion_soft_guarded
+          - rank_softmax_t1_75_inner_balanced_confusion_soft_guarded
           - rank_softmax_inner_confusion_guarded
           - rank_softmax_t2_inner_confusion_guarded
           - rank_softmax_t3_inner_confusion_guarded
@@ -1559,6 +1570,22 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_t15_soft_guarded_inner_prior_confusion": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t1_5_inner_balanced_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_rank_consensus": {
                   "window_centers": "0.175",
                   "window_size": "0.150",
@@ -1571,6 +1598,36 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_consensus",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_ranksoft_t0_5": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t0_5",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_ranksoft_t0_75": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t0_75",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -129,6 +129,11 @@ CONFUSION_CALIBRATION_BLEND_GRID = tuple(
 )
 CONFUSION_CALIBRATION_MARGIN_QUANTILES = (0.10, 0.25, 0.50, 0.75, 0.90, 1.0)
 INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES = {
+    # Sub-unit temperatures make the per-candidate rank posterior more
+    # top-heavy than the legacy t=1.0 rank_softmax. This is useful for the
+    # strong 175 ms / 150 ms BUSH-MEG window where top-1 is now the bottleneck.
+    "rank_softmax_t0_5": 0.50,
+    "rank_softmax_t0_75": 0.75,
     "rank_softmax_t1_25": 1.25,
     "rank_softmax_t1_5": 1.50,
     "rank_softmax_t1_75": 1.75,
@@ -140,6 +145,18 @@ INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_BASES = {
 INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_MARGIN_BASES = {
     f"{mode}_inner_confusion_margin_soft": mode
     for mode in INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES
+}
+INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_BASES = {
+    f"{mode}_inner_balanced": mode
+    for mode in INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES
+}
+INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SOFT_BASES = {
+    f"{mode}_inner_balanced_confusion_soft": mode
+    for mode in INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES
+}
+INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_BALANCED_CONFUSION_BASES = {
+    f"{mode}_guarded": base
+    for mode, base in INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SOFT_BASES.items()
 }
 INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_CONFUSION_BASES = {
     f"{mode}_guarded": base
@@ -261,11 +278,23 @@ def _install_intermediate_rank_softmax_temperatures(impl) -> None:
     """Expose rank-softmax temperatures between the legacy t=1/t=2/t=3 modes."""
 
     impl.RANK_SOFTMAX_TEMPERATURES.update(INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES)
+    impl.INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_BASES
+    )
+    impl.INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SOFT_BASES
+    )
+    impl.INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_BALANCED_CONFUSION_BASES
+    )
     impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
         dict.fromkeys(
             (
                 *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
                 *INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES,
+                *INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_BASES,
+                *INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SOFT_BASES,
+                *INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_BALANCED_CONFUSION_BASES,
             )
         )
     )

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -90,6 +90,30 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_allclose(adjusted[1], probabilities[1])
         self.assertAlmostEqual(metadata["margin_threshold"], 0.46)
 
+    def test_subunit_rank_softmax_temperatures_are_exported(self):
+        self.assertIn("rank_softmax_t0_5", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertIn("rank_softmax_t0_75", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+
+        scores = np.asarray([[4.0, 3.0, 2.0, 1.0]], dtype=float)
+        default = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax",
+        )
+        sharp = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax_t0_75",
+        )
+        sharper = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax_t0_5",
+        )
+
+        np.testing.assert_allclose(np.sum(default, axis=1), np.ones(1))
+        np.testing.assert_allclose(np.sum(sharp, axis=1), np.ones(1))
+        np.testing.assert_allclose(np.sum(sharper, axis=1), np.ones(1))
+        self.assertGreater(sharp[0, 0], default[0, 0])
+        self.assertGreater(sharper[0, 0], sharp[0, 0])
+
     def test_intermediate_rank_softmax_inner_confusion_margin_modes_are_exported(self):
         mode = "rank_softmax_t1_5_inner_confusion_margin_soft_guarded"
 
@@ -111,6 +135,70 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertTrue(metadata["margin_gated"])
         self.assertEqual(metadata["margin_quantile"], 0.5)
         self.assertLess(metadata["blend"], 1.0)
+
+    def test_intermediate_rank_softmax_inner_prior_modes_are_exported(self):
+        mode = "rank_softmax_t1_5_inner_balanced"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_softmax_t1_5",
+        )
+
+        metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            [
+                {
+                    "selected_inner_test_label_counts": "1:8;2:8",
+                    "selected_inner_predicted_label_counts": "1:12;2:4",
+                }
+            ],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertEqual(metadata["log_adjustment"].shape, (2,))
+        self.assertGreater(metadata["log_adjustment"][1], metadata["log_adjustment"][0])
+
+    def test_intermediate_rank_softmax_inner_prior_confusion_modes_are_exported(self):
+        mode = "rank_softmax_t1_5_inner_balanced_confusion_soft_guarded"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_softmax_t1_5",
+        )
+
+        prior_metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            [
+                {
+                    "selected_inner_test_label_counts": "1:8;2:8",
+                    "selected_inner_predicted_label_counts": "1:12;2:4",
+                    "selected_inner_true_predicted_label_pair_counts": "1001:3;1002:2;2002:4",
+                }
+            ],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+        confusion_metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            [
+                {
+                    "selected_inner_test_label_counts": "1:8;2:8",
+                    "selected_inner_predicted_label_counts": "1:12;2:4",
+                    "selected_inner_true_predicted_label_pair_counts": "1001:3;1002:2;2002:4",
+                }
+            ],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+
+        self.assertEqual(prior_metadata["inner_mode"], mode)
+        self.assertEqual(confusion_metadata["inner_mode"], mode)
+        self.assertTrue(confusion_metadata["guarded"])
+        self.assertLess(confusion_metadata["blend"], 1.0)
 
     def test_topk_borda_score_normalizations_are_exported(self):
         self.assertIn("rank_top2_borda", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)


### PR DESCRIPTION
## Summary
- add sub-unit rank-softmax temperatures to the exported cross-subject normalizers
- expose intermediate rank-softmax inner-prior and guarded inner-prior/confusion variants
- add BUSH-MEG workflow bundle options for the new 175 ms / 150 ms variants

## Validation
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject_next.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check`

Tests were not run, per request.