### PR TITLE
Add BUSH time-bin and median consensus variants

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -93,9 +93,11 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w150_time_bins7
           - windowed_logreg_175_w150_adaptive_ranksoft
           - windowed_logreg_175_w150_source_anova_sqrt
           - windowed_logreg_175_w150_pca160
+          - windowed_logreg_175_w150_pca160_median_consensus
           - windowed_logreg_175_w150_pca160_guarded_test_prior
           - windowed_logreg_175_w150_pca160_ranksoft_t0_75
           - windowed_logreg_175_w150_pca160_soft_guarded_inner_confusion
@@ -213,6 +215,7 @@ on:
           - rank_top3_margin_blend
           - rank_margin_blend
           - rank_adaptive_softmax
+          - rank_median_consensus
           - row_z_softmax_log_pool
           - rank_softmax_log_pool
           - rank_softmax_t0_5_log_pool
@@ -1662,6 +1665,41 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_time_bins7": {
+                  # Compare the current raw-sample w150 winner against a compact
+                  # seven-bin temporal-shape summary. The binned branch preserves
+                  # early visual latency structure while reducing feature width,
+                  # which may improve cross-subject robustness after baseline
+                  # whitening and PCA.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_time_bins7",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_median_consensus": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_median_consensus",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -96,6 +96,7 @@ ENSEMBLE_SCORE_NORMALIZATION_MODES = (
     "rank_z_blend_log_pool",
     "rank_margin_blend_log_pool",
     "rank_consensus",
+    "rank_median_consensus",
     "rank_softmax_test_prior_balance",
     "rank_softmax_t2_test_prior_balance",
     "rank_softmax_t3_test_prior_balance",
