### PR TITLE
Add BUSH w150 ANOVA and PCA bundles

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -94,6 +94,10 @@ on:
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
           - windowed_logreg_175_w150_adaptive_ranksoft
+          - windowed_logreg_175_w150_source_anova_sqrt
+          - windowed_logreg_175_w150_pca160
+          - windowed_logreg_175_w150_pca160_ranksoft_t0_75
+          - windowed_logreg_175_w150_pca160_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_pca160_c03_c05
           - windowed_logreg_175_w150_pca160_c03_c05_ranksoft_t0_75
           - windowed_logreg_175_w150_top3_margin_blend_pca160
@@ -1600,6 +1604,67 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_adaptive_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_source_anova_sqrt": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "feature_transforms": "none,source_anova_sqrt_scale",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_ranksoft_t0_75": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t0_75",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_soft_guarded_inner_confusion": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_soft_guarded",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -1732,6 +1732,10 @@ def _ensemble_diversity_key(config, diversity):
         f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
         f"feature={config.feature_mode},norm={config.normalization},alignment={config.alignment},"
         f"classifier={config.classifier},param={config.classifier_param},pca={config.components_pca},"
+        f"sample_weighting={getattr(config, 'sample_weighting', 'none')},"
+        f"score_calibration={getattr(config, 'score_calibration', 'none')},"
+        f"feature_transform={getattr(config, 'feature_transform', 'none')},"
+        f"alignment_alpha={getattr(config, 'alignment_alpha', 1.0)},"
         f"trial_cap={config.max_trials_per_class_per_participant}"
     )
 

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -20,7 +20,14 @@ DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING = "none"
 SAMPLE_WEIGHTING_MODES = ("none", "subject_class_balanced")
 DEFAULT_CROSS_SUBJECT_SCORE_CALIBRATION = "none"
 DEFAULT_CROSS_SUBJECT_FEATURE_TRANSFORM = "none"
-FEATURE_TRANSFORM_MODES = ("none", "source_anova_scale")
+FEATURE_TRANSFORM_MODES = ("none", "source_anova_scale", "source_anova_sqrt_scale")
+SOURCE_ANOVA_FEATURE_TRANSFORM_MODES = frozenset(
+    ("source_anova_scale", "source_anova_sqrt_scale")
+)
+SOURCE_ANOVA_FEATURE_TRANSFORM_POWERS = {
+    "source_anova_scale": 1.0,
+    "source_anova_sqrt_scale": 0.5,
+}
 SOURCE_ANOVA_FEATURE_TRANSFORM_MIN_WEIGHT = 0.25
 SOURCE_ANOVA_FEATURE_TRANSFORM_MAX_WEIGHT = 4.0
 SOURCE_ANOVA_FEATURE_TRANSFORM_EPSILON = 1e-12
