### PR TITLE
Add ranking and centered feature followups

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -96,6 +96,7 @@ on:
           - windowed_logreg_175_w150_adaptive_ranksoft
           - windowed_logreg_175_w150_source_anova_sqrt
           - windowed_logreg_175_w150_pca160
+          - windowed_logreg_175_w150_pca160_guarded_test_prior
           - windowed_logreg_175_w150_pca160_ranksoft_t0_75
           - windowed_logreg_175_w150_pca160_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_pca160_c03_c05
@@ -124,6 +125,7 @@ on:
           - windowed_logreg_175_w150_guarded_scorecal_sweep
           - windowed_logreg_175_w150_t15_soft_guarded_inner_prior_confusion
           - windowed_logreg_175_w150_rank_consensus
+          - windowed_logreg_175_w150_adaptive_ranksoft_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_gaussian_taper_mix
           - windowed_logreg_175_w150_ranksoft_t0_5
           - windowed_logreg_175_w150_ranksoft_t0_75
@@ -136,6 +138,8 @@ on:
           - windowed_logreg_175_w150_top2_borda_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_top3_borda_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_top2_margin_blend
+          - windowed_logreg_175_w150_pca160_top3_score_softmax
+          - windowed_logreg_175_w150_pca160_top3_score_softmax_inner_confusion
           - windowed_logreg_175_w150_top3_margin_blend
           - windowed_logreg_175_w150_top3_margin_blend_soft_guarded_inner_confusion
           - windowed_logreg_175_w125_w150
@@ -147,6 +151,7 @@ on:
           - windowed_logreg_200_w150
           - windowed_logreg_175_w150_temporal_delta
           - windowed_logreg_175_w150_shape_ensemble
+          - windowed_logreg_175_w150_centered_ensemble
           - windowed_logreg_175_w150_shape_confusion
           - windowed_logreg_175_inner_prior
           - windowed_logreg_175_inner_prior_quota
@@ -201,6 +206,8 @@ on:
           - rank_top2_borda
           - rank_top3_borda
           - rank_top2_margin_blend
+          - rank_top2_score_softmax
+          - rank_top3_score_softmax
           - rank_top3_margin_blend
           - rank_margin_blend
           - rank_adaptive_softmax
@@ -220,9 +227,14 @@ on:
           - rank_margin_blend_inner_confusion_soft
           - rank_margin_blend_inner_confusion_soft_guarded
           - rank_consensus
+          - rank_adaptive_softmax_inner_confusion_soft_guarded
           - rank_softmax_test_prior_balance
           - rank_softmax_t2_test_prior_balance
           - rank_softmax_t3_test_prior_balance
+          - rank_softmax_guarded_test_prior_balance
+          - rank_softmax_t0_75_guarded_test_prior_balance
+          - rank_softmax_t1_5_guarded_test_prior_balance
+          - rank_top3_margin_blend_guarded_test_prior_balance
           - rank_reciprocal_test_prior_balance
           - rank_borda_test_prior_balance
           - rank_z_blend_test_prior_balance
@@ -306,6 +318,8 @@ on:
           - rank_top2_borda_inner_confusion_soft_guarded
           - rank_top3_borda_inner_confusion_soft_guarded
           - rank_top2_margin_blend_inner_confusion_soft_guarded
+          - rank_top2_score_softmax_inner_confusion_soft_guarded
+          - rank_top3_score_softmax_inner_confusion_soft_guarded
           - rank_top3_margin_blend_inner_confusion_soft_guarded
           - rank_softmax_inner_balanced_confusion_soft
           - rank_softmax_inner_balanced_confusion_soft_guarded
@@ -1645,6 +1659,21 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_pca160_guarded_test_prior": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_guarded_test_prior_balance",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_pca160_ranksoft_t0_75": {
                   "window_centers": "0.175",
                   "window_size": "0.150",
