### PR TITLE
Add BUSH trial-margin and top-k quota variants

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -94,6 +94,7 @@ on:
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
           - windowed_logreg_175_w150_time_bins7
+          - windowed_logreg_175_w150_trial_margin
           - windowed_logreg_175_w150_adaptive_ranksoft
           - windowed_logreg_175_w150_source_anova_sqrt
           - windowed_logreg_175_w150_pca160
@@ -144,6 +145,8 @@ on:
           - windowed_logreg_175_w150_top2_margin_blend
           - windowed_logreg_175_w150_pca160_top3_score_softmax
           - windowed_logreg_175_w150_pca160_top3_score_softmax_inner_confusion
+          - windowed_logreg_175_w150_pca160_top2_score_softmax_quota
+          - windowed_logreg_175_w150_pca160_top3_score_softmax_quota
           - windowed_logreg_175_w150_top3_margin_blend
           - windowed_logreg_175_w150_top3_margin_blend_soft_guarded_inner_confusion
           - windowed_logreg_175_w125_w150
@@ -212,6 +215,8 @@ on:
           - rank_top2_margin_blend
           - rank_top2_score_softmax
           - rank_top3_score_softmax
+          - rank_top2_score_softmax_balanced_quota
+          - rank_top3_score_softmax_balanced_quota
           - rank_top3_margin_blend
           - rank_margin_blend
           - rank_adaptive_softmax
@@ -363,6 +368,19 @@ on:
           - rank_reciprocal_inner_balanced_confusion_balanced_quota
           - rank_borda_inner_balanced_confusion_balanced_quota
           - rank_z_blend_inner_balanced_confusion_balanced_quota
+      selection_ensemble_weighting_override:
+        description: Override the bundle's selected-ensemble weighting rule.
+        required: true
+        default: bundle-default
+        type: choice
+        options:
+          - bundle-default
+          - uniform
+          - inner_softmax
+          - inner_lcb_softmax
+          - inner_lcb_trial_margin_softmax
+          - inner_selection_softmax
+          - inner_selection_lcb_softmax
       selection_metric_override:
         description: Override the bundle's nested inner-LOSO selection metric.
         required: true
@@ -448,6 +466,7 @@ jobs:
           CONFIG_BUNDLE: ${{ inputs.config_bundle }}
           SELECTION_ENSEMBLE_DIVERSITY_OVERRIDE: ${{ inputs.selection_ensemble_diversity_override }}
           SELECTION_ENSEMBLE_SCORE_NORMALIZATION_OVERRIDE: ${{ inputs.selection_ensemble_score_normalization_override }}
+          SELECTION_ENSEMBLE_WEIGHTING_OVERRIDE: ${{ inputs.selection_ensemble_weighting_override }}
           SELECTION_METRIC_OVERRIDE: ${{ inputs.selection_metric_override }}
           PARTICIPANTS: ${{ inputs.participants }}
           PARTICIPANTS_PER_JOB: ${{ inputs.participants_per_job }}
@@ -1622,6 +1641,26 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_trial_margin": {
+                  # Same clean source-only w150 family as the current best run,
+                  # but weight the selected models per held-out trial by their
+                  # unlabeled score margin. This keeps the source-inner LCB
+                  # prior weights while down-weighting candidates that are
+                  # uncertain on a particular test trial.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_trial_margin_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_adaptive_ranksoft": {
                   "window_centers": "0.175",
                   "window_size": "0.150",
@@ -1776,6 +1815,38 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_top3_score_softmax_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_top2_score_softmax_quota": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top2_score_softmax_balanced_quota",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_top3_score_softmax_quota": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_score_softmax_balanced_quota",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
@@ -2696,6 +2767,7 @@ jobs:
           requested = os.environ["CONFIG_BUNDLE"]
           diversity_override = os.environ["SELECTION_ENSEMBLE_DIVERSITY_OVERRIDE"]
           score_normalization_override = os.environ["SELECTION_ENSEMBLE_SCORE_NORMALIZATION_OVERRIDE"]
