### PR TITLE
Add adaptive BUSH w150 variants

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -93,6 +93,10 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w150_adaptive_ranksoft
+          - windowed_logreg_175_w150_pca160_c03_c05
+          - windowed_logreg_175_w150_pca160_c03_c05_ranksoft_t0_75
+          - windowed_logreg_175_w150_top3_margin_blend_pca160
           - windowed_logreg_175_w150_top2_quota
           - windowed_logreg_175_w150_top3_quota
           - windowed_logreg_175_w150_top3_guarded_quota
@@ -100,6 +104,7 @@ on:
           - windowed_logreg_175_w150_t15_guarded_quota
           - windowed_logreg_175_w150_t15_inner_prior_confusion_guarded_quota
           - windowed_logreg_175_w150_smooth
+          - windowed_logreg_175_w150_taper_mix
           - windowed_logreg_175_w150_flat_dct
           - windowed_logreg_175_w150_ranksoft_t1_5_margin_confusion_guarded
           - windowed_logreg_175_w150_temporal_pyramid_features
@@ -119,6 +124,9 @@ on:
           - windowed_logreg_175_w150_ranksoft_t1_75_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_top2_borda_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_top3_borda_soft_guarded_inner_confusion
+          - windowed_logreg_175_w150_top2_margin_blend
+          - windowed_logreg_175_w150_top3_margin_blend
+          - windowed_logreg_175_w150_top3_margin_blend_soft_guarded_inner_confusion
           - windowed_logreg_175_w125_w150
           - windowed_logreg_w150_size_center_grid
           - windowed_logreg_175_temporal_delta_features
@@ -127,6 +135,8 @@ on:
           - windowed_logreg_150_w150
           - windowed_logreg_200_w150
           - windowed_logreg_175_w150_temporal_delta
+          - windowed_logreg_175_w150_shape_ensemble
+          - windowed_logreg_175_w150_shape_confusion
           - windowed_logreg_175_inner_prior
           - windowed_logreg_175_inner_prior_quota
           - windowed_logreg_175_inner_confusion
@@ -179,7 +189,10 @@ on:
           - rank_z_blend
           - rank_top2_borda
           - rank_top3_borda
+          - rank_top2_margin_blend
+          - rank_top3_margin_blend
           - rank_margin_blend
+          - rank_adaptive_softmax
           - row_z_softmax_log_pool
           - rank_softmax_log_pool
           - rank_softmax_t0_5_log_pool
@@ -281,6 +294,8 @@ on:
           - rank_top3_vote_inner_confusion_soft_guarded
           - rank_top2_borda_inner_confusion_soft_guarded
           - rank_top3_borda_inner_confusion_soft_guarded
+          - rank_top2_margin_blend_inner_confusion_soft_guarded
+          - rank_top3_margin_blend_inner_confusion_soft_guarded
           - rank_softmax_inner_balanced_confusion_soft
           - rank_softmax_inner_balanced_confusion_soft_guarded
           - rank_softmax_t1_25_inner_balanced_confusion_soft_guarded
