### PR TITLE
Add Gaussian taper and PCA c-grid bundles

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -100,6 +100,9 @@ on:
           - windowed_logreg_175_w150_pca160_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_pca160_c03_c05
           - windowed_logreg_175_w150_pca160_c03_c05_ranksoft_t0_75
+          - windowed_logreg_175_w150_pca160_cgrid
+          - windowed_logreg_175_w150_pca160_cgrid_top3_margin
+          - windowed_logreg_175_w150_pca160_cgrid_inner_confusion_guarded
           - windowed_logreg_175_w150_top3_margin_blend_pca160
           - windowed_logreg_175_w150_top2_quota
           - windowed_logreg_175_w150_top3_quota
@@ -118,6 +121,7 @@ on:
           - windowed_logreg_175_w150_guarded_scorecal_sweep
           - windowed_logreg_175_w150_t15_soft_guarded_inner_prior_confusion
           - windowed_logreg_175_w150_rank_consensus
+          - windowed_logreg_175_w150_gaussian_taper_mix
           - windowed_logreg_175_w150_ranksoft_t0_5
           - windowed_logreg_175_w150_ranksoft_t0_75
           - windowed_logreg_175_w150_ranksoft_t1_25
@@ -1698,6 +1702,65 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_pca160_cgrid": {
+                  # Distilled from the 175 ms / 150 ms finetune: PCA 160 was
+                  # selected in most outer folds, while C values 0.3, 0.5, 1,
+                  # and 2 all appeared among the top inner-LOSO candidates.
+                  # This keeps the promising candidate family but halves the
+                  # 128/160 finetune grid from 16 to 8 candidates.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5,1,2",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_cgrid_top3_margin": {
+                  # Same PCA-160 confirmation grid, but uses the existing
+                  # top-3/margin-blend scorer to exploit the strong top-2/top-3
+                  # BUSH signal while keeping all tuning source-inner only.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5,1,2",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_cgrid_inner_confusion_guarded": {
+                  # Conservative source-inner confusion reranking on the same
+                  # PCA-160 C-grid. The guarded variant is designed to avoid
+                  # large corrections unless the source-inner confusion pattern
+                  # has support.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5,1,2",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_top3_margin_blend_pca160": {
                   "window_centers": "0.175",
                   "window_size": "0.150",
@@ -1823,6 +1886,21 @@ jobs:
                   "window_centers": "0.175",
                   "window_size": "0.150",
                   "feature_modes": "sensor_flat,sensor_flat_taper",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_gaussian_taper_mix": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_gaussian_taper",
                   "normalizations": "subject_baseline_whiten",
                   "alignments": "none",
                   "classifiers": "multinomial-logistic,multinomial-logistic-weighted",

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -86,10 +86,13 @@ DEFAULT_SENSOR_TIME_PYRAMID_LEVELS = (1, 2, 4)
 DEFAULT_SENSOR_DCT_COEFFICIENTS = 8
 DEFAULT_SENSOR_FLAT_SMOOTH_KERNEL = (0.25, 0.50, 0.25)
 DEFAULT_SENSOR_FLAT_TAPER_FLOOR = 0.25
+DEFAULT_SENSOR_FLAT_GAUSSIAN_TAPER_FLOOR = 0.25
+DEFAULT_SENSOR_FLAT_GAUSSIAN_TAPER_SIGMA = 0.50
 BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",
     "sensor_flat_smooth",
     "sensor_flat_taper",
+    "sensor_flat_gaussian_taper",
     "sensor_flat_delta",
     "sensor_flat_dct",
     "sensor_flat_time_pyramid",
@@ -107,6 +110,7 @@ EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",
     "sensor_flat_smooth",
     "sensor_flat_taper",
+    "sensor_flat_gaussian_taper",
     "sensor_flat_delta",
     "sensor_flat_dct",
     "sensor_flat_time_pyramid",
@@ -798,6 +802,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_flat_smooth_feature(signal)
         elif feature_mode == "sensor_flat_taper":
             feature = _sensor_flat_taper_feature(signal)
+        elif feature_mode == "sensor_flat_gaussian_taper":
+            feature = _sensor_flat_gaussian_taper_feature(signal)
         elif feature_mode == "sensor_flat_delta":
             feature = _sensor_flat_delta_feature(signal)
         elif feature_mode == "sensor_flat_dct":
@@ -876,6 +882,50 @@ def _sensor_flat_taper_feature(window_signal):
     if signal.ndim != 2:
         raise ValueError("window_signal must be a channel x time matrix.")
     weights = _sensor_flat_taper_weights(signal.shape[1])
