### PR TITLE
Add compact PCA160 score calibration bundle

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -100,6 +100,7 @@ on:
           - windowed_logreg_175_w150_pca160_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_pca160_c03_c05
           - windowed_logreg_175_w150_pca160_c03_c05_ranksoft_t0_75
+          - windowed_logreg_175_w150_pca160_c03_c05_scorecal
           - windowed_logreg_175_w150_pca160_cgrid
           - windowed_logreg_175_w150_pca160_cgrid_top3_margin
           - windowed_logreg_175_w150_pca160_cgrid_inner_confusion_guarded
@@ -1699,6 +1700,25 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_t0_75",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_c03_c05_scorecal": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "sample_weightings": "none",
+                  "score_calibrations": "none,inner_class_bias,inner_rank_bias_guarded",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },


### PR DESCRIPTION
Adds a narrow source-only score-calibration bundle around the current BUSH-MEG winning regime.

Configuration:
- 175 ms center, 150 ms window
- sensor_flat, subject_baseline_whiten, no alignment
- multinomial logistic and weighted logistic
- C values 0.3 and 0.5
- PCA 160
- score calibration candidates: none, inner_class_bias, inner_rank_bias_guarded
- rank-aware inner selection objective

This prepares the follow-up calibration run after the compact PCA-160 confirmation runs complete.

Validation:
- Parsed `.github/workflows/stimulus-cross-subject-nested-matrix.yml` with PyYAML and verified the new bundle option is present.