@@ -1573,6 +1588,66 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_adaptive_ranksoft": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128,160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_adaptive_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_c03_c05": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_c03_c05_ranksoft_t0_75": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t0_75",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_top3_margin_blend_pca160": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_top2_quota": {
                   "window_centers": "0.175",
                   "window_size": "0.150",
@@ -1668,6 +1743,21 @@ jobs:
                   "window_centers": "0.175",
                   "window_size": "0.150",
                   "feature_modes": "sensor_flat,sensor_flat_smooth",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_taper_mix": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_taper",
                   "normalizations": "subject_baseline_whiten",
                   "alignments": "none",
                   "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
@@ -1975,6 +2065,52 @@ jobs:
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_top2_margin_blend": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top2_margin_blend",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_top3_margin_blend": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_top3_margin_blend_soft_guarded_inner_confusion": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w125_w150": {
                   "window_centers": "0.175",
                   "window_sizes": "0.125,0.150",
@@ -2037,6 +2173,38 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_shape_ensemble": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_smooth,sensor_flat_dct,sensor_flat_time_pyramid",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "5",
+                  "selection_ensemble_diversity": "window_feature_classifier_param_sample_weighting_score_calibration_pca",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_shape_confusion": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_smooth,sensor_flat_dct,sensor_flat_time_pyramid",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "5",
+                  "selection_ensemble_diversity": "window_feature_classifier_param_sample_weighting_score_calibration_pca",
+                  "selection_ensemble_score_normalization": "rank_softmax_t1_25_inner_confusion_soft_guarded",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -78,9 +78,11 @@ DEFAULT_SENSOR_BANDS = ((4.0, 8.0), (8.0, 13.0), (13.0, 30.0), (30.0, 70.0))
 DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
 DEFAULT_SENSOR_DCT_COEFFICIENTS = 8
 DEFAULT_SENSOR_FLAT_SMOOTH_KERNEL = (0.25, 0.50, 0.25)
+DEFAULT_SENSOR_FLAT_TAPER_FLOOR = 0.25
 BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",
     "sensor_flat_smooth",
+    "sensor_flat_taper",
     "sensor_flat_delta",
     "sensor_flat_dct",
     "sensor_flat_time_pyramid",
@@ -97,6 +99,7 @@ EXTENDED_FEATURE_MODES = (
     "sensor_mean_logpower",
     "sensor_flat_logpower",
     "sensor_flat_smooth",
+    "sensor_flat_taper",
     "sensor_flat_delta",
     "sensor_flat_dct",
     "sensor_flat_time_pyramid",
@@ -216,6 +219,22 @@ TOPK_BORDA_SCORE_NORMALIZATIONS = {
     "rank_top2_borda": 2,
     "rank_top3_borda": 3,
 }
+TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS = {
+    # BUSH-MEG w150 runs now have robust top-2/top-3 signal, but top-1 is
+    # still the bottleneck. The tuple is: (truncated Borda k, sharp rank-softmax
+    # temperature).
+    "rank_top2_margin_blend": (2, 0.75),
+    "rank_top3_margin_blend": (3, 0.75),
+}
+TOPK_MARGIN_BLEND_INNER_CONFUSION_SCORE_NORMALIZATION_BASES = {
+    f"{mode}_inner_confusion_soft_guarded": mode
+    for mode in TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS
+}
+ADAPTIVE_RANK_SOFTMAX_MODE = "rank_adaptive_softmax"
+ADAPTIVE_RANK_SOFTMAX_LOW_TEMPERATURE = 0.75
+ADAPTIVE_RANK_SOFTMAX_HIGH_TEMPERATURE = 1.75
+ADAPTIVE_RANK_SOFTMAX_MARGIN_LOW = 0.25
+ADAPTIVE_RANK_SOFTMAX_MARGIN_HIGH = 1.25
 WORST_CLASS_SELECTION_METRICS = (
     "balanced_worst_class",
     "balanced_worst_class_lcb",
@@ -310,6 +329,8 @@ def install(impl) -> None:
     _install_soft_inner_confusion_score_normalizations(impl)
     _install_guarded_quota_score_normalizations(impl)
     _install_topk_borda_score_normalizations(impl)
+    _install_topk_margin_blend_score_normalizations(impl)
+    _install_adaptive_rank_softmax_score_normalization(impl)
 
     impl._normalize_feature_mode = _normalize_feature_mode
     impl._normalized_config = _normalized_config
@@ -428,19 +449,119 @@ def _install_topk_borda_score_normalizations(impl) -> None:
     )
 
 
+def _install_topk_margin_blend_score_normalizations(impl) -> None:
+    """Expose confidence-gated top-k Borda/rank-softmax pooling modes."""
+
+    impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        TOPK_MARGIN_BLEND_INNER_CONFUSION_SCORE_NORMALIZATION_BASES
+    )
+    impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
+        dict.fromkeys(
+            (
+                *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+                *TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS,
+                *TOPK_MARGIN_BLEND_INNER_CONFUSION_SCORE_NORMALIZATION_BASES,
+            )
+        )
+    )
+
+
+def _install_adaptive_rank_softmax_score_normalization(impl) -> None:
+    """Expose a margin-adaptive rank-softmax normalizer for w150 BUSH runs."""
+
+    impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
+        dict.fromkeys(
+            (
+                *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+                ADAPTIVE_RANK_SOFTMAX_MODE,
+            )
+        )
+    )
+
+
 def _class_score_probabilities(scores, *, score_normalization=None):