@@ -1673,6 +1702,37 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_soft_guarded",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_top3_score_softmax": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_score_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_top3_score_softmax_inner_confusion": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_score_softmax_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_w150_pca160_c03_c05": {
@@ -2106,6 +2166,22 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_adaptive_ranksoft_soft_guarded_inner_confusion": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_adaptive_softmax_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_ranksoft_t0_5": {
                   "window_centers": "0.175",
                   "window_size": "0.150",
@@ -2383,6 +2459,22 @@ jobs:
                   "components_pca_values": "128",
                   "selection_metric": "balanced_top2_top3_rank_lcb",
                   "selection_ensemble_size": "5",
+                  "selection_ensemble_diversity": "window_feature_classifier_param_sample_weighting_score_calibration_pca",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_centered_ensemble": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_centered",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128,160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "window_feature_classifier_param_sample_weighting_score_calibration_pca",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass, fields
 from itertools import product
+from math import isfinite
 
 import numpy as np
 from pymegdec.classifiers import get_default_classifier_param, should_use_default_classifier_param, train_multiclass_classifier
@@ -97,6 +98,7 @@ BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_smooth",
     "sensor_flat_taper",
     "sensor_flat_gaussian_taper",
+    "sensor_flat_centered",
     "sensor_flat_delta",
     "sensor_flat_dct",
     "sensor_flat_time_pyramid",
@@ -116,6 +118,7 @@ EXTENDED_FEATURE_MODES = (
     "sensor_flat_smooth",
     "sensor_flat_taper",
     "sensor_flat_gaussian_taper",
+    "sensor_flat_centered",
     "sensor_flat_delta",
     "sensor_flat_dct",
     "sensor_flat_time_pyramid",
@@ -232,9 +235,27 @@ EXPERIMENTAL_GUARDED_QUOTA_BASE_MODES = (
 EXPERIMENTAL_GUARDED_QUOTA_SCORE_NORMALIZATIONS = tuple(
     f"{mode}_guarded_balanced_quota" for mode in EXPERIMENTAL_GUARDED_QUOTA_BASE_MODES
 )
+GUARDED_TEST_PRIOR_BALANCE_SUFFIX = "_guarded_test_prior_balance"
+GUARDED_TEST_PRIOR_BALANCE_MARGIN_QUANTILE = 0.50
+GUARDED_TEST_PRIOR_BALANCE_BASE_MODES = (
+    "rank_softmax",
+    "rank_softmax_t0_75",
+    "rank_softmax_t1_25",
+    "rank_softmax_t1_5",
+    "rank_softmax_t1_75",
+    "rank_top3_margin_blend",
+)
+GUARDED_TEST_PRIOR_BALANCE_SCORE_NORMALIZATIONS = tuple(
+    f"{mode}{GUARDED_TEST_PRIOR_BALANCE_SUFFIX}"
+    for mode in GUARDED_TEST_PRIOR_BALANCE_BASE_MODES
+)
 TOPK_BORDA_SCORE_NORMALIZATIONS = {
     "rank_top2_borda": 2,
     "rank_top3_borda": 3,
+}
+TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS = {
+    "rank_top2_score_softmax": 2,
+    "rank_top3_score_softmax": 3,
 }
 TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS = {
     # BUSH-MEG w150 runs now have robust top-2/top-3 signal, but top-1 is
@@ -243,11 +264,18 @@ TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS = {
     "rank_top2_margin_blend": (2, 0.75),
     "rank_top3_margin_blend": (3, 0.75),
 }
+TOPK_SCORE_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES = {
+    f"{mode}_inner_confusion_soft_guarded": mode
+    for mode in TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS
+}
 TOPK_MARGIN_BLEND_INNER_CONFUSION_SCORE_NORMALIZATION_BASES = {
     f"{mode}_inner_confusion_soft_guarded": mode
     for mode in TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS
 }
 ADAPTIVE_RANK_SOFTMAX_MODE = "rank_adaptive_softmax"
+ADAPTIVE_RANK_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES = {
+    f"{ADAPTIVE_RANK_SOFTMAX_MODE}_inner_confusion_soft_guarded": ADAPTIVE_RANK_SOFTMAX_MODE,
+}
 ADAPTIVE_RANK_SOFTMAX_LOW_TEMPERATURE = 0.75
 ADAPTIVE_RANK_SOFTMAX_HIGH_TEMPERATURE = 1.75
 ADAPTIVE_RANK_SOFTMAX_MARGIN_LOW = 0.25
@@ -277,6 +305,10 @@ _previous_prediction_rows = None
 _previous_summarize_smoke = None
 _previous_summarize_nested = None
 _previous_rank_nested_candidates = None
+_previous_without_test_prior_balance_suffix = None
+_previous_test_class_prior_balance_mode = None
+_previous_test_class_prior_balance_metadata = None
+_previous_add_test_class_prior_balance_fields = None
 
 CrossSubjectStimulusConfig = None
 
@@ -290,6 +322,8 @@ def install(impl) -> None:
     global _previous_score_outer_fold_model, _previous_candidate_model_scores, _previous_align_training_features_by_subject
     global _previous_align_test_features_by_subject, _previous_prediction_rows, _previous_summarize_smoke
     global _previous_summarize_nested, _previous_rank_nested_candidates, _previous_class_score_probabilities
+    global _previous_without_test_prior_balance_suffix, _previous_test_class_prior_balance_mode
+    global _previous_test_class_prior_balance_metadata, _previous_add_test_class_prior_balance_fields
 
     if getattr(impl, "_next_methods_installed", False):
         return
@@ -313,6 +347,10 @@ def install(impl) -> None:
     _previous_summarize_smoke = impl.summarize_cross_subject_stimulus_smoke
     _previous_summarize_nested = impl.summarize_nested_cross_subject_stimulus
     _previous_rank_nested_candidates = impl._rank_nested_candidates
+    _previous_without_test_prior_balance_suffix = impl._without_test_prior_balance_suffix
+    _previous_test_class_prior_balance_mode = impl._test_class_prior_balance_mode
+    _previous_test_class_prior_balance_metadata = impl._test_class_prior_balance_metadata
+    _previous_add_test_class_prior_balance_fields = impl._add_test_class_prior_balance_fields
 
     @dataclass(frozen=True)
     class NextCrossSubjectStimulusConfig(_BaseConfig):
@@ -345,7 +383,9 @@ def install(impl) -> None:
     _install_intermediate_rank_softmax_temperatures(impl)
     _install_soft_inner_confusion_score_normalizations(impl)
     _install_guarded_quota_score_normalizations(impl)
+    _install_guarded_test_prior_balance_score_normalizations(impl)
     _install_topk_borda_score_normalizations(impl)
+    _install_topk_score_softmax_score_normalizations(impl)
     _install_topk_margin_blend_score_normalizations(impl)
     _install_adaptive_rank_softmax_score_normalization(impl)
 
@@ -361,6 +401,11 @@ def install(impl) -> None:
     impl._fit_training_feature_transform = _fit_training_feature_transform
     impl._apply_training_feature_transform = _apply_training_feature_transform
     impl._score_outer_fold_model = _score_outer_fold_model
+    impl._without_test_prior_balance_suffix = _without_test_prior_balance_suffix
+    impl._test_class_prior_balance_mode = _test_class_prior_balance_mode
+    impl._test_class_prior_balance_metadata = _test_class_prior_balance_metadata
+    impl._add_test_class_prior_balance_fields = _add_test_class_prior_balance_fields
+    impl._guarded_test_prior_balance_probabilities = _guarded_test_prior_balance_probabilities
     impl._class_score_probabilities = _class_score_probabilities
     impl._candidate_model_scores = _candidate_model_scores
     impl._apply_score_calibration = _apply_score_calibration
@@ -416,6 +461,9 @@ def _install_soft_inner_confusion_score_normalizations(impl) -> None:
         TOPK_BORDA_INNER_CONFUSION_SCORE_NORMALIZATION_BASES
     )
     impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        TOPK_SCORE_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES
+    )
+    impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
         INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_BASES
     )
     impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
@@ -424,6 +472,9 @@ def _install_soft_inner_confusion_score_normalizations(impl) -> None:
     impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
         INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_CONFUSION_BASES
     )
+    impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        ADAPTIVE_RANK_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES
+    )
     impl.INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
         SOFT_INNER_BALANCED_CONFUSION_SCORE_NORMALIZATION_BASES
     )
