### PR TITLE
Add smoothed sensor-flat workflow variant

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -36,6 +36,7 @@ on:
           - windowed_logreg_lean_rankaware
           - windowed_logreg_lean_rankaware_reciprocal
           - windowed_logreg_lean_rankaware_reciprocal_inner_prior
+          - windowed_logreg_lean_worstclass_lcb
           - windowed_logreg_lean_test_prior_balance
           - windowed_logreg_lean_rankaware_t2
           - windowed_logreg_lean_rankaware_t2_inner_prior
@@ -55,6 +56,7 @@ on:
           - windowed_logreg_175_predbalance
           - windowed_logreg_175_finetune
           - windowed_logreg_175_balanced_lcb
+          - windowed_logreg_175_source_anova
           - windowed_logreg_175_flat_logpower
           - windowed_logreg_175_flat_delta
           - windowed_logreg_175_log_pool
@@ -95,6 +97,7 @@ on:
           - windowed_logreg_175_w150_inner_prior
           - windowed_logreg_175_w150_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_soft_guarded_inner_prior_confusion
+          - windowed_logreg_175_w150_guarded_scorecal_sweep
           - windowed_logreg_175_w150_t15_soft_guarded_inner_prior_confusion
           - windowed_logreg_175_w150_rank_consensus
           - windowed_logreg_175_w150_ranksoft_t0_5
@@ -303,6 +306,7 @@ on:
           - balanced_top2_top3_rank_lcb
           - balanced_top2_top3_rank_prediction_balance
           - balanced_top2_top3_rank_prediction_balance_lcb
+          - balanced_worst_class_lcb
           - balanced_rank
       benchmark_preset:
         description: Screening keeps the trial cap; final-all-trials ignores it and can exceed 2h per shard.
