### PR TITLE
Add rank log-pool and flat DCT variants

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -33,6 +33,7 @@ on:
           - windowed_logreg_lean_margin_blend
           - windowed_logreg_lean_balanced_lcb
           - windowed_logreg_lean_predbalance
+          - windowed_logreg_lean_ranksoft_t0_75_log_pool
           - windowed_logreg_lean_rankaware
           - windowed_logreg_lean_rankaware_reciprocal
           - windowed_logreg_lean_rankaware_reciprocal_inner_prior
@@ -93,6 +94,7 @@ on:
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
           - windowed_logreg_175_w150_smooth
+          - windowed_logreg_175_w150_flat_dct
           - windowed_logreg_175_w150_ranksoft_t1_5_margin_confusion_guarded
           - windowed_logreg_175_w150_temporal_pyramid_features
           - windowed_logreg_175_w150_inner_prior
@@ -172,6 +174,11 @@ on:
           - rank_margin_blend
           - row_z_softmax_log_pool
           - rank_softmax_log_pool
+          - rank_softmax_t0_5_log_pool
+          - rank_softmax_t0_75_log_pool
+          - rank_softmax_t1_25_log_pool
+          - rank_softmax_t1_5_log_pool
+          - rank_softmax_t1_75_log_pool
           - rank_softmax_t2_log_pool
           - rank_softmax_t3_log_pool
           - rank_reciprocal_log_pool