@@ -431,9 +482,11 @@ def _install_soft_inner_confusion_score_normalizations(impl) -> None:
         *tuple(SOFT_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
         *tuple(TOPK_BORDA_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
         *tuple(SOFT_GUARDED_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
+        *tuple(TOPK_SCORE_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
         *tuple(INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_BASES),
         *tuple(INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_MARGIN_BASES),
         *tuple(INTERMEDIATE_RANK_SOFTMAX_GUARDED_INNER_CONFUSION_BASES),
+        *tuple(ADAPTIVE_RANK_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
         *tuple(SOFT_INNER_BALANCED_CONFUSION_SCORE_NORMALIZATION_BASES),
     )
     impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
@@ -454,6 +507,19 @@ def _install_guarded_quota_score_normalizations(impl) -> None:
     )
 
 
+def _install_guarded_test_prior_balance_score_normalizations(impl) -> None:
+    """Expose margin-gated unlabeled test-prior balancing modes."""
+
+    impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
+        dict.fromkeys(
+            (
+                *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+                *GUARDED_TEST_PRIOR_BALANCE_SCORE_NORMALIZATIONS,
+            )
+        )
+    )
+
+
 def _install_topk_borda_score_normalizations(impl) -> None:
     """Expose truncated-Borda rank pooling for source-only score ensembles."""
 
@@ -462,6 +528,19 @@ def _install_topk_borda_score_normalizations(impl) -> None:
             (
                 *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
                 *TOPK_BORDA_SCORE_NORMALIZATIONS,
+            )
+        )
+    )
+
+
+def _install_topk_score_softmax_score_normalizations(impl) -> None:
+    """Expose top-k score-softmax rank pooling for source-only ensembles."""
+
+    impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
+        dict.fromkeys(
+            (
+                *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+                *TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS,
             )
         )
     )