-    """Return class probabilities, adding top-k Borda rank normalizers."""
+    """Return class probabilities, adding BUSH-focused rank normalizers."""
 
     if score_normalization is None:
         score_normalization = _impl.DEFAULT_CROSS_SUBJECT_ENSEMBLE_SCORE_NORMALIZATION
     base_mode = _impl._base_ensemble_score_normalization(score_normalization)
+    if base_mode == ADAPTIVE_RANK_SOFTMAX_MODE:
+        return _rank_adaptive_softmax_probabilities(scores)
     top_k = TOPK_BORDA_SCORE_NORMALIZATIONS.get(base_mode)
     if top_k is not None:
         return _rank_topk_borda_probabilities(scores, top_k=top_k)
+    topk_margin_blend = TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS.get(base_mode)
+    if topk_margin_blend is not None:
+        top_k, sharp_temperature = topk_margin_blend
+        return _rank_topk_margin_blend_probabilities(
+            scores,
+            top_k=top_k,
+            sharp_temperature=sharp_temperature,
+        )
     return _previous_class_score_probabilities(
         scores,
         score_normalization=score_normalization,
     )
+
+
+def _rank_adaptive_softmax_probabilities(scores):
+    """Convert ranks to probabilities with a per-trial adaptive temperature."""
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError(
+            "Nested score ensembling requires a non-empty two-dimensional "
+            "class-score matrix."
+        )
+
+    probabilities = np.empty_like(scores, dtype=float)
+    low_temperature = float(ADAPTIVE_RANK_SOFTMAX_LOW_TEMPERATURE)
+    high_temperature = float(ADAPTIVE_RANK_SOFTMAX_HIGH_TEMPERATURE)
+    if low_temperature <= 0.0 or high_temperature <= 0.0:
+        raise ValueError("Adaptive rank-softmax temperatures must be positive.")
+
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        if not np.any(finite):
+            probabilities[row_index] = np.full(
+                row.shape[0],
+                1.0 / row.shape[0],
+                dtype=float,
+            )
+            continue
+
+        confidence = _adaptive_rank_softmax_confidence(row)
+        temperature = high_temperature - confidence * (
+            high_temperature - low_temperature
+        )
+        rank_scores = np.where(finite, row, -np.inf)
+        descending_columns = np.argsort(-rank_scores, kind="mergesort")
+        ranks = np.empty(row.shape[0], dtype=float)
+        ranks[descending_columns] = np.arange(row.shape[0], dtype=float)
+        logits = -ranks / float(temperature)
+        logits[~finite] = -50.0
+        exp_logits = np.exp(logits - np.max(logits))
+        probabilities[row_index] = exp_logits / np.sum(exp_logits)
+    return probabilities
+
+
+def _adaptive_rank_softmax_confidence(row):
+    """Map z-scored top-1/top-2 score separation to a 0..1 confidence."""
+
+    row = np.asarray(row, dtype=float)
+    finite = np.isfinite(row)
+    if int(np.sum(finite)) < 2:
+        return 1.0
+    finite_scores = row[finite]
+    centered = finite_scores - np.mean(finite_scores)
+    scale = float(np.std(centered))
+    if scale > 1e-12:
+        centered = centered / scale
+    ordered = np.sort(centered)[::-1]
+    margin = float(ordered[0] - ordered[1])
+    low = float(ADAPTIVE_RANK_SOFTMAX_MARGIN_LOW)
+    high = float(ADAPTIVE_RANK_SOFTMAX_MARGIN_HIGH)
+    return float(np.clip((margin - low) / max(high - low, 1e-12), 0.0, 1.0))
 
 
 def _rank_topk_borda_probabilities(scores, *, top_k):
@@ -476,6 +597,34 @@ def _rank_topk_borda_probabilities(scores, *, top_k):
         weights[ordered_columns] = np.arange(k, 0, -1, dtype=float)
         probabilities[row_index] = weights / np.sum(weights)
     return probabilities