+    return (signal * weights[None, :]).reshape(-1, order="F")
+
+
+def _sensor_flat_gaussian_taper_weights(
+    n_samples,
+    *,
+    floor=DEFAULT_SENSOR_FLAT_GAUSSIAN_TAPER_FLOOR,
+    sigma=DEFAULT_SENSOR_FLAT_GAUSSIAN_TAPER_SIGMA,
+):
+    """Return a broad Gaussian temporal taper for flattened evoked samples.
+
+    The current best BUSH-MEG source-only result uses a wider 150 ms window,
+    suggesting that useful information is spread across the early visual
+    response.  This taper keeps the same feature width and channel-block layout
+    as ``sensor_flat`` but softly emphasizes the window center instead of giving
+    the low-SNR window edges equal weight.
+    """
+
+    n_samples = int(n_samples)
+    if n_samples <= 0:
+        raise ValueError("sensor_flat_gaussian_taper requires at least one time sample.")
+    if n_samples == 1:
+        return np.ones(1, dtype=float)
+
+    floor = float(floor)
+    sigma = float(sigma)
+    if not 0.0 <= floor <= 1.0:
+        raise ValueError("DEFAULT_SENSOR_FLAT_GAUSSIAN_TAPER_FLOOR must be in [0, 1].")
+    if sigma <= 0.0:
+        raise ValueError("DEFAULT_SENSOR_FLAT_GAUSSIAN_TAPER_SIGMA must be positive.")
+
+    positions = np.linspace(-1.0, 1.0, n_samples, dtype=float)
+    weights = np.exp(-0.5 * np.square(positions / sigma))
+    weights /= float(np.max(weights))
+    return floor + (1.0 - floor) * weights
+
+
+def _sensor_flat_gaussian_taper_feature(window_signal):
+    """Return Gaussian-tapered samples in sensor_flat channel-block layout."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    if signal.ndim != 2:
+        raise ValueError("window_signal must be a channel x time matrix.")
+    weights = _sensor_flat_gaussian_taper_weights(signal.shape[1])
     return (signal * weights[None, :]).reshape(-1, order="F")
 
 
@@ -1083,6 +1133,13 @@ def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
         return _sensor_flat_smooth_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_taper":
         return _sensor_flat_taper_baseline_statistics(data, config, n_window_samples, trial_indices)
+    if feature_mode == "sensor_flat_gaussian_taper":
+        return _sensor_flat_gaussian_taper_baseline_statistics(
+            data,
+            config,
+            n_window_samples,
+            trial_indices,
+        )
     if feature_mode == "sensor_flat_delta":
         return _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_dct":
@@ -1175,6 +1232,28 @@ def _sensor_flat_taper_baseline_statistics(data, config, n_window_samples, trial
         n_channels,
     )
     flat_std = np.tile(channel_std, n_window_samples)
+    return flat_mean[None, :], _impl._nonzero_std(flat_std[None, :]), n_baseline_samples
+
+
+def _sensor_flat_gaussian_taper_baseline_statistics(
+    data,
+    config,
+    n_window_samples,
+    trial_indices,
+):
+    """Baseline statistics for Gaussian-tapered sensor_flat features."""
+
+    channel_mean, channel_std, n_baseline_samples = _impl._baseline_channel_statistics(
+        data,
+        config.baseline_window,
+        trial_indices,
+    )
+    n_window_samples = int(n_window_samples)
+    weights = _sensor_flat_gaussian_taper_weights(n_window_samples)
+    n_channels = int(channel_mean.shape[0])
+    repeated_weights = np.repeat(weights, n_channels)
+    flat_mean = np.tile(channel_mean, n_window_samples) * repeated_weights
+    flat_std = np.tile(channel_std, n_window_samples) * repeated_weights
     return flat_mean[None, :], _impl._nonzero_std(flat_std[None, :]), n_baseline_samples
 
 

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -447,6 +447,7 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertIn("sensor_flat_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_smooth", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_taper", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_flat_gaussian_taper", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_delta", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_dct", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_time_pyramid", cross_subject.FEATURE_MODES)
@@ -559,6 +560,33 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         )
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
+    def test_sensor_flat_gaussian_taper_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0, 5.0], [0.0, 0.0, 2.0, 4.0, 6.0]],
+            [[0.0, 0.0, 2.0, 4.0, 6.0], [0.0, 0.0, 1.0, 3.0, 5.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            feature_mode="sensor_flat_gaussian_taper",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        weights = cross_subject._sensor_flat_gaussian_taper_weights(3)  # pylint: disable=protected-access
+        expected = np.asarray([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]) * np.repeat(weights, 2)
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        np.testing.assert_allclose(feature_set.features[0], expected)
+        self.assertGreater(weights[1], weights[0])
+        self.assertGreater(weights[1], weights[2])
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
     def test_sensor_flat_taper_baseline_whiten_allows_different_baseline_duration(self):
         time = np.asarray([-0.3, -0.2, -0.1, 0.1, 0.2, 0.3], dtype=float)
         trials = [
@@ -571,6 +599,32 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
             window_size=0.2,
             baseline_window=(-0.3, -0.1),
             feature_mode="sensor_flat_taper",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 6))
+        self.assertEqual(feature_set.baseline_feature_std.shape, (1, 6))
+        self.assertTrue(np.all(feature_set.baseline_feature_std > 0.0))
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_gaussian_taper_baseline_whiten_allows_different_baseline_duration(self):
+        time = np.asarray([-0.3, -0.2, -0.1, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.1, 0.2, 0.3, 1.0, 3.0, 5.0], [0.4, 0.5, 0.6, 2.0, 4.0, 6.0]],
+            [[0.2, 0.3, 0.4, 2.0, 4.0, 6.0], [0.5, 0.6, 0.7, 1.0, 3.0, 5.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            baseline_window=(-0.3, -0.1),
+            feature_mode="sensor_flat_gaussian_taper",
             normalization="subject_baseline_whiten",
             components_pca=float("inf"),
             chance_classes=2,


### PR DESCRIPTION
Summary
- Add baseline-whitened sensor-flat Gaussian taper features and tests.
- Add PCA-160 C-grid workflow bundles for BUSH follow-up runs.

Validation
- python -m py_compile src\\pymegdec\\_stimulus_cross_subject_next.py tests\\test_stimulus_cross_subject_next.py
- YAML workflow parse
- git diff --check

Tests were not run per request.