@@ -492,8 +571,132 @@ def _install_adaptive_rank_softmax_score_normalization(impl) -> None:
             (
                 *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
                 ADAPTIVE_RANK_SOFTMAX_MODE,
+                *ADAPTIVE_RANK_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES,
             )
         )
+    )
+
+
+def _without_test_prior_balance_suffix(score_normalization):
+    score_normalization = str(score_normalization).strip()
+    if score_normalization.endswith(GUARDED_TEST_PRIOR_BALANCE_SUFFIX):
+        return score_normalization.removesuffix(GUARDED_TEST_PRIOR_BALANCE_SUFFIX)
+    return _previous_without_test_prior_balance_suffix(score_normalization)
+
+
+def _test_class_prior_balance_mode(score_normalization):
+    normalized = str(score_normalization).strip().lower().replace("-", "_")
+    if (
+        normalized in _impl.ENSEMBLE_SCORE_NORMALIZATION_MODES
+        and normalized.endswith(GUARDED_TEST_PRIOR_BALANCE_SUFFIX)
+    ):
+        return normalized
+    return _previous_test_class_prior_balance_mode(score_normalization)
+
+
+def _test_class_prior_balance_metadata(probabilities, class_order, score_normalization):
+    """Return metadata for legacy or guarded held-out test-prior balancing."""
+
+    mode = _test_class_prior_balance_mode(score_normalization)
+    if mode is None or not str(mode).endswith(GUARDED_TEST_PRIOR_BALANCE_SUFFIX):
+        return _previous_test_class_prior_balance_metadata(
+            probabilities,
+            class_order,
+            score_normalization,
+        )
+
+    full_adjusted, target_mass, iterations, status = _impl._test_class_prior_balanced_probabilities(probabilities)
+    guarded_adjusted, adjusted_trials, margin_threshold = _guarded_test_prior_balance_probabilities(
+        probabilities,
+        full_adjusted,
+    )
+    guarded_status = f"{status}_guarded" if str(status).startswith("applied") else status
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    probabilities = np.asarray(probabilities, dtype=float)
+    observed_mass = (
+        np.sum(probabilities, axis=0)
+        if probabilities.ndim == 2
+        else np.asarray((), dtype=float)
+    )
+    adjusted_mass = (
+        np.sum(guarded_adjusted, axis=0)
+        if guarded_adjusted.ndim == 2
+        else np.asarray((), dtype=float)
+    )
+    return {
+        "mode": mode,
+        "status": guarded_status,
+        "iterations": iterations,
+        "class_order": class_order,
+        "target_mass": target_mass,
+        "observed_mass": observed_mass,
+        "adjusted_mass": adjusted_mass,
+        "probabilities": guarded_adjusted,
+        "guarded": True,
+        "guarded_margin_quantile": GUARDED_TEST_PRIOR_BALANCE_MARGIN_QUANTILE,
+        "guarded_margin_threshold": margin_threshold,
+        "guarded_adjusted_trials": adjusted_trials,
+    }
+
+
+def _guarded_test_prior_balance_probabilities(probabilities, balanced_probabilities):
+    """Apply balanced-prior probabilities only to low-margin held-out rows."""
+
+    probabilities = np.asarray(probabilities, dtype=float)
+    balanced_probabilities = np.asarray(balanced_probabilities, dtype=float)
+    if (
+        probabilities.ndim != 2
+        or balanced_probabilities.shape != probabilities.shape
+        or probabilities.shape[0] == 0
+        or probabilities.shape[1] == 0
+    ):
+        return probabilities, 0, ""
+
+    margins = _probability_margins(probabilities)
+    finite_margins = margins[np.isfinite(margins)]
+    if finite_margins.size == 0:
+        return balanced_probabilities, int(probabilities.shape[0]), ""
+    threshold = float(
+        np.quantile(
+            finite_margins,
+            float(GUARDED_TEST_PRIOR_BALANCE_MARGIN_QUANTILE),
+        )
+    )
+    low_margin_rows = margins <= threshold
+    adjusted = probabilities.copy()
+    adjusted[low_margin_rows] = balanced_probabilities[low_margin_rows]
+    row_sums = np.sum(adjusted, axis=1, keepdims=True)
+    adjusted = np.divide(
+        adjusted,
+        row_sums,
+        out=np.full_like(adjusted, 1.0 / adjusted.shape[1]),
+        where=row_sums > 0.0,
+    )
+    return adjusted, int(np.sum(low_margin_rows)), threshold
+
+
+def _probability_margins(probabilities):
+    probabilities = np.asarray(probabilities, dtype=float)
+    if probabilities.ndim != 2 or probabilities.shape[1] < 2:
+        return np.zeros(probabilities.shape[0] if probabilities.ndim == 2 else 0, dtype=float)
+    ordered = np.sort(probabilities, axis=1)[:, ::-1]
+    return ordered[:, 0] - ordered[:, 1]
+
+
+def _add_test_class_prior_balance_fields(row, metadata):
+    _previous_add_test_class_prior_balance_fields(row, metadata)
+    row["ensemble_test_class_prior_guarded"] = metadata.get("guarded", "")
+    row["ensemble_test_class_prior_guarded_margin_quantile"] = metadata.get(
+        "guarded_margin_quantile",
+        "",
+    )
+    row["ensemble_test_class_prior_guarded_margin_threshold"] = metadata.get(
+        "guarded_margin_threshold",
+        "",
+    )
+    row["ensemble_test_class_prior_guarded_adjusted_trials"] = metadata.get(
+        "guarded_adjusted_trials",
+        "",
     )
 
 