@@ -312,8 +313,10 @@ RANK_SOFTMAX_INNER_SUFFIXES = (
 RANK_MARGIN_BLEND_LOW = 0.25
 RANK_MARGIN_BLEND_HIGH = 1.25
 RANK_CONSENSUS_TEMPERATURE = 1.0
-TRIAL_MARGIN_ENSEMBLE_WEIGHT_FLOOR = 0.25
 RANK_CONSENSUS_DISAGREEMENT_PENALTY = 0.5
+RANK_MEDIAN_CONSENSUS_TEMPERATURE = 0.75
+RANK_MEDIAN_CONSENSUS_TOP_AGREEMENT_BONUS = 0.50
+TRIAL_MARGIN_ENSEMBLE_WEIGHT_FLOOR = 0.25
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
     "window",
@@ -2137,7 +2140,7 @@ def _score_outer_fold_ensemble_models(
         class_scores, score_classes = _candidate_model_scores(fitted_model, test_set, config)
         aligned_scores = _align_class_score_columns(class_scores, score_classes, class_order)
         aligned_score_matrices.append(aligned_scores)
-        if base_score_normalization == "rank_consensus":
+        if base_score_normalization in {"rank_consensus", "rank_median_consensus"}:
             pass
         else:
             probabilities = _class_score_probabilities(class_scores, score_normalization=base_score_normalization)
@@ -2146,6 +2149,8 @@ def _score_outer_fold_ensemble_models(
 
     if base_score_normalization == "rank_consensus":
         ensemble_probabilities = _rank_consensus_ensemble_probabilities(aligned_score_matrices, weights)
+    elif base_score_normalization == "rank_median_consensus":
+        ensemble_probabilities = _rank_median_consensus_ensemble_probabilities(aligned_score_matrices, weights)
     else:
         pool_weights = _trial_margin_ensemble_weights(
             aligned_score_matrices,
@@ -2415,6 +2420,8 @@ def _class_score_probabilities(scores, *, score_normalization=DEFAULT_CROSS_SUBJ
         return _rank_margin_blend_probabilities(scores)
     if score_normalization == "rank_consensus":
         return _rank_softmax_probabilities(scores)
+    if score_normalization == "rank_median_consensus":
+        return _rank_softmax_probabilities(scores)
     raise ValueError(f"Unsupported ensemble score normalization: {score_normalization}")
 
 
@@ -2645,6 +2652,69 @@ def _rank_consensus_ensemble_probabilities(score_matrices, weights):
         out=np.full_like(exp_logits, 1.0 / exp_logits.shape[1]),
         where=row_sums > 0.0,
     )
+
+
+def _rank_median_consensus_ensemble_probabilities(score_matrices, weights):
+    """Return probabilities from robust cross-model median-rank agreement."""
+
+    score_tensor = np.asarray(tuple(score_matrices), dtype=float)
+    if score_tensor.ndim != 3 or score_tensor.shape[0] == 0 or score_tensor.shape[2] == 0:
+        raise ValueError(
+            "Median-rank consensus ensembling requires non-empty model x trial x class scores."
+        )
+
+    weights = _normalized_ensemble_weights(weights, score_tensor.shape[0])
+    rank_tensor = _rank_consensus_model_ranks(score_tensor)
+    median_ranks = _weighted_median_model_ranks(rank_tensor, weights)
+    top_agreement = np.tensordot(
+        weights,
+        (rank_tensor <= 0.0).astype(float),
+        axes=(0, 0),
+    )
+    logits = (
+        -median_ranks / float(RANK_MEDIAN_CONSENSUS_TEMPERATURE)
+        + float(RANK_MEDIAN_CONSENSUS_TOP_AGREEMENT_BONUS) * top_agreement
+    )
+    logits -= np.max(logits, axis=1, keepdims=True)
+    exp_logits = np.exp(np.clip(logits, -50.0, 50.0))
+    row_sums = np.sum(exp_logits, axis=1, keepdims=True)
+    return np.divide(
+        exp_logits,
+        row_sums,
+        out=np.full_like(exp_logits, 1.0 / exp_logits.shape[1]),
+        where=row_sums > 0.0,
+    )
+
+
+def _weighted_median_model_ranks(rank_tensor, weights):
+    """Return weighted median ranks for each trial x class cell."""
+
+    rank_tensor = np.asarray(rank_tensor, dtype=float)
+    if rank_tensor.ndim != 3:
+        raise ValueError("Weighted median ranks require model x trial x class ranks.")
+    weights = _normalized_ensemble_weights(weights, rank_tensor.shape[0])
+    _n_models, n_trials, n_classes = rank_tensor.shape
+    output = np.empty((n_trials, n_classes), dtype=float)
+    for trial_index in range(n_trials):
+        for class_index in range(n_classes):
+            values = rank_tensor[:, trial_index, class_index]
+            finite = np.isfinite(values)
+            if not np.any(finite):
+                output[trial_index, class_index] = 0.5 * float(max(n_classes - 1, 0))
+                continue
+            finite_values = values[finite]
+            finite_weights = weights[finite]
+            weight_sum = float(np.sum(finite_weights))
+            if weight_sum <= 0.0:
+                output[trial_index, class_index] = float(np.median(finite_values))
+                continue
+            finite_weights = finite_weights / weight_sum
+            order = np.argsort(finite_values, kind="mergesort")
+            cumulative = np.cumsum(finite_weights[order])
+            median_position = int(np.searchsorted(cumulative, 0.5, side="left"))
+            median_position = min(median_position, order.shape[0] - 1)
+            output[trial_index, class_index] = float(finite_values[order[median_position]])
+    return output
 
 
 def _rank_consensus_model_ranks(score_tensor):

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -92,6 +92,7 @@ DEFAULT_SENSOR_FLAT_GAUSSIAN_TAPER_SIGMA = 0.50
 SENSOR_FLAT_TIME_BIN_FEATURE_MODES = {
     "sensor_flat_time_bins3": 3,
     "sensor_flat_time_bins5": 5,
+    "sensor_flat_time_bins7": 7,
 }
 BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_logpower",

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -219,6 +219,38 @@ class TestStimulusCrossSubject(unittest.TestCase):
         np.testing.assert_allclose(feature_set.features[0], np.asarray([2.0, 4.0, 2.0, 4.0, 1.0, 2.0]))
         np.testing.assert_allclose(feature_set.features[1], np.asarray([3.0, 6.0, 2.0, 4.0, 1.0, 2.0]))
 
+    def test_sensor_flat_time_bins7_keeps_fine_temporal_shape(self):
+        time = np.asarray([-0.5, 0.0, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16], dtype=float)
+        trials = [
+            [
+                [0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+                [0.0, 0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0],
+            ],
+            [
+                [0.0, 0.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0],
+                [0.0, 0.0, 20.0, 40.0, 60.0, 80.0, 100.0, 120.0, 140.0],
+            ],
+        ]
+        data_by_participant = {1: _mat_data_from_trials([1, 2], trials, time)}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.13,
+            window_size=0.06,
+            feature_mode="sensor_flat_time_bins7",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        self.assertEqual(feature_set.features.shape, (2, 14))
+        self.assertEqual(feature_set.n_window_samples, 7)
+        np.testing.assert_allclose(
+            feature_set.features[0],
+            np.asarray([1.0, 10.0, 2.0, 20.0, 3.0, 30.0, 4.0, 40.0, 5.0, 50.0, 6.0, 60.0, 7.0, 70.0]),
+        )
+
     def test_sensor_temporal_pyramid_keeps_multiscale_channel_means(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3, 0.4], dtype=float)
         trials = [
@@ -1440,6 +1472,28 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertIn("1:", artifacts["group_summary"][0]["selected_ensemble_candidate_counts"])
         self.assertIn("2:", artifacts["group_summary"][0]["selected_ensemble_candidate_counts"])
         self.assertEqual(fit_model.call_count, 20)
+
+    def test_rank_median_consensus_prefers_majority_top_rank(self):
+        score_matrices = (
+            np.asarray([[4.0, 3.0, 2.0], [1.0, 5.0, 4.0]]),
+            np.asarray([[1.0, 5.0, 4.0], [5.0, 4.0, 1.0]]),
+            np.asarray([[0.0, 6.0, 5.0], [4.0, 6.0, 2.0]]),
+        )
+
+        probabilities = cross_subject._rank_median_consensus_ensemble_probabilities(  # pylint: disable=protected-access
+            score_matrices,
+            np.asarray([1 / 3, 1 / 3, 1 / 3]),
+        )
+
+        self.assertEqual(probabilities.shape, (2, 3))
+        np.testing.assert_allclose(
+            np.sum(probabilities, axis=1),
+            np.ones(2),
+        )
+        self.assertGreater(probabilities[0, 1], probabilities[0, 0])
+        self.assertGreater(probabilities[0, 1], probabilities[0, 2])
+        self.assertGreater(probabilities[1, 1], probabilities[1, 0])
+        self.assertGreater(probabilities[1, 1], probabilities[1, 2])
 
     def test_nested_ensemble_weights_can_follow_inner_validation_scores(self):
         rows = [


### PR DESCRIPTION
## Summary
- add seven-bin sensor-flat temporal features for BUSH runs
- add rank median consensus ensembling
- expose both variants in the nested stimulus matrix workflow

## Verification
- Not run, per request: tests
- python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject.py
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"
- git diff --check
