### PR TITLE
Add fractional rank-softmax followups

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -101,10 +101,12 @@ on:
           - windowed_logreg_175_w150_pca160_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_pca160_c03_c05
           - windowed_logreg_175_w150_pca160_c03_c05_ranksoft_t0_75
+          - windowed_logreg_175_w150_pca160_c03_c05_ranksoft_t0_75_inner_confusion_guarded
           - windowed_logreg_175_w150_pca160_c03_c05_scorecal
           - windowed_logreg_175_w150_pca160_cgrid
           - windowed_logreg_175_w150_pca160_cgrid_top3_margin
           - windowed_logreg_175_w150_pca160_cgrid_inner_confusion_guarded
+          - windowed_logreg_175_w150_pca160_cgrid_ranksoft_t0_75_inner_confusion_guarded
           - windowed_logreg_175_w150_pca160_c03_c05_trial_margin
           - windowed_logreg_175_w150_top3_margin_blend_pca160
           - windowed_logreg_175_w150_top2_quota
@@ -290,6 +292,8 @@ on:
           - rank_softmax_t1_5_inner_confusion_soft
           - rank_softmax_t1_75_inner_confusion_soft
           - rank_softmax_t2_inner_confusion_soft
+          - rank_softmax_t0_5_inner_confusion_soft
+          - rank_softmax_t0_75_inner_confusion_soft
           - rank_softmax_inner_confusion_margin_soft
           - rank_softmax_t2_inner_confusion_margin_soft
           - rank_softmax_t3_inner_confusion_margin_soft
@@ -311,6 +315,8 @@ on:
           - rank_softmax_t1_75_inner_confusion_soft_guarded
           - rank_softmax_t2_inner_confusion_soft_guarded
           - rank_softmax_t3_inner_confusion_soft_guarded
+          - rank_softmax_t0_5_inner_confusion_soft_guarded
+          - rank_softmax_t0_75_inner_confusion_soft_guarded
           - rank_reciprocal_inner_confusion_soft_guarded
           - rank_borda_inner_confusion_soft_guarded
           - rank_top2_vote_inner_confusion_soft_guarded
@@ -1765,6 +1771,22 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_pca160_c03_c05_ranksoft_t0_75_inner_confusion_guarded": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t0_75_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_pca160_c03_c05_trial_margin": {
                   "window_centers": "0.175",
                   "window_size": "0.150",
@@ -1855,6 +1877,22 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_cgrid_ranksoft_t0_75_inner_confusion_guarded": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5,1,2",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_t0_75_inner_confusion_soft_guarded",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -289,6 +289,26 @@ RANK_SOFTMAX_TEMPERATURES = {
     "rank_softmax_t2": 2.0,
     "rank_softmax_t3": 3.0,
 }
+RANK_SOFTMAX_DYNAMIC_PREFIX = "rank_softmax_t"
+RANK_SOFTMAX_INNER_BALANCED_SUFFIXES = ("_inner_balanced",)
+RANK_SOFTMAX_INNER_CONFUSION_SUFFIXES = (
+    "_inner_confusion",
+    "_inner_confusion_soft",
+    "_inner_confusion_margin_soft",
+    "_inner_confusion_soft_guarded",
+    "_inner_confusion_guarded",
+    "_inner_confusion_margin_soft_guarded",
+)
+RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SUFFIXES = (
+    "_inner_balanced_confusion",
+    "_inner_balanced_confusion_soft",
+    "_inner_balanced_confusion_soft_guarded",
+)
+RANK_SOFTMAX_INNER_SUFFIXES = (
+    *RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SUFFIXES,
+    *RANK_SOFTMAX_INNER_CONFUSION_SUFFIXES,
+    *RANK_SOFTMAX_INNER_BALANCED_SUFFIXES,
+)
 RANK_MARGIN_BLEND_LOW = 0.25
 RANK_MARGIN_BLEND_HIGH = 1.25
 RANK_CONSENSUS_TEMPERATURE = 1.0
@@ -2378,8 +2398,9 @@ def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJ
     score_normalization = _base_ensemble_score_normalization(score_normalization)
     if score_normalization == "row_z_softmax":
         return _row_softmax_probabilities(scores)
-    if score_normalization in RANK_SOFTMAX_TEMPERATURES:
-        return _rank_softmax_probabilities(scores, temperature=RANK_SOFTMAX_TEMPERATURES[score_normalization])
+    rank_softmax_temperature = _rank_softmax_temperature(score_normalization)
+    if rank_softmax_temperature is not None:
+        return _rank_softmax_probabilities(scores, temperature=rank_softmax_temperature)
     if score_normalization == "rank_reciprocal":
         return _rank_reciprocal_probabilities(scores)
     if score_normalization == "rank_borda":
@@ -2419,6 +2440,25 @@ def _rank_softmax_probabilities(scores, *, temperature=1.0):
         exp_logits = np.exp(logits - np.max(logits))
         probabilities[row_index] = exp_logits / np.sum(exp_logits)
     return probabilities
+
+
+def _rank_softmax_temperature(score_normalization):
+    """Return a rank-softmax temperature parsed from a normalization name."""
+    mode = str(score_normalization).strip().lower().replace("-", "_")
+    if mode in RANK_SOFTMAX_TEMPERATURES:
+        return float(RANK_SOFTMAX_TEMPERATURES[mode])
+    if not mode.startswith(RANK_SOFTMAX_DYNAMIC_PREFIX):
+        return None
+    temperature_token = mode.removeprefix(RANK_SOFTMAX_DYNAMIC_PREFIX)
+    if not temperature_token:
+        return None
+    try:
+        temperature = float(temperature_token.replace("_", "."))
+    except ValueError:
+        return None
+    if temperature <= 0.0 or not np.isfinite(temperature):
+        return None
+    return temperature
 
 
 def _rank_reciprocal_probabilities(scores):