@@ -508,6 +711,9 @@ def _class_score_probabilities(scores, *, score_normalization=None):
     top_k = TOPK_BORDA_SCORE_NORMALIZATIONS.get(base_mode)
     if top_k is not None:
         return _rank_topk_borda_probabilities(scores, top_k=top_k)
+    top_k = TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS.get(base_mode)
+    if top_k is not None:
+        return _rank_topk_score_softmax_probabilities(scores, top_k=top_k)
     topk_margin_blend = TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS.get(base_mode)
     if topk_margin_blend is not None:
         top_k, sharp_temperature = topk_margin_blend
@@ -614,6 +820,48 @@ def _rank_topk_borda_probabilities(scores, *, top_k):
         weights = np.zeros(row.shape[0], dtype=float)
         weights[ordered_columns] = np.arange(k, 0, -1, dtype=float)
         probabilities[row_index] = weights / np.sum(weights)
+    return probabilities
+
+
+def _rank_topk_score_softmax_probabilities(scores, *, top_k):
+    """Convert class scores to a sparse softmax over only the top-k classes."""
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError(
+            "Nested score ensembling requires a non-empty two-dimensional "
+            "class-score matrix."
+        )
+    top_k = int(top_k)
+    if top_k < 1:
+        raise ValueError("top_k must be at least one.")
+
+    probabilities = np.zeros_like(scores, dtype=float)
+    n_classes = int(scores.shape[1])
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        n_finite = int(np.sum(finite))
+        if n_finite == 0:
+            probabilities[row_index] = np.full(n_classes, 1.0 / n_classes, dtype=float)
+            continue
+
+        k = min(top_k, n_finite)
+        ordered_columns = np.argsort(
+            -np.where(finite, row, -np.inf),
+            kind="mergesort",
+        )[:k]
+        logits = np.asarray(row[ordered_columns], dtype=float)
+        logits = logits - float(np.mean(logits))
+        scale = float(np.std(logits))
+        if isfinite(scale) and scale > 1e-12:
+            logits = logits / scale
+        logits = logits - float(np.max(logits))
+        exp_logits = np.exp(logits)
+        total = float(np.sum(exp_logits))
+        if not isfinite(total) or total <= 0.0:
+            probabilities[row_index, ordered_columns] = 1.0 / k
+        else:
+            probabilities[row_index, ordered_columns] = exp_logits / total
     return probabilities
 
 