@@ -532,6 +536,21 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_reciprocal_inner_balanced",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_worstclass_lcb": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_worst_class_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -779,6 +798,24 @@ jobs:
                   "classifier_params": "0.1,0.2,0.3,0.5,1,2,3",
                   "components_pca_values": "96,128,160,192",
                   "selection_metric": "balanced_accuracy_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_source_anova": {
+                  "window_centers": "0.175",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none",
+                  "feature_transforms": "none,source_anova_scale",
+                  "alignment_alphas": "1.0",
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
@@ -1570,6 +1607,25 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_guarded_scorecal_sweep": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_rank_bias_guarded,inner_rank_margin_confusion_blend_guarded",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_score_calibration",
+                  "selection_ensemble_score_normalization": "rank_z_blend",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_t15_soft_guarded_inner_prior_confusion": {
                   "window_centers": "0.175",
                   "window_size": "0.150",
@@ -1932,6 +1988,7 @@ jobs:
                   row.setdefault("window_sizes", "")
                   row.setdefault("sample_weightings", "none")
                   row.setdefault("score_calibrations", "none")
+                  row.setdefault("feature_transforms", "none")
                   row.setdefault("alignment_alphas", "1.0")
                   row.setdefault("selection_metric", "balanced_accuracy")
                   if diversity_override != "bundle-default":
@@ -2006,6 +2063,7 @@ jobs:
       COMPONENTS_PCA_VALUES: ${{ matrix.components_pca_values }}
       SAMPLE_WEIGHTINGS: ${{ matrix.sample_weightings }}
       SCORE_CALIBRATIONS: ${{ matrix.score_calibrations }}
+      FEATURE_TRANSFORMS: ${{ matrix.feature_transforms }}
       ALIGNMENT_ALPHAS: ${{ matrix.alignment_alphas }}
       SELECTION_ENSEMBLE_SIZE: ${{ matrix.selection_ensemble_size }}
       SELECTION_ENSEMBLE_DIVERSITY: ${{ matrix.selection_ensemble_diversity }}
@@ -2077,6 +2135,7 @@ jobs:
           echo "Output prefix: ${output_prefix}"
           echo "Sample weightings: ${SAMPLE_WEIGHTINGS}"
           echo "Score calibrations: ${SCORE_CALIBRATIONS}"
+          echo "Feature transforms: ${FEATURE_TRANSFORMS}"
           echo "Alignment alphas: ${ALIGNMENT_ALPHAS}"
           args=(
             python scripts/export_stimulus_cross_subject_nested.py
@@ -2093,6 +2152,7 @@ jobs:
             --components-pca-values "${COMPONENTS_PCA_VALUES}"
             --sample-weightings "${SAMPLE_WEIGHTINGS}"
             --score-calibrations "${SCORE_CALIBRATIONS}"
+            --feature-transforms "${FEATURE_TRANSFORMS}"
             --alignment-alphas "${ALIGNMENT_ALPHAS}"
             --selection-ensemble-size "${SELECTION_ENSEMBLE_SIZE}"
             --selection-ensemble-diversity "${SELECTION_ENSEMBLE_DIVERSITY}"

--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -92,6 +92,7 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w150_smooth
           - windowed_logreg_175_w150_ranksoft_t1_5_margin_confusion_guarded
           - windowed_logreg_175_w150_temporal_pyramid_features
           - windowed_logreg_175_w150_inner_prior
@@ -1520,6 +1521,21 @@ jobs:
                   "window_centers": "0.175",
                   "window_size": "0.150",
                   "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_smooth": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_smooth",
                   "normalizations": "subject_baseline_whiten",
                   "alignments": "none",
                   "classifiers": "multinomial-logistic,multinomial-logistic-weighted",

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -77,8 +77,10 @@ DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = 1.0
 DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
 DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
 DEFAULT_SENSOR_DCT_COEFFICIENTS = 8
+DEFAULT_SENSOR_FLAT_SMOOTH_KERNEL = (0.25, 0.50, 0.25)
 BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",
+    "sensor_flat_smooth",
     "sensor_flat_delta",
     "sensor_flat_time_pyramid",
     "sensor_flat_time_pyramid_logpower",
@@ -93,6 +95,7 @@ EXTENDED_FEATURE_MODES = (
     "sensor_logpower",
     "sensor_mean_logpower",
     "sensor_flat_logpower",
+    "sensor_flat_smooth",
     "sensor_flat_delta",
     "sensor_flat_time_pyramid",
     "sensor_flat_time_pyramid_logpower",
@@ -578,6 +581,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_logpower_feature(signal)
         elif feature_mode == "sensor_flat_logpower":
             feature = _sensor_flat_logpower_feature(signal)
+        elif feature_mode == "sensor_flat_smooth":
+            feature = _sensor_flat_smooth_feature(signal)
         elif feature_mode == "sensor_flat_delta":
             feature = _sensor_flat_delta_feature(signal)
         elif feature_mode == "sensor_flat_time_pyramid":
@@ -624,6 +629,34 @@ def _sensor_flat_logpower_feature(window_signal):
 
     signal = np.asarray(window_signal, dtype=float)
     return np.concatenate((signal.reshape(-1, order="F"), _sensor_logpower_feature(signal)))
+
+
+def _sensor_flat_smooth_feature(window_signal):
+    """Return lightly time-smoothed raw evoked samples in sensor_flat layout."""
+
+    return _temporal_smooth_signal(window_signal).reshape(-1, order="F")
+
+
+def _temporal_smooth_signal(window_signal):
+    """Apply a short edge-padded temporal smoothing kernel per sensor."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    if signal.ndim != 2:
+        raise ValueError("window_signal must be a channel x time matrix.")
+    if signal.shape[1] < 2:
+        return signal.copy()
+
+    kernel = np.asarray(DEFAULT_SENSOR_FLAT_SMOOTH_KERNEL, dtype=float)
+    if kernel.shape != (3,) or not np.isclose(np.sum(kernel), 1.0):
+        raise ValueError(
+            "DEFAULT_SENSOR_FLAT_SMOOTH_KERNEL must contain three weights summing to one."
+        )
+    padded = np.pad(signal, ((0, 0), (1, 1)), mode="edge")
+    return (
+        kernel[0] * padded[:, :-2]
+        + kernel[1] * padded[:, 1:-1]
+        + kernel[2] * padded[:, 2:]
+    )
 
 
 def _sensor_flat_delta_feature(window_signal):
@@ -797,6 +830,8 @@ def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
     feature_mode = _normalize_feature_mode(config.feature_mode)
     if feature_mode == "sensor_flat_logpower":
         return _sensor_flat_logpower_baseline_statistics(data, config, n_window_samples, trial_indices)
+    if feature_mode == "sensor_flat_smooth":
+        return _sensor_flat_smooth_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_delta":
         return _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_time_pyramid":
@@ -855,6 +890,19 @@ def _sensor_flat_logpower_baseline_statistics(data, config, n_window_samples, tr
     flat_std = np.tile(channel_std, int(n_window_samples))
     mean = np.concatenate((flat_mean, np.mean(logpower_features, axis=0)))[None, :]
     std = np.concatenate((flat_std, np.std(logpower_features, axis=0)))[None, :]
+    return mean, _impl._nonzero_std(std), n_baseline_samples
+
+
+def _sensor_flat_smooth_baseline_statistics(data, config, n_window_samples, trial_indices):
+    """Baseline statistics for smoothed sensor_flat features."""
+
+    channel_mean, channel_std, n_baseline_samples = _impl._baseline_channel_statistics(
+        data,
+        config.baseline_window,
+        trial_indices,
+    )
+    mean = np.tile(channel_mean, int(n_window_samples))[None, :]
+    std = np.tile(channel_std, int(n_window_samples))[None, :]
     return mean, _impl._nonzero_std(std), n_baseline_samples
 
 

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -19,6 +19,12 @@ from pymegdec.classifiers import get_default_classifier_param, should_use_defaul
 DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING = "none"
 SAMPLE_WEIGHTING_MODES = ("none", "subject_class_balanced")
 DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION = "none"
+DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM = "none"
+FEATURE_TRANSFORM_MODES = ("none", "source_anova_scale")
+SOURCE_ANOVA_FEATURE_TRANSFORM_MIN_WEIGHT = 0.25
+SOURCE_ANOVA_FEATURE_TRANSFORM_MAX_WEIGHT = 4.0
+SOURCE_ANOVA_FEATURE_TRANSFORM_EPSILON = 1e-12
+SOURCE_ANOVA_FEATURE_TRANSFORM_NORMALIZER_FALLBACK = 1.0
 INNER_SCORE_CALIBRATION_MODES = frozenset(
     (
         "inner_class_bias",
@@ -169,6 +175,11 @@ TOPK_BORDA_SCORE_NORMALIZATIONS = {
     "rank_top2_borda": 2,
     "rank_top3_borda": 3,
 }
+WORST_CLASS_SELECTION_METRICS = (
+    "balanced_worst_class",
+    "balanced_worst_class_lcb",
+)
+WORST_CLASS_SELECTION_WEIGHT = 0.25
 
 _impl = None
 _BaseConfig = None
@@ -230,6 +241,7 @@ def install(impl) -> None:
     class NextCrossSubjectStimulusConfig(_BaseConfig):
         sample_weighting: str = DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING
         score_calibration: str = DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION
+        feature_transform: str = DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM
         alignment_alpha: float = DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA
 
     CrossSubjectStimulusConfig = NextCrossSubjectStimulusConfig
@@ -239,12 +251,19 @@ def install(impl) -> None:
     impl.DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION = DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION
     impl.SCORE_CALIBRATION_MODES = SCORE_CALIBRATION_MODES
     impl.GUARDED_INNER_SCORE_CALIBRATION_MODES = GUARDED_INNER_SCORE_CALIBRATION_MODES
+    impl.DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM = DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM
+    impl.FEATURE_TRANSFORM_MODES = FEATURE_TRANSFORM_MODES
     impl.SCORE_CALIBRATION_MIN_INNER_GAIN = SCORE_CALIBRATION_MIN_INNER_GAIN
     impl.DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA = DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA
     impl.EXTENDED_FEATURE_MODES = EXTENDED_FEATURE_MODES
     impl.DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = DEFAULT_SENSOR_TIME_PYRAMID_LEVELS
     impl.DEFAULT_SENSOR_DCT_COEFFICIENTS = DEFAULT_SENSOR_DCT_COEFFICIENTS
     impl.FEATURE_MODES = tuple(dict.fromkeys((*impl.FEATURE_MODES, *EXTENDED_FEATURE_MODES)))
+    impl.CROSS_SUBJECT_SELECTION_METRIC_CHOICES = tuple(
+        dict.fromkeys(
+            (*impl.CROSS_SUBJECT_SELECTION_METRIC_CHOICES, *WORST_CLASS_SELECTION_METRICS)
+        )
+    )
     impl.CrossSubjectStimulusConfig = NextCrossSubjectStimulusConfig
     _install_intermediate_rank_softmax_temperatures(impl)
     _install_soft_inner_confusion_score_normalizations(impl)
@@ -258,6 +277,8 @@ def install(impl) -> None:
     impl._normalize_features = _normalize_features
     impl._normalized_subject_features = _normalized_subject_features
     impl._fit_outer_fold_model = _fit_outer_fold_model
+    impl._fit_training_feature_transform = _fit_training_feature_transform
+    impl._apply_training_feature_transform = _apply_training_feature_transform
     impl._score_outer_fold_model = _score_outer_fold_model
     impl._class_score_probabilities = _class_score_probabilities
     impl._candidate_model_scores = _candidate_model_scores
@@ -399,7 +420,12 @@ def _rank_topk_borda_probabilities(scores, *, top_k):
 
 def _prediction_group_columns(columns):
     output = list(columns)
-    for column in ("sample_weighting", "score_calibration", "alignment_alpha"):
+    for column in (
+        "sample_weighting",
+        "score_calibration",
+        "feature_transform",
+        "alignment_alpha",
+    ):
         if column not in output:
             output.append(column)
     return tuple(output)
@@ -433,6 +459,13 @@ def _score_calibration_base_mode(value):
     return token
 
 
+def _normalize_feature_transform(value):
+    token = str(value).strip().lower().replace("-", "_")
+    if token not in FEATURE_TRANSFORM_MODES:
+        raise ValueError(f"feature_transform must be one of {FEATURE_TRANSFORM_MODES}.")
+    return token
+
+
 def _normalize_alignment_alpha(value):
     alpha = float(value)
     if not 0.0 <= alpha <= 1.0:
@@ -445,6 +478,7 @@ def _normalized_config(config):
     kwargs = {field.name: getattr(base, field.name) for field in fields(base)}
     kwargs["sample_weighting"] = _normalize_sample_weighting(getattr(config, "sample_weighting", DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING))
     kwargs["score_calibration"] = _normalize_score_calibration(getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION))
+    kwargs["feature_transform"] = _normalize_feature_transform(getattr(config, "feature_transform", DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM))
     kwargs["alignment_alpha"] = _normalize_alignment_alpha(getattr(config, "alignment_alpha", DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA))
     return CrossSubjectStimulusConfig(**kwargs)
 
@@ -466,6 +500,7 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
     trial_selection_seed=None,
     sample_weightings=(DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING,),
     score_calibrations=(DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION,),
+    feature_transforms=(DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM,),
     alignment_alphas=(DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA,),
     chance_classes=None,
     random_state=0,
@@ -504,13 +539,14 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
             trial_selection_seed=trial_selection_seed,
             sample_weighting=_normalize_sample_weighting(sample_weighting),
             score_calibration=_normalize_score_calibration(score_calibration),
+            feature_transform=_normalize_feature_transform(feature_transform),
             alignment_alpha=_normalize_alignment_alpha(alignment_alpha),
             chance_classes=chance_classes,
             random_state=random_state,
             signflip_permutations=signflip_permutations,
             signflip_seed=signflip_seed,
         )
-        for window_center, grid_window_size, feature_mode, normalization, alignment, classifier, components_pca, sample_weighting, score_calibration, alignment_alpha in product(
+        for window_center, grid_window_size, feature_mode, normalization, alignment, classifier, components_pca, sample_weighting, score_calibration, feature_transform, alignment_alpha in product(
             window_centers,
             window_sizes,
             feature_modes,
@@ -520,6 +556,7 @@ def make_cross_subject_candidate_configs(  # pylint: disable=too-many-arguments
             _impl._components_pca_values_for_grid(components_pca_values),
             sample_weightings,
             score_calibrations,
+            feature_transforms,
             alignment_alphas,
         )
         for classifier_param in _impl._classifier_params_for_classifier(classifier, classifier_params)
@@ -980,6 +1017,126 @@ def _align_test_features_by_subject(test_features, test_set, config, alignment_m
     return aligned, metadata
 
 
+def _fit_training_feature_transform(train_features, train_sets, config, *, train_labels=None):
+    """Fit a source-only supervised feature rescaling transform."""
+
+    config = _normalized_config(config)
+    mode = _normalize_feature_transform(
+        getattr(config, "feature_transform", DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM)
+    )
+    train_features = np.asarray(train_features, dtype=float)
+    if mode == "none":
+        return train_features, None
+    if mode != "source_anova_scale":
+        raise ValueError(f"Unsupported feature_transform: {mode}")
+
+    labels = _feature_transform_labels(train_sets, train_features, train_labels)
+    weights, diagnostics = _source_anova_feature_weights(train_features, labels)
+    transformed = train_features * weights[None, :]
+    return transformed, {
+        "mode": mode,
+        "feature_weights": weights,
+        "weight_min": float(np.min(weights)) if weights.size else np.nan,
+        "weight_max": float(np.max(weights)) if weights.size else np.nan,
+        "weight_mean": float(np.mean(weights)) if weights.size else np.nan,
+        "n_features": int(weights.shape[0]),
+        **diagnostics,
+    }
+
+
+def _feature_transform_labels(train_sets, train_features, train_labels):
+    if train_labels is not None:
+        labels = np.asarray(train_labels, dtype=int).ravel()
+    else:
+        labels = np.concatenate(
+            [
+                np.asarray(feature_set.labels, dtype=int).ravel() - 1
+                for feature_set in train_sets
+            ]
+        )
+    if labels.shape[0] != np.asarray(train_features).shape[0]:
+        raise ValueError("feature_transform labels must match train feature rows.")
+    return labels
+
+
+def _source_anova_feature_weights(features, labels):
+    features = np.asarray(features, dtype=float)
+    labels = np.asarray(labels, dtype=int).ravel()
+    n_samples, n_features = features.shape
+    if n_samples == 0 or n_features == 0:
+        return np.ones(n_features, dtype=float), {
+            "feature_transform_status": "skipped_empty_features"
+        }
+
+    unique_labels = np.unique(labels)
+    if unique_labels.size < 2:
+        return np.ones(n_features, dtype=float), {
+            "feature_transform_status": "skipped_one_class"
+        }
+
+    total_mean = np.mean(features, axis=0)
+    ss_between = np.zeros(n_features, dtype=float)
+    ss_within = np.zeros(n_features, dtype=float)
+    used_classes = 0
+    for label in unique_labels:
+        group = features[labels == label]
+        if group.shape[0] == 0:
+            continue
+        group_mean = np.mean(group, axis=0)
+        ss_between += float(group.shape[0]) * np.square(group_mean - total_mean)
+        ss_within += np.sum(np.square(group - group_mean), axis=0)
+        used_classes += 1
+
+    if used_classes < 2:
+        return np.ones(n_features, dtype=float), {
+            "feature_transform_status": "skipped_one_class"
+        }
+    df_between = max(used_classes - 1, 1)
+    df_within = max(n_samples - used_classes, 1)
+    f_scores = (ss_between / float(df_between)) / (
+        (ss_within / float(df_within)) + SOURCE_ANOVA_FEATURE_TRANSFORM_EPSILON
+    )
+    f_scores = np.where(np.isfinite(f_scores) & (f_scores > 0.0), f_scores, 0.0)
+    raw_weights = np.sqrt(f_scores)
+    positive = raw_weights[np.isfinite(raw_weights) & (raw_weights > 0.0)]
+    normalizer = (
+        float(np.median(positive))
+        if positive.size
+        else SOURCE_ANOVA_FEATURE_TRANSFORM_NORMALIZER_FALLBACK
+    )
+    if not np.isfinite(normalizer) or normalizer <= 0.0:
+        normalizer = SOURCE_ANOVA_FEATURE_TRANSFORM_NORMALIZER_FALLBACK
+    weights = raw_weights / normalizer
+    weights = np.clip(
+        weights,
+        SOURCE_ANOVA_FEATURE_TRANSFORM_MIN_WEIGHT,
+        SOURCE_ANOVA_FEATURE_TRANSFORM_MAX_WEIGHT,
+    )
+    return weights.astype(float, copy=False), {
+        "feature_transform_status": "fitted_source_anova_scale",
+        "feature_transform_classes": int(used_classes),
+        "feature_transform_normalizer": float(normalizer),
+    }
+
+
+def _has_active_feature_transform_metadata(metadata):
+    return (
+        isinstance(metadata, dict)
+        and metadata.get("mode") == "source_anova_scale"
+        and "feature_weights" in metadata
+    )
+
+
+def _apply_training_feature_transform(features, metadata):
+    features = np.asarray(features, dtype=float)
+    if not _has_active_feature_transform_metadata(metadata):
+        return features
+    weights = np.asarray(metadata["feature_weights"], dtype=float).ravel()
+    if features.ndim != 2 or features.shape[1] != weights.shape[0]:
+        raise ValueError("Stored feature transform width does not match feature matrix width.")
+    return features * weights[None, :]
+
+
 def _fit_outer_fold_model(train_sets, config, classifier_param, *, label_shuffle_seed=None, label_shuffle_context=(), fit_score_calibration=True):
     config = _normalized_config(config)
     train_features_by_subject = [_impl._normalized_subject_features(feature_set, config) for feature_set in train_sets]
@@ -995,7 +1152,9 @@ def _fit_outer_fold_model(train_sets, config, classifier_param, *, label_shuffle
     feature_transform_metadata = None
     fit_training_feature_transform = getattr(_impl, "_fit_training_feature_transform", None)
     if fit_training_feature_transform is not None:
-        train_features, feature_transform_metadata = fit_training_feature_transform(train_features, train_sets, config)
+        train_features, feature_transform_metadata = fit_training_feature_transform(
+            train_features, train_sets, config, train_labels=train_labels
+        )
     train_window = _impl._centered_window(config.window_center, config.window_size)
     model_bundle = _impl.fit_reptrace_window_model(
         train_features,
@@ -1640,8 +1799,38 @@ def _align_class_score_columns(scores, score_classes, class_order):
     return aligned
 
 
+def _model_scores_with_feature_transform(fitted_model, test_set, config):
+    config = _normalized_config(config)
+    test_features = _impl._normalized_subject_features(test_set, config)
+    alignment_model = (
+        _impl._fitted_alignment_model(fitted_model)
+        if hasattr(_impl, "_fitted_alignment_model")
+        else {"metadata": fitted_model.get("alignment_metadata", {})}
+    )
+    test_features, _test_alignment_metadata = _align_test_features_by_subject(
+        test_features, test_set, config, alignment_model
+    )
+    test_features = _apply_training_feature_transform(
+        test_features,
+        fitted_model.get("feature_transform_metadata", {})
+        if isinstance(fitted_model, dict)
+        else {},
+    )
+    return _impl._model_class_scores(fitted_model["model_bundle"], test_features)
+
+
 def _candidate_model_scores(fitted_model, test_set, config):
-    scores, classes = _previous_candidate_model_scores(fitted_model, test_set, config)
+    feature_transform_metadata = (
+        fitted_model.get("feature_transform_metadata", {})
+        if isinstance(fitted_model, dict)
+        else {}
+    )
+    if _has_active_feature_transform_metadata(feature_transform_metadata):
+        scores, classes = _model_scores_with_feature_transform(
+            fitted_model, test_set, config
+        )
+    else:
+        scores, classes = _previous_candidate_model_scores(fitted_model, test_set, config)
     return _apply_score_calibration(scores, classes, fitted_model)
 
 
@@ -1713,7 +1902,12 @@ def _apply_score_calibration(scores, classes, fitted_model):
 def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictions=True):
     config = _normalized_config(config)
     metadata = fitted_model.get("score_calibration_metadata", {}) if isinstance(fitted_model, dict) else {}
-    if not _has_active_score_calibration_metadata(metadata):
+    feature_transform_metadata = (
+        fitted_model.get("feature_transform_metadata", {})
+        if isinstance(fitted_model, dict)
+        else {}
+    )
+    if not _has_active_score_calibration_metadata(metadata) and not _has_active_feature_transform_metadata(feature_transform_metadata):
         outer_row, prediction_rows = _previous_score_outer_fold_model(fitted_model, test_set, config, include_predictions=include_predictions)
         _add_next_fields(outer_row, config, fitted_model)
         for row in prediction_rows:
@@ -1724,6 +1918,7 @@ def _score_outer_fold_model(fitted_model, test_set, config, *, include_predictio
     test_features = _impl._normalized_subject_features(test_set, config)
     alignment_model = _impl._fitted_alignment_model(fitted_model) if hasattr(_impl, "_fitted_alignment_model") else {"metadata": fitted_model.get("alignment_metadata", {})}
     test_features, test_alignment_metadata = _align_test_features_by_subject(test_features, test_set, config, alignment_model)
+    test_features = _apply_training_feature_transform(test_features, feature_transform_metadata)
     class_scores, score_classes = _impl._model_class_scores(fitted_model["model_bundle"], test_features)
     class_scores, score_classes = _apply_score_calibration(class_scores, score_classes, fitted_model)
     test_labels = np.asarray(test_set.labels, dtype=int) - 1
@@ -1789,6 +1984,7 @@ def _prediction_rows(test_set, test_labels, predictions, true_label_ranks, *, co
 def _add_config_fields(row, config):
     row["sample_weighting"] = getattr(config, "sample_weighting", DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING)
     row["score_calibration"] = getattr(config, "score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION)
+    row["feature_transform"] = getattr(config, "feature_transform", DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM)
     row["alignment_alpha"] = getattr(config, "alignment_alpha", DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA)
 
 
@@ -1814,10 +2010,30 @@ def _add_next_fields(row, config, fitted_model):
     row["score_calibration_probability_map_identity_blend"] = metadata.get(
         "probability_map_identity_blend", ""
     )
+    feature_metadata = fitted_model.get("feature_transform_metadata", {}) if isinstance(fitted_model, dict) else {}
+    row["feature_transform"] = feature_metadata.get(
+        "mode", getattr(config, "feature_transform", DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM)
+    )
+    row["feature_transform_status"] = feature_metadata.get("feature_transform_status", "")
+    row["feature_transform_weight_min"] = feature_metadata.get("weight_min", "")
+    row["feature_transform_weight_max"] = feature_metadata.get("weight_max", "")
+    row["feature_transform_weight_mean"] = feature_metadata.get("weight_mean", "")
+    row["feature_transform_n_features"] = feature_metadata.get("n_features", "")
 
 
 def _rank_nested_candidates(inner_rows, *, selection_metric=None):
-    if selection_metric is None:
+    metric = (
+        None
+        if selection_metric is None
+        else str(selection_metric).strip().lower().replace("-", "_")
+    )
+    if metric in WORST_CLASS_SELECTION_METRICS:
+        ranked = _previous_rank_nested_candidates(
+            inner_rows,
+            selection_metric="balanced_accuracy",
+        )
+        ranked = _rerank_nested_candidates_by_worst_class(ranked, metric)
+    elif selection_metric is None:
         ranked = _previous_rank_nested_candidates(inner_rows)
     else:
         ranked = _previous_rank_nested_candidates(inner_rows, selection_metric=selection_metric)
@@ -1826,8 +2042,101 @@ def _rank_nested_candidates(inner_rows, *, selection_metric=None):
         example = examples.get(int(row["selected_candidate_index"]), {})
         row["selected_sample_weighting"] = example.get("sample_weighting", DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING)
         row["selected_score_calibration"] = example.get("score_calibration", DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION)
+        row["selected_feature_transform"] = example.get("feature_transform", DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM)
         row["selected_alignment_alpha"] = example.get("alignment_alpha", DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA)
     return ranked
+
+
+def _rerank_nested_candidates_by_worst_class(ranked_rows, selection_metric):
+    """Rerank source-inner candidates with a soft per-class recall floor."""
+
+    selection_metric = str(selection_metric).strip().lower().replace("-", "_")
+    if selection_metric not in WORST_CLASS_SELECTION_METRICS:
+        raise ValueError(f"Unsupported worst-class selection metric: {selection_metric}")
+
+    rows = [dict(row) for row in ranked_rows]
+    for row in rows:
+        row["selection_metric"] = selection_metric
+        worst_recall = _selected_inner_worst_class_recall(row)
+        row["selected_inner_worst_class_recall"] = worst_recall
+        score = _worst_class_selection_score(row, selection_metric)
+        row["selected_inner_selection_score_mean"] = score
+        row["selected_inner_selection_score_median"] = score
+        row["selected_inner_selection_score_sem"] = 0.0
+        row["selected_inner_selection_ranking_score"] = score
+
+    ranked = sorted(rows, key=_worst_class_selection_sort_key, reverse=True)
+    if not ranked:
+        return ranked
+
+    selected = ranked[0]
+    selected_score = float(selected["selected_inner_selection_ranking_score"])
+    if len(ranked) > 1:
+        second_best_balanced_mean = float(
+            ranked[1]["selected_inner_balanced_accuracy_mean"]
+        )
+        second_best_score = float(ranked[1]["selected_inner_selection_ranking_score"])
+        winner_margin = selected_score - second_best_score
+    else:
+        second_best_balanced_mean = np.nan
+        second_best_score = np.nan
+        winner_margin = np.nan
+
+    for rank, row in enumerate(ranked, start=1):
+        row_score = float(row["selected_inner_selection_ranking_score"])
+        row["selected_inner_rank"] = int(rank)
+        row["selected_inner_second_best_balanced_accuracy_mean"] = second_best_balanced_mean
+        row["selected_inner_second_best_selection_score_mean"] = second_best_score
+        row["selected_inner_winner_margin"] = (
+            winner_margin if rank == 1 else selected_score - row_score
+        )
+    return ranked
+
+
+def _worst_class_selection_sort_key(row):
+    return (
+        _impl._finite_sort_value(row.get("selected_inner_selection_ranking_score", np.nan)),
+        _impl._finite_sort_value(row.get("selected_inner_balanced_accuracy_mean", np.nan)),
+        _impl._finite_sort_value(row.get("selected_inner_worst_class_recall", np.nan)),
+        _impl._finite_sort_value(row.get("selected_inner_top2_accuracy_mean", np.nan)),
+        _impl._finite_sort_value(row.get("selected_inner_top3_accuracy_mean", np.nan)),
+        _impl._finite_sort_value(-float(row.get("selected_inner_mean_true_label_rank_mean", np.inf))),
+        -int(row["selected_candidate_index"]),
+    )
+
+
+def _worst_class_selection_score(row, selection_metric):
+    balanced = float(row.get("selected_inner_balanced_accuracy_mean", np.nan))
+    if selection_metric.endswith("_lcb"):
+        sem = float(row.get("selected_inner_balanced_accuracy_sem", 0.0))
+        balanced -= sem if np.isfinite(sem) else 0.0
+    worst_recall = _impl._finite_or(
+        row.get("selected_inner_worst_class_recall", np.nan),
+        default=balanced,
+    )
+    weight = float(WORST_CLASS_SELECTION_WEIGHT)
+    return float((1.0 - weight) * balanced + weight * worst_recall)
+
+
+def _selected_inner_worst_class_recall(row):
+    counter = _impl._parse_confusion_counter(
+        row.get("selected_inner_confusion_counts", "")
+    )
+    if not counter:
+        return np.nan
+    labels = sorted(
+        {int(true_label) for true_label, _predicted_label in counter}
+        | {int(predicted_label) for _true_label, predicted_label in counter}
+    )
+    if not labels:
+        return np.nan
+    matrix = _impl._confusion_counter_matrix(counter, labels)
+    totals = np.sum(matrix, axis=1)
+    valid = totals > 0.0
+    if not np.any(valid):
+        return np.nan
+    recalls = np.diag(matrix)[valid] / totals[valid]
+    return float(np.min(recalls))
 
 
 def summarize_cross_subject_stimulus_smoke(outer_rows, *, config=None):
@@ -1845,6 +2154,7 @@ def summarize_nested_cross_subject_stimulus(outer_rows, *, signflip_permutations
     for row in rows:
         row["selected_sample_weighting_counts"] = _impl._format_counter(Counter(str(value.get("selected_sample_weighting", value.get("sample_weighting", ""))) for value in outer_rows))
         row["selected_score_calibration_counts"] = _impl._format_counter(Counter(str(value.get("selected_score_calibration", value.get("score_calibration", ""))) for value in outer_rows))
+        row["selected_feature_transform_counts"] = _impl._format_counter(Counter(str(value.get("selected_feature_transform", value.get("feature_transform", ""))) for value in outer_rows))
         row["selected_alignment_alpha_counts"] = _impl._format_counter(Counter(str(value.get("selected_alignment_alpha", value.get("alignment_alpha", ""))) for value in outer_rows))
     return rows
 

--- a/src/pymegdec/stimulus_cli.py
+++ b/src/pymegdec/stimulus_cli.py
@@ -42,6 +42,8 @@ from pymegdec.stimulus_cross_subject import (
     DEFAULT_CROSS_SUBJECT_PARTICIPANTS,
     DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING,
     DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION,
+    DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM,
+    FEATURE_TRANSFORM_MODES,
     DEFAULT_CROSS_SUBJECT_SELECTION_METRIC,
     FEATURE_MODES,
     DEFAULT_CROSS_SUBJECT_SELECTION_ENSEMBLE_SIZE,
@@ -156,6 +158,10 @@ def _parse_sample_weighting_list(value: str) -> tuple[str, ...]:
 
 
 def _parse_score_calibration_list(value: str) -> tuple[str, ...]:
+    return tuple(token.strip().lower().replace("-", "_") for token in _parse_token_list(value))
+
+
+def _parse_feature_transform_list(value: str) -> tuple[str, ...]:
     return tuple(token.strip().lower().replace("-", "_") for token in _parse_token_list(value))
 
 
@@ -635,6 +641,12 @@ def _build_cross_subject_nested_parser(prog: str | None = None) -> argparse.Argu
         help="Comma-separated score calibration modes, e.g. none,inner_class_bias.",
     )
     parser.add_argument(
+        "--feature-transforms",
+        type=_parse_feature_transform_list,
+        default=(DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM,),
+        help=f"Comma-separated source-only feature transform modes, e.g. {','.join(FEATURE_TRANSFORM_MODES)}.",
+    )
+    parser.add_argument(
         "--alignment-alphas",
         type=parse_float_list,
         default=(DEFAULT_CROSS_SUBJECT_ALIGNMENT_ALPHA,),
@@ -738,6 +750,7 @@ def stimulus_cross_subject_nested(argv: Sequence[str] | None = None, prog: str |
         components_pca_values=args.components_pca_values,
         sample_weightings=args.sample_weightings,
         score_calibrations=args.score_calibrations,
+        feature_transforms=args.feature_transforms,
         alignment_alphas=args.alignment_alphas,
         max_trials_per_class_per_participant=args.max_trials_per_class_per_participant,
         trial_selection=args.trial_selection,

--- a/tests/test_source_anova_feature_transform.py
+++ b/tests/test_source_anova_feature_transform.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+
+import numpy as np
+from pymegdec import stimulus_cross_subject as cross_subject
+from pymegdec.stimulus_cross_subject import (
+    CrossSubjectStimulusConfig,
+    make_cross_subject_candidate_configs,
+)
+
+
+def test_make_candidate_configs_expands_source_anova_feature_transform():
+    configs = make_cross_subject_candidate_configs(
+        window_centers=(0.175,),
+        window_size=0.1,
+        feature_modes=("sensor_flat",),
+        normalizations=("subject_baseline_whiten",),
+        alignments=("none",),
+        classifiers=("multinomial-logistic",),
+        classifier_params=(1.0,),
+        components_pca_values=(128,),
+        feature_transforms=("none", "source_anova_scale"),
+        chance_classes=16,
+    )
+
+    assert [config.feature_transform for config in configs] == [
+        "none",
+        "source_anova_scale",
+    ]
+
+
+def test_source_anova_feature_transform_scales_discriminative_dimensions():
+    train_features = np.asarray(
+        [
+            [-2.0, -0.2],
+            [-1.8, 0.2],
+            [1.8, -0.2],
+            [2.0, 0.2],
+        ],
+        dtype=float,
+    )
+    train_labels = np.asarray([0, 0, 1, 1], dtype=int)
+    train_sets = (
+        SimpleNamespace(labels=np.asarray([1, 1])),
+        SimpleNamespace(labels=np.asarray([2, 2])),
+    )
+    config = CrossSubjectStimulusConfig(
+        feature_transform="source_anova_scale", chance_classes=2
+    )
+
+    transformed, metadata = cross_subject._fit_training_feature_transform(  # pylint: disable=protected-access
+        train_features, train_sets, config, train_labels=train_labels
+    )
+
+    assert metadata["mode"] == "source_anova_scale"
+    weights = metadata["feature_weights"]
+    assert weights.shape == (2,)
+    assert weights[0] > weights[1]
+    np.testing.assert_allclose(transformed, train_features * weights[None, :])
+    np.testing.assert_allclose(
+        cross_subject._apply_training_feature_transform(  # pylint: disable=protected-access
+            np.ones((1, 2)), metadata
+        ),
+        weights[None, :],
+    )

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -200,6 +200,73 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertTrue(confusion_metadata["guarded"])
         self.assertLess(confusion_metadata["blend"], 1.0)
 
+    def test_worst_class_selection_metrics_are_exported(self):
+        self.assertIn("balanced_worst_class", cross_subject.CROSS_SUBJECT_SELECTION_METRIC_CHOICES)
+        self.assertIn("balanced_worst_class_lcb", cross_subject.CROSS_SUBJECT_SELECTION_METRIC_CHOICES)
+
+    def test_worst_class_lcb_selection_prefers_less_collapsed_class(self):
+        inner_rows = [
+            self._inner_candidate_row(
+                candidate_index=1,
+                balanced_accuracy=0.80,
+                confusion_counts="1>1:10;2>1:8;2>2:2",
+            ),
+            self._inner_candidate_row(
+                candidate_index=2,
+                balanced_accuracy=0.78,
+                confusion_counts="1>1:8;1>2:2;2>1:2;2>2:8",
+            ),
+        ]
+
+        balanced_ranked = cross_subject._rank_nested_candidates(  # pylint: disable=protected-access
+            inner_rows,
+            selection_metric="balanced_accuracy",
+        )
+        worst_class_ranked = cross_subject._rank_nested_candidates(  # pylint: disable=protected-access
+            inner_rows,
+            selection_metric="balanced_worst_class_lcb",
+        )
+
+        self.assertEqual(balanced_ranked[0]["selected_candidate_index"], 1)
+        self.assertEqual(worst_class_ranked[0]["selected_candidate_index"], 2)
+        self.assertAlmostEqual(
+            worst_class_ranked[0]["selected_inner_worst_class_recall"],
+            0.8,
+        )
+        self.assertEqual(worst_class_ranked[0]["selection_metric"], "balanced_worst_class_lcb")
+
+    @staticmethod
+    def _inner_candidate_row(*, candidate_index, balanced_accuracy, confusion_counts):
+        return {
+            "outer_test_participant": 1,
+            "inner_validation_participant": 2,
+            "candidate_index": candidate_index,
+            "balanced_accuracy": balanced_accuracy,
+            "accuracy": balanced_accuracy,
+            "top2_accuracy": min(1.0, balanced_accuracy + 0.1),
+            "top3_accuracy": min(1.0, balanced_accuracy + 0.2),
+            "mean_true_label_rank": 1.5,
+            "chance_mean_rank": 1.5,
+            "chance_classes": 2,
+            "test_label_counts": "1:10;2:10",
+            "predicted_label_counts": "1:10;2:10",
+            "true_predicted_label_pair_counts": "",
+            "confusion_counts": confusion_counts,
+            "window_center_s": 0.175,
+            "window_size_s": 0.1,
+            "window_start_s": 0.125,
+            "window_stop_s": 0.225,
+            "feature_mode": "sensor_flat",
+            "normalization": "subject_baseline_whiten",
+            "alignment": "none",
+            "classifier": "multinomial-logistic",
+            "classifier_param": 1.0,
+            "components_pca": 128,
+            "max_trials_per_class_per_participant": "",
+            "label_shuffle_control": False,
+            "label_shuffle_seed": "",
+        }
+
     def test_topk_borda_score_normalizations_are_exported(self):
         self.assertIn("rank_top2_borda", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
         self.assertIn("rank_top3_borda", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -292,6 +292,7 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertIn("sensor_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_mean_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_logpower", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_flat_smooth", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_delta", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_time_pyramid", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_time_pyramid_logpower", cross_subject.FEATURE_MODES)
@@ -349,6 +350,57 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(feature_set.features.shape, (2, 6))
         np.testing.assert_allclose(feature_set.features[0, :4], np.asarray([1.0, 2.0, 3.0, 6.0]))
         np.testing.assert_allclose(feature_set.features[0, 4:], np.log(np.asarray([5.0, 20.0]) + 1e-12))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_smooth_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0, 5.0], [0.0, 0.0, 2.0, 4.0, 6.0]],
+            [[0.0, 0.0, 2.0, 4.0, 6.0], [0.0, 0.0, 1.0, 3.0, 5.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            feature_mode="sensor_flat_smooth",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        np.testing.assert_allclose(
+            feature_set.features[0],
+            np.asarray([1.5, 2.5, 3.0, 4.0, 4.5, 5.5]),
+        )
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_smooth_baseline_whiten_allows_different_baseline_duration(self):
+        time = np.asarray([-0.3, -0.2, -0.1, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.1, 0.2, 0.3, 1.0, 3.0, 5.0], [0.4, 0.5, 0.6, 2.0, 4.0, 6.0]],
+            [[0.2, 0.3, 0.4, 2.0, 4.0, 6.0], [0.5, 0.6, 0.7, 1.0, 3.0, 5.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            baseline_window=(-0.3, -0.1),
+            feature_mode="sensor_flat_smooth",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 6))
+        self.assertEqual(feature_set.baseline_feature_std.shape, (1, 6))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
     def test_sensor_flat_delta_feature(self):


### PR DESCRIPTION
## Summary
- add `sensor_flat_smooth` as a lightly time-smoothed sensor-flat feature mode
- add baseline statistics support for subject-baseline whitening
- add a 175 ms / 150 ms workflow bundle that compares raw and smoothed sensor-flat features

## Validation
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject_next.py tests\test_source_anova_feature_transform.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"`
- `git diff --check`

Tests were not run, per request.