+          weighting_override = os.environ["SELECTION_ENSEMBLE_WEIGHTING_OVERRIDE"]
           selection_metric_override = os.environ["SELECTION_METRIC_OVERRIDE"]
           selected_ids = tuple(bundles) if requested == "all" else (requested,)
           participants = parse_participants(os.environ["PARTICIPANTS"])
@@ -2722,6 +2794,8 @@ jobs:
                       row["selection_ensemble_diversity"] = diversity_override
                   if score_normalization_override != "bundle-default":
                       row["selection_ensemble_score_normalization"] = score_normalization_override
+                  if weighting_override != "bundle-default":
+                      row["selection_ensemble_weighting"] = weighting_override
                   if selection_metric_override != "bundle-default":
                       row["selection_metric"] = selection_metric_override
                   include.append(row)

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -258,6 +258,10 @@ TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS = {
     "rank_top2_score_softmax": 2,
     "rank_top3_score_softmax": 3,
 }
+TOPK_SCORE_SOFTMAX_BALANCED_QUOTA_SCORE_NORMALIZATIONS = {
+    f"{mode}_balanced_quota": top_k
+    for mode, top_k in TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS.items()
+}
 TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS = {
     # BUSH-MEG w150 runs now have robust top-2/top-3 signal, but top-1 is
     # still the bottleneck. The tuple is: (truncated Borda k, sharp rank-softmax
@@ -310,6 +314,8 @@ _previous_without_test_prior_balance_suffix = None
 _previous_test_class_prior_balance_mode = None
 _previous_test_class_prior_balance_metadata = None
 _previous_add_test_class_prior_balance_fields = None
+_previous_balanced_quota_metadata = None
+_previous_add_balanced_quota_fields = None
 
 CrossSubjectStimulusConfig = None
 
@@ -325,6 +331,7 @@ def install(impl) -> None:
     global _previous_summarize_nested, _previous_rank_nested_candidates, _previous_class_score_probabilities
     global _previous_without_test_prior_balance_suffix, _previous_test_class_prior_balance_mode
     global _previous_test_class_prior_balance_metadata, _previous_add_test_class_prior_balance_fields
+    global _previous_balanced_quota_metadata, _previous_add_balanced_quota_fields
 
     if getattr(impl, "_next_methods_installed", False):
         return
@@ -352,6 +359,8 @@ def install(impl) -> None:
     _previous_test_class_prior_balance_mode = impl._test_class_prior_balance_mode
     _previous_test_class_prior_balance_metadata = impl._test_class_prior_balance_metadata
     _previous_add_test_class_prior_balance_fields = impl._add_test_class_prior_balance_fields
+    _previous_balanced_quota_metadata = impl._balanced_quota_metadata
+    _previous_add_balanced_quota_fields = impl._add_balanced_quota_fields
 
     @dataclass(frozen=True)
     class NextCrossSubjectStimulusConfig(_BaseConfig):
@@ -387,6 +396,7 @@ def install(impl) -> None:
     _install_guarded_test_prior_balance_score_normalizations(impl)
     _install_topk_borda_score_normalizations(impl)
     _install_topk_score_softmax_score_normalizations(impl)
+    _install_topk_score_softmax_balanced_quota_score_normalizations(impl)
     _install_topk_margin_blend_score_normalizations(impl)
     _install_adaptive_rank_softmax_score_normalization(impl)
 
@@ -406,6 +416,9 @@ def install(impl) -> None:
     impl._test_class_prior_balance_mode = _test_class_prior_balance_mode
     impl._test_class_prior_balance_metadata = _test_class_prior_balance_metadata
     impl._add_test_class_prior_balance_fields = _add_test_class_prior_balance_fields
+    impl._balanced_quota_metadata = _balanced_quota_metadata
+    impl._add_balanced_quota_fields = _add_balanced_quota_fields
+    impl._topk_constrained_balanced_quota_predictions = _topk_constrained_balanced_quota_predictions
     impl._guarded_test_prior_balance_probabilities = _guarded_test_prior_balance_probabilities
     impl._class_score_probabilities = _class_score_probabilities
     impl._candidate_model_scores = _candidate_model_scores
@@ -542,6 +555,19 @@ def _install_topk_score_softmax_score_normalizations(impl) -> None:
             (
                 *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
                 *TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS,
+            )
+        )
+    )
+
+
+def _install_topk_score_softmax_balanced_quota_score_normalizations(impl) -> None:
+    """Expose top-k constrained balanced-quota assignment modes."""
+
+    impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
+        dict.fromkeys(
+            (
+                *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+                *TOPK_SCORE_SOFTMAX_BALANCED_QUOTA_SCORE_NORMALIZATIONS,
             )
         )
     )