@@ -811,6 +1059,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_flat_taper_feature(signal)
         elif feature_mode == "sensor_flat_gaussian_taper":
             feature = _sensor_flat_gaussian_taper_feature(signal)
+        elif feature_mode == "sensor_flat_centered":
+            feature = _sensor_flat_centered_feature(signal)
         elif feature_mode == "sensor_flat_delta":
             feature = _sensor_flat_delta_feature(signal)
         elif feature_mode == "sensor_flat_dct":
@@ -939,6 +1189,15 @@ def _sensor_flat_gaussian_taper_feature(window_signal):
         raise ValueError("window_signal must be a channel x time matrix.")
     weights = _sensor_flat_gaussian_taper_weights(signal.shape[1])
     return (signal * weights[None, :]).reshape(-1, order="F")
+
+
+def _sensor_flat_centered_feature(window_signal):
+    """Return per-trial temporal-mean-centered samples in sensor_flat layout."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    if signal.ndim != 2:
+        raise ValueError("window_signal must be a channel x time matrix.")
+    return (signal - np.mean(signal, axis=1, keepdims=True)).reshape(-1, order="F")
 
 
 def _sensor_flat_time_bins_feature(window_signal, *, n_bins):
@@ -1171,6 +1430,8 @@ def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
             n_window_samples,
             trial_indices,
         )
+    if feature_mode == "sensor_flat_centered":
+        return _sensor_flat_centered_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_delta":
         return _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_dct":
@@ -1293,6 +1554,21 @@ def _sensor_flat_gaussian_taper_baseline_statistics(
     flat_mean = np.tile(channel_mean, n_window_samples) * repeated_weights
     flat_std = np.tile(channel_std, n_window_samples) * repeated_weights
     return flat_mean[None, :], _impl._nonzero_std(flat_std[None, :]), n_baseline_samples
+
+
+def _sensor_flat_centered_baseline_statistics(data, config, n_window_samples, trial_indices):
+    """Baseline statistics for temporal-mean-centered sensor_flat features."""
+
+    _channel_mean, channel_std, n_baseline_samples = _impl._baseline_channel_statistics(
+        data,
+        config.baseline_window,
+        trial_indices,
+    )
+    n_window_samples = int(n_window_samples)
+    n_channels = int(channel_std.shape[0])
+    mean = np.zeros(n_channels * n_window_samples, dtype=float)
+    std = np.tile(channel_std, n_window_samples)
+    return mean[None, :], _impl._nonzero_std(std[None, :]), n_baseline_samples
 
 
 def _sensor_flat_time_bins_baseline_statistics(data, config, trial_indices, *, n_bins):

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -97,6 +97,78 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(metadata["inner_mode"], mode)
         self.assertTrue(metadata["guarded"])
 
+    def test_topk_score_softmax_modes_are_exported(self):
+        mode = "rank_top3_score_softmax"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+
+        scores = np.asarray([[4.0, 3.0, 2.0, 1.0]], dtype=float)
+        probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization=mode,
+        )
+
+        self.assertEqual(np.count_nonzero(probabilities[0]), 3)
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(1))
+        self.assertGreater(probabilities[0, 0], probabilities[0, 1])
+        self.assertGreater(probabilities[0, 1], probabilities[0, 2])
+        self.assertEqual(probabilities[0, 3], 0.0)
+
+    def test_topk_score_softmax_inner_confusion_guarded_mode_is_exported(self):
+        mode = "rank_top3_score_softmax_inner_confusion_soft_guarded"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_top3_score_softmax",
+        )
+
+        metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            [{"selected_inner_true_predicted_label_pair_counts": "1001:4;1002:2;2002:5"}],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertTrue(metadata["guarded"])
+
+    def test_guarded_test_prior_balance_is_exported_and_margin_gated(self):
+        mode = "rank_softmax_guarded_test_prior_balance"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_softmax",
+        )
+        self.assertEqual(
+            cross_subject._test_class_prior_balance_mode(mode),  # pylint: disable=protected-access
+            mode,
+        )
+
+        probabilities = np.asarray(
+            [
+                [0.90, 0.10],
+                [0.60, 0.40],
+                [0.55, 0.45],
+                [0.30, 0.70],
+            ],
+            dtype=float,
+        )
+        metadata = cross_subject._test_class_prior_balance_metadata(  # pylint: disable=protected-access
+            probabilities,
+            np.arange(2, dtype=int),
+            mode,
+        )
+        adjusted = cross_subject._apply_test_class_prior_balance(probabilities, metadata)  # pylint: disable=protected-access
+
+        self.assertEqual(metadata["mode"], mode)
+        self.assertTrue(metadata["guarded"])
+        self.assertEqual(metadata["guarded_margin_quantile"], 0.5)
+        self.assertEqual(metadata["guarded_adjusted_trials"], 2)
+        np.testing.assert_allclose(np.sum(adjusted, axis=1), np.ones(4))
+        np.testing.assert_allclose(adjusted[0], probabilities[0])
+        self.assertFalse(np.allclose(adjusted[2], probabilities[2]))
+
     def test_margin_gated_inner_confusion_leaves_high_margin_rows_unchanged(self):
         probabilities = np.asarray([[0.51, 0.49], [0.95, 0.05]], dtype=float)
         metadata = {
@@ -468,6 +540,40 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertLess(adaptive[0, 0], default[0, 0])
         self.assertGreater(adaptive[1, 0], default[1, 0])
 
+    def test_adaptive_rank_softmax_soft_guarded_inner_confusion_mode_is_exported(self):
+        mode = "rank_adaptive_softmax_inner_confusion_soft_guarded"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_adaptive_softmax",
+        )
+
+        scores = np.asarray(
+            [
+                [4.0, 3.95, 2.0, 1.0],
+                [4.0, 0.0, -1.0, -2.0],
+            ],
+            dtype=float,
+        )
+        probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization=mode,
+        )
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(2))
+
+        metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            [{"selected_inner_true_predicted_label_pair_counts": "1001:4;1002:2;2002:5"}],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertTrue(metadata["guarded"])
+        self.assertFalse(metadata["margin_gated"])
+        self.assertLess(metadata["blend"], 1.0)
+
     def test_extended_feature_modes_are_exported(self):
         self.assertIn("sensor_logpower", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_mean_logpower", cross_subject.FEATURE_MODES)
@@ -475,6 +581,7 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertIn("sensor_flat_smooth", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_taper", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_gaussian_taper", cross_subject.FEATURE_MODES)
+        self.assertIn("sensor_flat_centered", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_delta", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_dct", cross_subject.FEATURE_MODES)
         self.assertIn("sensor_flat_time_pyramid", cross_subject.FEATURE_MODES)
@@ -656,6 +763,58 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_allclose(feature_set.features[0], expected)
         self.assertGreater(weights[1], weights[0])
         self.assertGreater(weights[1], weights[2])
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_centered_feature(self):
+        time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.0, 0.0, 1.0, 3.0, 5.0], [0.0, 0.0, 2.0, 4.0, 6.0]],
+            [[0.0, 0.0, 2.0, 4.0, 6.0], [0.0, 0.0, 1.0, 3.0, 5.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            feature_mode="sensor_flat_centered",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        np.testing.assert_allclose(
+            feature_set.features[0],
+            np.asarray([-2.0, -2.0, 0.0, 0.0, 2.0, 2.0]),
+        )
+        self.assertTrue(np.all(np.isfinite(feature_set.features)))
+
+    def test_sensor_flat_centered_baseline_whiten_allows_different_baseline_duration(self):
+        time = np.asarray([-0.3, -0.2, -0.1, 0.1, 0.2, 0.3], dtype=float)
+        trials = [
+            [[0.1, 0.2, 0.3, 1.0, 3.0, 5.0], [0.4, 0.5, 0.6, 2.0, 4.0, 6.0]],
+            [[0.2, 0.3, 0.4, 2.0, 4.0, 6.0], [0.5, 0.6, 0.7, 1.0, 3.0, 5.0]],
+        ]
+        data_by_participant = {1: mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.2,
+            window_size=0.2,
+            baseline_window=(-0.3, -0.1),
+            feature_mode="sensor_flat_centered",
+            normalization="subject_baseline_whiten",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 6))
+        self.assertEqual(feature_set.baseline_feature_mean.shape, (1, 6))
+        self.assertEqual(feature_set.baseline_feature_std.shape, (1, 6))
+        self.assertTrue(np.all(feature_set.baseline_feature_std > 0.0))
         self.assertTrue(np.all(np.isfinite(feature_set.features)))
 
     def test_sensor_flat_taper_baseline_whiten_allows_different_baseline_duration(self):


### PR DESCRIPTION
## Summary
- add guarded test-prior balancing and top-k score-softmax ranking modes
- expose adaptive rank-softmax guarded inner-confusion and workflow entries
- add sensor_flat_centered feature extraction and baseline whitening support

## Verification
- python -m py_compile src\\pymegdec\\_stimulus_cross_subject_next.py tests\\test_stimulus_cross_subject_next.py
- python -c " import yaml pathlib