### PR TITLE
Use next score path for inner calibration

### DIFF
--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -2001,7 +2001,16 @@ def _fit_inner_score_calibration(train_sets, config, classifier_param, *, label_
             label_shuffle_context=(*tuple(label_shuffle_context), int(validation_set.participant), validation_index),
             fit_score_calibration=False,
         )
-        scores, score_classes = _previous_candidate_model_scores(inner_model, validation_set, inner_config)
+        # Source-inner calibration must validate the same candidate-score path
+        # that is used for outer scoring. Calling the legacy helper here skips
+        # _next hooks such as feature transforms, train-only target alignment,
+        # and score wrappers, so guarded calibration can make its apply/skip
+        # decision on a representation that differs from the final model path.
+        scores, score_classes = _candidate_model_scores(
+            inner_model,
+            validation_set,
+            inner_config,
+        )
         all_scores.append(_align_class_score_columns(scores, score_classes, class_order))
         all_labels.append(np.asarray(validation_set.labels, dtype=int) - 1)
     scores = np.vstack(all_scores)

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
@@ -214,6 +215,63 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         )
         pooled = cross_subject._weighted_probability_pool(probabilities, trial_weights)  # pylint: disable=protected-access
         self.assertEqual(pooled.shape, (2, 2))
+
+    def test_inner_score_calibration_uses_next_candidate_scoring_path(self):
+        feature_sets = tuple(
+            SimpleNamespace(
+                participant=participant,
+                labels=np.asarray([1, 2, 1, 2], dtype=int),
+            )
+            for participant in (1, 2, 3)
+        )
+        config = CrossSubjectStimulusConfig(
+            chance_classes=2,
+            score_calibration="inner_class_bias",
+        )
+        seen_validation_participants = []
+
+        def fake_fit_outer_fold_model(
+            *_args,
+            **_kwargs,
+        ):
+            return {
+                "model_bundle": object(),
+                "score_calibration_metadata": {"mode": "none"},
+            }
+
+        def fake_candidate_scores(_model, validation_set, _config):
+            seen_validation_participants.append(int(validation_set.participant))
+            labels = np.asarray(validation_set.labels, dtype=int) - 1
+            scores = np.full((labels.shape[0], 2), -1.0, dtype=float)
+            scores[np.arange(labels.shape[0]), labels] = 1.0
+            return scores, np.arange(2, dtype=int)
+
+        with (
+            patch.object(
+                next_hooks,
+                "_fit_outer_fold_model",
+                side_effect=fake_fit_outer_fold_model,
+            ),
+            patch.object(
+                next_hooks,
+                "_candidate_model_scores",
+                side_effect=fake_candidate_scores,
+            ),
+            patch.object(
+                next_hooks,
+                "_previous_candidate_model_scores",
+                side_effect=AssertionError("legacy score path used"),
+            ),
+        ):
+            metadata = next_hooks._fit_inner_score_calibration(  # pylint: disable=protected-access
+                feature_sets,
+                config,
+                1.0,
+            )
+
+        self.assertEqual(seen_validation_participants, [1, 2, 3])
+        self.assertEqual(metadata["mode"], "inner_class_bias")
+        self.assertIn("inner_balanced_accuracy", metadata)
 
     def test_subunit_rank_softmax_temperatures_are_exported(self):
         self.assertIn("rank_softmax_t0_5", cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)


### PR DESCRIPTION
## Summary
- use the next-hook candidate scoring path for inner score calibration
- add a regression test that fails if the legacy score helper is used

## Verification
- Not run, per request: tests
- python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject_next.py
- git diff --check HEAD~1..HEAD