+
+
+def _rank_topk_margin_blend_probabilities(scores, *, top_k, sharp_temperature):
+    """Blend sharp rank-softmax with truncated top-k Borda by score margin."""
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError(
+            "Nested score ensembling requires a non-empty two-dimensional "
+            "class-score matrix."
+        )
+    sharp = _impl._rank_softmax_probabilities(
+        scores,
+        temperature=float(sharp_temperature),
+    )
+    soft = _rank_topk_borda_probabilities(scores, top_k=top_k)
+    confidence = np.asarray(_impl._rank_margin_blend_confidence(scores), dtype=float)[
+        :, None
+    ]
+    confidence = np.clip(confidence, 0.0, 1.0)
+    blended = confidence * sharp + (1.0 - confidence) * soft
+    row_sums = np.sum(blended, axis=1, keepdims=True)
+    return np.divide(
+        blended,
+        row_sums,
+        out=np.full_like(blended, 1.0 / blended.shape[1]),
+        where=row_sums > 0.0,
+    )
 
 
 def _prediction_group_columns(columns):
@@ -640,6 +789,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_flat_logpower_feature(signal)
         elif feature_mode == "sensor_flat_smooth":
             feature = _sensor_flat_smooth_feature(signal)
+        elif feature_mode == "sensor_flat_taper":
+            feature = _sensor_flat_taper_feature(signal)
         elif feature_mode == "sensor_flat_delta":
             feature = _sensor_flat_delta_feature(signal)
         elif feature_mode == "sensor_flat_dct":
@@ -694,6 +845,31 @@ def _sensor_flat_smooth_feature(window_signal):
     """Return lightly time-smoothed raw evoked samples in sensor_flat layout."""
 
     return _temporal_smooth_signal(window_signal).reshape(-1, order="F")