@@ -697,6 +723,127 @@ def _add_test_class_prior_balance_fields(row, metadata):
     )
     row["ensemble_test_class_prior_guarded_adjusted_trials"] = metadata.get(
         "guarded_adjusted_trials",
+        "",
+    )
+
+
+def _balanced_quota_metadata(probabilities, class_order, score_normalization):
+    """Return optional top-k constrained balanced-assignment metadata."""
+
+    mode = _impl._normalize_ensemble_score_normalization(score_normalization)
+    top_k = TOPK_SCORE_SOFTMAX_BALANCED_QUOTA_SCORE_NORMALIZATIONS.get(mode)
+    if top_k is None:
+        return _previous_balanced_quota_metadata(
+            probabilities,
+            class_order,
+            score_normalization,
+        )
+
+    predictions, quota_counts, status, fallback = _topk_constrained_balanced_quota_predictions(
+        probabilities,
+        class_order,
+        top_k=top_k,
+    )
+    return {
+        "mode": mode,
+        "status": status,
+        "class_order": np.asarray(class_order, dtype=int).ravel(),
+        "quota_counts": quota_counts,
+        "predictions": predictions,
+        "guarded_fixed_trials": "",
+        "top_k_constrained": int(top_k),
+        "top_k_fallback": bool(fallback),
+    }
+
+
+def _topk_constrained_balanced_quota_predictions(probabilities, class_order, *, top_k):
+    probabilities = np.asarray(probabilities, dtype=float)
+    class_order = np.asarray(class_order, dtype=int).ravel()
+    top_k = int(top_k)
+    if top_k <= 0:
+        raise ValueError("top_k must be positive.")
+    if (
+        probabilities.ndim != 2
+        or probabilities.shape[0] == 0
+        or probabilities.shape[1] == 0
+    ):
+        return (
+            np.asarray([], dtype=int),
+            np.zeros(class_order.shape[0], dtype=int),
+            "skipped_empty_scores",
+            False,
+        )
+    if class_order.shape[0] != probabilities.shape[1]:
+        return (
+            np.asarray([], dtype=int),
+            np.zeros(class_order.shape[0], dtype=int),
+            "skipped_class_order_mismatch",
+            False,
+        )
+
+    sanitized = _impl._finite_assignment_scores(probabilities)
+    quotas = _impl._balanced_quota_counts(sanitized)
+    expanded_columns = np.repeat(np.arange(sanitized.shape[1], dtype=int), quotas)
+    if expanded_columns.shape[0] != sanitized.shape[0]:
+        predictions, quota_counts, status = _impl._balanced_quota_predictions(
+            probabilities,
+            class_order,
+        )
+        return predictions, quota_counts, f"fallback_top{top_k}_{status}", True
+
+    allowed = _topk_allowed_assignment_mask(probabilities, top_k=top_k)
+    assignment_scores = sanitized[:, expanded_columns].copy()
+    disallowed = ~allowed[:, expanded_columns]
+    if np.any(disallowed):
+        finite_scores = assignment_scores[np.isfinite(assignment_scores)]
+        if finite_scores.size:
+            score_floor = float(np.min(finite_scores))
+            score_span = max(float(np.max(finite_scores) - score_floor), 1.0)
+            assignment_scores[disallowed] = score_floor - score_span - 1.0
+        else:
+            assignment_scores[disallowed] = -1.0
+
+    row_indices, slot_indices = _impl.linear_sum_assignment(-assignment_scores)
+    assigned_columns = expanded_columns[slot_indices]
+    assigned_allowed = allowed[row_indices, assigned_columns]
+    if not bool(np.all(assigned_allowed)):
+        predictions, quota_counts, status = _impl._balanced_quota_predictions(
+            probabilities,
+            class_order,
+        )
+        return predictions, quota_counts, f"fallback_top{top_k}_infeasible_{status}", True
+
+    prediction_columns = np.empty(sanitized.shape[0], dtype=int)
+    prediction_columns[row_indices] = assigned_columns
+    return class_order[prediction_columns], quotas, f"applied_top{top_k}_constrained", False
+
+
+def _topk_allowed_assignment_mask(probabilities, *, top_k):
+    probabilities = np.asarray(probabilities, dtype=float)
+    allowed = np.zeros(probabilities.shape, dtype=bool)
+    for row_index, row in enumerate(probabilities):
+        finite = np.isfinite(row)
+        n_finite = int(np.sum(finite))
+        if n_finite == 0:
+            allowed[row_index, :] = True
+            continue
+        k = min(int(top_k), n_finite)
+        ranked = np.argsort(-np.where(finite, row, -np.inf), kind="mergesort")[:k]
+        allowed[row_index, ranked] = True
+        positive = finite & (row > 0.0)
+        if np.any(positive):
+            allowed[row_index, positive] = True
+    return allowed
+
+
+def _add_balanced_quota_fields(row, metadata):
+    _previous_add_balanced_quota_fields(row, metadata)
+    row["ensemble_balanced_quota_top_k_constrained"] = metadata.get(
+        "top_k_constrained",
+        "",
+    )
+    row["ensemble_balanced_quota_top_k_fallback"] = metadata.get(
+        "top_k_fallback",
         "",
     )
 

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -115,6 +115,37 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertGreater(probabilities[0, 1], probabilities[0, 2])
         self.assertEqual(probabilities[0, 3], 0.0)
 