@@ -493,6 +500,21 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_test_prior_balance",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_lean_ranksoft_t0_75_log_pool": {
+                  "window_centers": "0.175,0.200",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "64,128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t0_75_log_pool",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_lean_rankaware": {
@@ -1536,6 +1558,21 @@ jobs:
                   "window_centers": "0.175",
                   "window_size": "0.150",
                   "feature_modes": "sensor_flat,sensor_flat_smooth",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_flat_dct": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_dct",
                   "normalizations": "subject_baseline_whiten",
                   "alignments": "none",
                   "classifiers": "multinomial-logistic,multinomial-logistic-weighted",

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -82,6 +82,7 @@ BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",
     "sensor_flat_smooth",
     "sensor_flat_delta",
+    "sensor_flat_dct",
     "sensor_flat_time_pyramid",
     "sensor_flat_time_pyramid_logpower",
     "sensor_flat_time_pyramid_delta",
@@ -97,6 +98,7 @@ EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",
     "sensor_flat_smooth",
     "sensor_flat_delta",
+    "sensor_flat_dct",
     "sensor_flat_time_pyramid",
     "sensor_flat_time_pyramid_logpower",
     "sensor_flat_time_pyramid_delta",
@@ -161,6 +163,10 @@ INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_BASES = {
 }
 INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SOFT_BASES = {
     f"{mode}_inner_balanced_confusion_soft": mode
+    for mode in INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES
+}
+INTERMEDIATE_RANK_SOFTMAX_LOG_POOL_MODES = {
+    f"{mode}_log_pool": mode
     for mode in INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES
 }
 INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_BALANCED_CONFUSION_BASES = {
@@ -316,6 +322,7 @@ def _install_intermediate_rank_softmax_temperatures(impl) -> None:
             (
                 *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
                 *INTERMEDIATE_RANK_SOFTMAX_TEMPERATURES,
+                *INTERMEDIATE_RANK_SOFTMAX_LOG_POOL_MODES,
                 *INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_BASES,
                 *INTERMEDIATE_RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SOFT_BASES,
                 *INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_BALANCED_CONFUSION_BASES,
@@ -585,6 +592,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_flat_smooth_feature(signal)
         elif feature_mode == "sensor_flat_delta":
             feature = _sensor_flat_delta_feature(signal)
+        elif feature_mode == "sensor_flat_dct":
+            feature = _sensor_flat_dct_feature(signal)
         elif feature_mode == "sensor_flat_time_pyramid":
             feature = _sensor_flat_time_pyramid_feature(signal)
         elif feature_mode == "sensor_flat_time_pyramid_logpower":
@@ -668,6 +677,13 @@ def _sensor_flat_delta_feature(window_signal):
         return flat
     deltas = np.diff(signal, axis=1).reshape(-1, order="F")
     return np.concatenate((flat, deltas))
+
+
+def _sensor_flat_dct_feature(window_signal):
+    """Return raw evoked samples plus compact low-order DCT waveform blocks."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    return np.concatenate((signal.reshape(-1, order="F"), _sensor_dct_feature(signal)))
 
 
 def _sensor_flat_time_pyramid_feature(window_signal):
@@ -834,6 +850,8 @@ def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
         return _sensor_flat_smooth_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_delta":
         return _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial_indices)
+    if feature_mode == "sensor_flat_dct":
+        return _sensor_flat_dct_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_time_pyramid":
         return _sensor_flat_time_pyramid_baseline_statistics(
             data,
@@ -938,6 +956,27 @@ def _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial
     delta_std_tiled = np.tile(delta_std, n_delta_samples)
     mean = np.concatenate((flat_mean, delta_mean_tiled))[None, :]
     std = np.concatenate((flat_std, delta_std_tiled))[None, :]
+    return mean, _impl._nonzero_std(std), n_baseline_samples
+
+
+def _sensor_flat_dct_baseline_statistics(data, config, n_window_samples, trial_indices):
+    """Baseline statistics for raw flat samples plus DCT waveform blocks."""
+
+    channel_mean, channel_std, n_baseline_samples = _impl._baseline_channel_statistics(
+        data,
+        config.baseline_window,
+        trial_indices,
+    )
+    dct_features, _ = _extract_window_features(
+        data,
+        config.baseline_window,
+        feature_mode="sensor_dct",
+        trial_indices=trial_indices,
+    )
+    flat_mean = np.tile(channel_mean, int(n_window_samples))
+    flat_std = np.tile(channel_std, int(n_window_samples))
+    mean = np.concatenate((flat_mean, np.mean(dct_features, axis=0)))[None, :]
+    std = np.concatenate((flat_std, np.std(dct_features, axis=0)))[None, :]
     return mean, _impl._nonzero_std(std), n_baseline_samples
 
 

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -114,6 +114,25 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertGreater(sharp[0, 0], default[0, 0])
         self.assertGreater(sharper[0, 0], sharp[0, 0])
 
+    def test_intermediate_rank_softmax_log_pool_modes_are_exported(self):
+        mode = "rank_softmax_t0_75_log_pool"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_softmax_t0_75",
+        )
+        self.assertEqual(
+            cross_subject._ensemble_log_pool_mode(mode),  # pylint: disable=protected-access
+            mode,
+        )
+
+        scores = np.asarray([[4.0, 3.0, 2.0, 1.0]], dtype=float)
+        probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores, score_normalization=mode
+        )
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(1))
+
     def test_intermediate_rank_softmax_inner_confusion_margin_modes_are_exported(self):
         mode = "rank_softmax_t1_5_inner_confusion_margin_soft_guarded"
 
@@ -294,6 +313,7 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertIn("sensor_flat_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_smooth", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_delta", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_flat_dct", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_time_pyramid", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_time_pyramid_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_time_pyramid_delta", cross_subject.FEATURE_MODES)
@@ -401,6 +421,57 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(feature_set.features.shape, (2, 6))
         self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 6))
         self.assertEqual(feature_set.baseline_feature_std.shape, (1, 6))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_dct_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0, 6.0], [0.0, 0.0, 2.0, 5.0, 9.0]],
+            [[0.0, 0.0, 2.0, 4.0, 7.0], [0.0, 0.0, 4.0, 7.0, 11.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            feature_mode="sensor_flat_dct",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 22))
+        np.testing.assert_allclose(
+            feature_set.features[0, :6],
+            np.asarray([1.0, 2.0, 3.0, 5.0, 6.0, 9.0]),
+        )
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_dct_baseline_whiten_allows_different_baseline_duration(self):
+        time = np.asarray([-0.3, -0.2, -0.1, 0.1, 0.2], dtype=float)
+        trials = [
+            [[0.1, 0.2, 0.3, 1.0, 3.0], [0.4, 0.5, 0.6, 2.0, 6.0]],
+            [[0.2, 0.3, 0.4, 2.0, 4.0], [0.5, 0.6, 0.7, 4.0, 8.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.15,
+            window_size=0.1,
+            baseline_window=(-0.3, -0.1),
+            feature_mode="sensor_flat_dct",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 20))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 20))
+        self.assertEqual(feature_set.baseline_feature_std.shape, (1, 20))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
     def test_sensor_flat_delta_feature(self):


### PR DESCRIPTION
﻿## Summary
- add intermediate rank-softmax log-pool score-normalization modes
- add sensor_flat_dct feature extraction and baseline whitening support
- add workflow bundle entries for the new variants

## Validation
- python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\stimulus_cli.py tests\test_stimulus_cross_subject_next.py tests\test_source_anova_feature_transform.py
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"
- git diff --check

Tests were not run per request.