+
+
+def _sensor_flat_taper_weights(n_samples, floor=DEFAULT_SENSOR_FLAT_TAPER_FLOOR):
+    """Return a smooth nonzero temporal taper for flattened evoked samples."""
+
+    n_samples = int(n_samples)
+    if n_samples <= 0:
+        raise ValueError("sensor_flat_taper requires at least one time sample.")
+    if n_samples == 1:
+        return np.ones(1, dtype=float)
+
+    floor = float(floor)
+    if not 0.0 <= floor <= 1.0:
+        raise ValueError("DEFAULT_SENSOR_FLAT_TAPER_FLOOR must be in [0, 1].")
+    return floor + (1.0 - floor) * np.hanning(n_samples)
+
+
+def _sensor_flat_taper_feature(window_signal):
+    """Return raised-Hann tapered samples in sensor_flat channel-block layout."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    if signal.ndim != 2:
+        raise ValueError("window_signal must be a channel x time matrix.")
+    weights = _sensor_flat_taper_weights(signal.shape[1])
+    return (signal * weights[None, :]).reshape(-1, order="F")
 
 
 def _temporal_smooth_signal(window_signal):
@@ -898,6 +1074,8 @@ def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
         return _sensor_flat_logpower_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_smooth":
         return _sensor_flat_smooth_baseline_statistics(data, config, n_window_samples, trial_indices)
+    if feature_mode == "sensor_flat_taper":
+        return _sensor_flat_taper_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_delta":
         return _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_dct":
@@ -972,6 +1150,25 @@ def _sensor_flat_smooth_baseline_statistics(data, config, n_window_samples, tria
     mean = np.tile(channel_mean, int(n_window_samples))[None, :]
     std = np.tile(channel_std, int(n_window_samples))[None, :]
     return mean, _impl._nonzero_std(std), n_baseline_samples
+
+
+def _sensor_flat_taper_baseline_statistics(data, config, n_window_samples, trial_indices):
+    """Baseline statistics for tapered sensor_flat features."""
+
+    channel_mean, channel_std, n_baseline_samples = _impl._baseline_channel_statistics(
+        data,
+        config.baseline_window,
+        trial_indices,
+    )
+    n_window_samples = int(n_window_samples)
+    weights = _sensor_flat_taper_weights(n_window_samples)
+    n_channels = int(channel_mean.shape[0])
+    flat_mean = np.tile(channel_mean, n_window_samples) * np.repeat(
+        weights,
+        n_channels,
+    )
+    flat_std = np.tile(channel_std, n_window_samples)
+    return flat_mean[None, :], _impl._nonzero_std(flat_std[None, :]), n_baseline_samples
 
 
 def _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial_indices):

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -368,11 +368,85 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_allclose(probabilities[0], np.asarray([3.0, 2.0, 1.0, 0.0]) / 6.0)
         np.testing.assert_allclose(probabilities[1], np.asarray([0.0, 3.0, 2.0, 1.0]) / 6.0)
 
+    def test_topk_margin_blend_score_normalizations_are_exported(self):
+        self.assertIn("rank_top2_margin_blend", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertIn("rank_top3_margin_blend", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+
+        scores = np.asarray(
+            [
+                [4.00, 3.95, 3.90, 0.00],
+                [4.00, 1.00, 0.00, -1.00],
+            ],
+            dtype=float,
+        )
+
+        probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_top3_margin_blend",
+        )
+
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(2))
+        self.assertTrue(np.all(np.isfinite(probabilities)))
+        self.assertTrue(np.all(probabilities >= 0.0))
+        self.assertEqual(int(np.argmax(probabilities[0])), 0)
+        self.assertEqual(int(np.argmax(probabilities[1])), 0)
+        self.assertGreater(probabilities[0, 1], probabilities[1, 1])
+        self.assertGreater(probabilities[1, 0], probabilities[0, 0])
+
+    def test_topk_margin_blend_soft_guarded_inner_confusion_mode_is_exported(self):
+        mode = "rank_top3_margin_blend_inner_confusion_soft_guarded"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_top3_margin_blend",
+        )
+
+        metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            [{"selected_inner_true_predicted_label_pair_counts": "1001:4;1002:2;2002:5"}],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertTrue(metadata["guarded"])
+        self.assertLess(metadata["blend"], 1.0)
+
+    def test_adaptive_rank_softmax_is_exported_and_margin_sensitive(self):
+        mode = "rank_adaptive_softmax"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            mode,
+        )
+
+        scores = np.asarray(
+            [
+                [4.0, 3.95, 2.0, 1.0],
+                [4.0, 0.0, -1.0, -2.0],
+            ],
+            dtype=float,
+        )
+        adaptive = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization=mode,
+        )
+        default = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax",
+        )
+
+        np.testing.assert_allclose(np.sum(adaptive, axis=1), np.ones(2))
+        self.assertLess(adaptive[0, 0], default[0, 0])
+        self.assertGreater(adaptive[1, 0], default[1, 0])
+
     def test_extended_feature_modes_are_exported(self):
         self.assertIn("sensor_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_mean_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_smooth", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_flat_taper", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_delta", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_dct", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_time_pyramid", cross_subject.FEATURE_MODES)
@@ -457,6 +531,58 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
             feature_set.features[0],
             np.asarray([1.5, 2.5, 3.0, 4.0, 4.5, 5.5]),
         )
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_taper_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0, 5.0], [0.0, 0.0, 2.0, 4.0, 6.0]],
+            [[0.0, 0.0, 2.0, 4.0, 6.0], [0.0, 0.0, 1.0, 3.0, 5.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            feature_mode="sensor_flat_taper",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        np.testing.assert_allclose(
+            feature_set.features[0],
+            np.asarray([0.25, 0.50, 3.00, 4.00, 1.25, 1.50]),
+        )
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_taper_baseline_whiten_allows_different_baseline_duration(self):
+        time = np.asarray([-0.3, -0.2, -0.1, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.1, 0.2, 0.3, 1.0, 3.0, 5.0], [0.4, 0.5, 0.6, 2.0, 4.0, 6.0]],
+            [[0.2, 0.3, 0.4, 2.0, 4.0, 6.0], [0.5, 0.6, 0.7, 1.0, 3.0, 5.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            baseline_window=(-0.3, -0.1),
+            feature_mode="sensor_flat_taper",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 6))
+        self.assertEqual(feature_set.baseline_feature_std.shape, (1, 6))
+        self.assertTrue(np.all(feature_set.baseline_feature_std > 0.0))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
     def test_sensor_flat_smooth_baseline_whiten_allows_different_baseline_duration(self):


### PR DESCRIPTION
## Summary
- add adaptive rank-softmax score normalization for BUSH w150 ensembles
- add tapered sensor-flat features and workflow bundle
- add w150 workflow bundles for adaptive rank-softmax, taper, margin blend, PCA confirmation, and shape variants

## Validation
- python -m py_compile src\\pymegdec\\_stimulus_cross_subject_next.py tests\\test_stimulus_cross_subject_next.py
- python -c " import yaml pathlib