@@ -2700,6 +2740,8 @@ def _inner_class_prior_balance_mode(score_normalization):
         inner_mode
         if inner_mode in INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES
         or inner_mode in INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        or _rank_softmax_inner_mode_base(inner_mode, RANK_SOFTMAX_INNER_BALANCED_SUFFIXES) is not None
+        or _rank_softmax_inner_mode_base(inner_mode, RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SUFFIXES) is not None
         else None
     )
 
@@ -2710,7 +2752,29 @@ def _inner_confusion_correction_mode(score_normalization):
         inner_mode
         if inner_mode in INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES
         or inner_mode in INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES
+        or _rank_softmax_inner_mode_base(inner_mode, RANK_SOFTMAX_INNER_CONFUSION_SUFFIXES) is not None
+        or _rank_softmax_inner_mode_base(inner_mode, RANK_SOFTMAX_INNER_BALANCED_CONFUSION_SUFFIXES) is not None
         else None
+    )
+
+
+def _rank_softmax_inner_mode_base(inner_mode, suffixes=RANK_SOFTMAX_INNER_SUFFIXES):
+    """Return the dynamic rank-softmax base for an inner-derived mode."""
+    mode = str(inner_mode).strip().lower().replace("-", "_")
+    for suffix in suffixes:
+        if not mode.endswith(suffix):
+            continue
+        base = mode.removesuffix(suffix)
+        if _rank_softmax_temperature(base) is not None:
+            return base
+    return None
+
+
+def _dynamic_rank_softmax_score_normalization(score_normalization):
+    mode = _without_log_pool_suffix(_without_balanced_quota_suffix(score_normalization))
+    return (
+        _rank_softmax_temperature(mode) is not None
+        or _rank_softmax_inner_mode_base(mode) is not None
     )
 
 
@@ -2721,6 +2785,7 @@ def _base_ensemble_score_normalization(score_normalization):
         INNER_BALANCED_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(inner_mode)
         or INNER_BALANCED_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(inner_mode)
         or INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.get(inner_mode)
+        or _rank_softmax_inner_mode_base(inner_mode)
         or inner_mode
     )
 
@@ -4356,7 +4421,10 @@ def _normalize_selection_ensemble_diversity(value):
 
 def _normalize_ensemble_score_normalization(value):
     normalized = str(value).strip().lower().replace("-", "_")
-    if normalized not in ENSEMBLE_SCORE_NORMALIZATION_MODES:
+    if (
+        normalized not in ENSEMBLE_SCORE_NORMALIZATION_MODES
+        and not _dynamic_rank_softmax_score_normalization(normalized)
+    ):
         raise ValueError(f"selection_ensemble_score_normalization must be one of {ENSEMBLE_SCORE_NORMALIZATION_MODES}.")
     return normalized
 

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -80,6 +80,41 @@ def _drop_topk_fields(rows):
 
 
 class TestStimulusCrossSubject(unittest.TestCase):
+    def test_fractional_rank_softmax_temperature_modes_are_supported(self):
+        scores = np.asarray([[3.0, 2.0, 1.0]], dtype=float)
+        default_probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax",
+        )
+        softer_probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization="rank_softmax_t1_5",
+        )
+
+        self.assertEqual(
+            cross_subject._normalize_ensemble_score_normalization("rank-softmax-t1-5"),  # pylint: disable=protected-access
+            "rank_softmax_t1_5",
+        )
+        self.assertLess(softer_probabilities[0, 0], default_probabilities[0, 0])
+        self.assertGreater(softer_probabilities[0, 1], default_probabilities[0, 1])
+
+    def test_fractional_rank_softmax_inner_confusion_modes_are_supported(self):
+        modes = [
+            "rank_softmax_t1_5_inner_confusion_soft_guarded",
+            "rank_softmax_t1_5_inner_balanced_confusion_soft_guarded_guarded_balanced_quota",
+        ]
+
+        for mode in modes:
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    cross_subject._normalize_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+                    mode,
+                )
+                self.assertEqual(
+                    cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+                    "rank_softmax_t1_5",
+                )
+
     def test_load_participant_stimulus_features_uses_main_data_only(self):
         data_by_participant = {1: _mat_data([1, 2, 1, 2], [-1.0, 1.0, -1.0, 1.0])}
         config = CrossSubjectStimulusConfig(window_center=0.2, window_size=0.1, normalization="none", components_pca=float("inf"), chance_classes=2)

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -258,6 +258,26 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         )
         np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(1))
 
+    def test_subunit_rank_softmax_soft_guarded_inner_confusion_modes_are_exported(self):
+        mode = "rank_softmax_t0_75_inner_confusion_soft_guarded"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_softmax_t0_75",
+        )
+
+        metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            [{"selected_inner_true_predicted_label_pair_counts": "1001:4;1002:2;2002:5"}],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertTrue(metadata["guarded"])
+        self.assertLess(metadata["blend"], 1.0)
+
     def test_intermediate_rank_softmax_inner_confusion_margin_modes_are_exported(self):
         mode = "rank_softmax_t1_5_inner_confusion_margin_soft_guarded"
 


### PR DESCRIPTION
## Summary
- add dynamic fractional rank-softmax normalization support for legacy score paths
- expose guarded t0.75 inner-confusion workflow bundles
- cover fractional and guarded inner-confusion modes with focused tests

## Verification
- Not run, per request: tests
- python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py tests\test_stimulus_cross_subject_next.py
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"
- git diff --check