+    def test_topk_score_softmax_balanced_quota_modes_are_exported_and_constrained(self):
+        mode = "rank_top2_score_softmax_balanced_quota"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_top2_score_softmax",
+        )
+
+        probabilities = np.asarray(
+            [
+                [0.90, 0.10, 0.00],
+                [0.80, 0.20, 0.00],
+                [0.10, 0.80, 0.10],
+                [0.00, 0.70, 0.30],
+                [0.20, 0.00, 0.80],
+                [0.10, 0.00, 0.90],
+            ],
+            dtype=float,
+        )
+        metadata = cross_subject._balanced_quota_metadata(  # pylint: disable=protected-access
+            probabilities,
+            np.arange(3, dtype=int),
+            mode,
+        )
+
+        self.assertEqual(metadata["status"], "applied_top2_constrained")
+        np.testing.assert_array_equal(metadata["quota_counts"], np.asarray([2, 2, 2]))
+        np.testing.assert_array_equal(metadata["predictions"], np.asarray([0, 0, 1, 1, 2, 2]))
+        self.assertEqual(metadata["top_k_constrained"], 2)
+
     def test_topk_score_softmax_inner_confusion_guarded_mode_is_exported(self):
         mode = "rank_top3_score_softmax_inner_confusion_soft_guarded"
 


### PR DESCRIPTION
Summary:
- add BUSH W150 trial-margin workflow variant alongside time-bin runs
- add top-k score softmax balanced quota normalization modes
- add focused regression coverage for constrained top-k quota assignments

Verification:
- python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject_next.py
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"
- git diff --check

Tests were not run per request.