@@ -1361,14 +1368,24 @@ def _fit_training_feature_transform(train_features, train_sets, config, *, train
     train_features = np.asarray(train_features, dtype=float)
     if mode == "none":
         return train_features, None
-    if mode != "source_anova_scale":
+    if mode not in SOURCE_ANOVA_FEATURE_TRANSFORM_MODES:
         raise ValueError(f"Unsupported feature_transform: {mode}")
 
     labels = _feature_transform_labels(train_sets, train_features, train_labels)
     weights, diagnostics = _source_anova_feature_weights(train_features, labels)
+    power = float(SOURCE_ANOVA_FEATURE_TRANSFORM_POWERS[mode])
+    if not np.isclose(power, 1.0):
+        # ``source_anova_scale`` already normalizes weights to a median of roughly
+        # one.  Applying a fractional power shrinks both boosts and suppressions
+        # back toward one without changing their ordering, which gives a
+        # conservative source-only alternative for high-dimensional MEG windows.
+        weights = np.power(weights, power)
+    diagnostics = dict(diagnostics)
+    diagnostics["feature_transform_status"] = f"fitted_{mode}"
     transformed = train_features * weights[None, :]
     return transformed, {
         "mode": mode,
+        "feature_transform_power": power,
         "feature_weights": weights,
         "weight_min": float(np.min(weights)) if weights.size else np.nan,
         "weight_max": float(np.max(weights)) if weights.size else np.nan,
@@ -1456,7 +1473,7 @@ def _source_anova_feature_weights(features, labels):
 def _has_active_feature_transform_metadata(metadata):
     return (
         isinstance(metadata, dict)
-        and metadata.get("mode") == "source_anova_scale"
+        and metadata.get("mode") in SOURCE_ANOVA_FEATURE_TRANSFORM_MODES
         and "feature_weights" in metadata
     )
 

--- a/tests/test_source_anova_feature_transform.py
+++ b/tests/test_source_anova_feature_transform.py
@@ -18,13 +18,14 @@ def test_make_candidate_configs_expands_source_anova_feature_transform():
         classifiers=("multinomial-logistic",),
         classifier_params=(1.0,),
         components_pca_values=(128,),
-        feature_transforms=("none", "source_anova_scale"),
+        feature_transforms=("none", "source_anova_scale", "source_anova_sqrt_scale"),
         chance_classes=16,
     )
 
     assert [config.feature_transform for config in configs] == [
         "none",
         "source_anova_scale",
+        "source_anova_sqrt_scale",
     ]
 
 
@@ -61,4 +62,48 @@ def test_source_anova_feature_transform_scales_discriminative_dimensions():
             np.ones((1, 2)), metadata
         ),
         weights[None, :],
+    )
+
+
+def test_source_anova_sqrt_feature_transform_is_conservative():
+    train_features = np.asarray(
+        [
+            [-2.0, -0.4],
+            [-1.8, -0.2],
+            [1.8, 0.2],
+            [2.0, 0.4],
+        ],
+        dtype=float,
+    )
+    train_labels = np.asarray([0, 0, 1, 1], dtype=int)
+    train_sets = (
+        SimpleNamespace(labels=np.asarray([1, 1])),
+        SimpleNamespace(labels=np.asarray([2, 2])),
+    )
+
+    full_config = CrossSubjectStimulusConfig(
+        feature_transform="source_anova_scale", chance_classes=2
+    )
+    sqrt_config = CrossSubjectStimulusConfig(
+        feature_transform="source_anova_sqrt_scale", chance_classes=2
+    )
+    _full_transformed, full_metadata = cross_subject._fit_training_feature_transform(  # pylint: disable=protected-access
+        train_features, train_sets, full_config, train_labels=train_labels
+    )
+    transformed, metadata = cross_subject._fit_training_feature_transform(  # pylint: disable=protected-access
+        train_features, train_sets, sqrt_config, train_labels=train_labels
+    )
+
+    assert metadata["mode"] == "source_anova_sqrt_scale"
+    assert metadata["feature_transform_power"] == 0.5
+    full_weights = full_metadata["feature_weights"]
+    sqrt_weights = metadata["feature_weights"]
+    assert 1.0 < sqrt_weights[0] < full_weights[0]
+    assert full_weights[1] < sqrt_weights[1] < 1.0
+    np.testing.assert_allclose(transformed, train_features * sqrt_weights[None, :])
+    np.testing.assert_allclose(
+        cross_subject._apply_training_feature_transform(  # pylint: disable=protected-access
+            np.ones((1, 2)), metadata
+        ),
+        sqrt_weights[None, :],
     )


### PR DESCRIPTION
﻿## Summary
- add source_anova_sqrt_scale feature transform for source-only BUSH runs
- include transform metadata and diversity keys for feature-transform-aware ensembles
- add w150 PCA-160 confirmation workflow bundles

## Validation
- python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_source_anova_feature_transform.py
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"
- git diff --check; git diff --cached --check

Tests were not run per request.
