### PR TITLE
Add recall bias strength and entropy variants

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -96,6 +96,7 @@ on:
           - windowed_logreg_175_w150_worstclass_lcb
           - windowed_logreg_175_w150_time_bins7
           - windowed_logreg_175_w150_trial_margin
+          - windowed_logreg_175_w150_trial_entropy
           - windowed_logreg_175_w150_adaptive_ranksoft
           - windowed_logreg_175_w150_source_anova_sqrt
           - windowed_logreg_175_w150_pca160
@@ -103,6 +104,9 @@ on:
           - windowed_logreg_175_w150_pca160_guarded_test_prior
           - windowed_logreg_175_w150_pca160_recall_bias
           - windowed_logreg_175_w150_pca160_top3_recall_bias
+          - windowed_logreg_175_w150_pca160_recall_bias_s25
+          - windowed_logreg_175_w150_pca160_recall_bias_s75
+          - windowed_logreg_175_w150_pca160_recall_bias_s100
           - windowed_logreg_175_w150_pca160_ranksoft_t0_75
           - windowed_logreg_175_w150_pca160_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_pca160_c03_c05
@@ -227,7 +231,13 @@ on:
           - rank_top3_margin_blend
           - rank_margin_blend
           - rank_softmax_inner_recall_bias
+          - rank_softmax_inner_recall_bias_s25
+          - rank_softmax_inner_recall_bias_s75
+          - rank_softmax_inner_recall_bias_s100
           - rank_softmax_t0_75_inner_recall_bias
+          - rank_softmax_t0_75_inner_recall_bias_s25
+          - rank_softmax_t0_75_inner_recall_bias_s75
+          - rank_softmax_t0_75_inner_recall_bias_s100
           - rank_softmax_t1_25_inner_recall_bias
           - rank_top3_score_softmax_inner_recall_bias
           - rank_top3_margin_blend_inner_recall_bias
@@ -391,6 +401,7 @@ on:
           - inner_softmax
           - inner_lcb_softmax
           - inner_lcb_trial_margin_softmax
+          - inner_lcb_trial_entropy_softmax
           - inner_selection_softmax
           - inner_selection_lcb_softmax
       selection_metric_override:
@@ -1673,6 +1684,28 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_trial_margin_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_trial_entropy": {
+                  # Same clean source-only w150 family as the current best run,
+                  # but weight selected models per held-out trial by normalized
+                  # score entropy. Unlike the margin-only variant, entropy uses
+                  # the whole unlabeled score posterior and can favor a model
+                  # that is globally less ambiguous on a trial even when the
+                  # top-two margin is similar. No cue data or held-out labels
+                  # are used.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_trial_entropy_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_worstclass_lcb": {
                   # The current clean BUSH-MEG w150 source-only winner is strong
                   # on average but still has weak recall for a few stimulus
@@ -1754,6 +1787,55 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax_inner_recall_bias",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_recall_bias_s25": {
+                  # Same low-risk w150/PCA160 family as recall_bias, but with a
+                  # weaker source-inner recall-bias correction.  This should be
+                  # useful if the default 0.50 strength over-corrects top-1 class
+                  # biases while the top-2/top-3 signal remains strong.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_recall_bias_s25",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_recall_bias_s75": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_recall_bias_s75",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_recall_bias_s100": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5,1",
+                  "components_pca_values": "160",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax_inner_recall_bias_s100",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -73,6 +73,7 @@ SELECTION_ENSEMBLE_WEIGHTING_MODES = (
     "inner_softmax",
     "inner_lcb_softmax",
     "inner_lcb_trial_margin_softmax",
+    "inner_lcb_trial_entropy_softmax",
     "inner_selection_softmax",
     "inner_selection_lcb_softmax",
 )
@@ -317,6 +318,8 @@ RANK_CONSENSUS_DISAGREEMENT_PENALTY = 0.5
 RANK_MEDIAN_CONSENSUS_TEMPERATURE = 0.75
 RANK_MEDIAN_CONSENSUS_TOP_AGREEMENT_BONUS = 0.50
 TRIAL_MARGIN_ENSEMBLE_WEIGHT_FLOOR = 0.25
+TRIAL_ENTROPY_ENSEMBLE_WEIGHT_FLOOR = 0.25
+TRIAL_ENTROPY_EPSILON = 1e-12
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
     "window",
@@ -1796,6 +1799,8 @@ def _nested_ensemble_weight_scores(selected_rows, *, weighting):
         return means
     if weighting == "inner_lcb_trial_margin_softmax":
         weighting = "inner_lcb_softmax"
+    if weighting == "inner_lcb_trial_entropy_softmax":
+        weighting = "inner_lcb_softmax"
     if weighting == "inner_lcb_softmax":
         means = np.asarray([float(row["selected_inner_balanced_accuracy_mean"]) for row in selected_rows], dtype=float)
         sems = np.asarray([float(row.get("selected_inner_balanced_accuracy_sem", 0.0)) for row in selected_rows], dtype=float)
@@ -2325,25 +2330,55 @@ def _normalize_trialwise_ensemble_weights(weights, n_models, n_trials):
 
 
 def _trial_margin_ensemble_weights(score_matrices, base_weights, weighting):
-    """Return trialwise model weights for the margin-aware ensemble mode."""
+    """Return optional trialwise model weights for confidence-aware ensemble modes."""
 
     weighting = _normalize_selection_ensemble_weighting(weighting)
     score_matrices = tuple(score_matrices)
     base_weights = _normalized_ensemble_weights(base_weights, len(score_matrices))
-    if weighting != "inner_lcb_trial_margin_softmax":
+    if weighting not in {"inner_lcb_trial_margin_softmax", "inner_lcb_trial_entropy_softmax"}:
         return base_weights
 
     score_tensor = np.stack(tuple(np.asarray(matrix, dtype=float) for matrix in score_matrices), axis=0)
     if score_tensor.ndim != 3 or score_tensor.shape[0] == 0:
         return base_weights
-    confidences = np.vstack([
-        _rank_margin_blend_confidence(score_tensor[model_index])
-        for model_index in range(score_tensor.shape[0])
-    ])
-    floor = float(TRIAL_MARGIN_ENSEMBLE_WEIGHT_FLOOR)
+    if weighting == "inner_lcb_trial_entropy_softmax":
+        confidences = np.vstack([
+            _score_entropy_confidence(score_tensor[model_index])
+            for model_index in range(score_tensor.shape[0])
+        ])
+        floor = float(TRIAL_ENTROPY_ENSEMBLE_WEIGHT_FLOOR)
+    else:
+        confidences = np.vstack([
+            _rank_margin_blend_confidence(score_tensor[model_index])
+            for model_index in range(score_tensor.shape[0])
+        ])
+        floor = float(TRIAL_MARGIN_ENSEMBLE_WEIGHT_FLOOR)
     confidence_weights = floor + (1.0 - floor) * np.clip(confidences, 0.0, 1.0)
     trial_weights = base_weights[:, None] * confidence_weights
     return _normalize_trialwise_ensemble_weights(trial_weights, score_tensor.shape[0], score_tensor.shape[1])
+
+
+def _score_entropy_confidence(scores):
+    """Return unlabeled per-trial confidence from normalized score entropy.
+
+    The BUSH-MEG source-only models often put the true class in the top-2/top-3
+    even when the final top-1 class differs across ensemble members.  This
+    confidence score lets the ensemble lean toward the selected model whose
+    row-normalized score posterior is sharpest for a given held-out
+    trial, while preserving the source-inner LCB prior weights and avoiding
+    any held-out labels or cue data.
+    """
+
+    probabilities = _row_softmax_probabilities(scores)
+    if probabilities.ndim != 2 or probabilities.shape[0] == 0:
+        return np.asarray([], dtype=float)
+    n_classes = int(probabilities.shape[1])
+    if n_classes <= 1:
+        return np.ones(probabilities.shape[0], dtype=float)
+    epsilon = float(TRIAL_ENTROPY_EPSILON)
+    sanitized = np.clip(np.asarray(probabilities, dtype=float), epsilon, 1.0)
+    entropy = -np.sum(sanitized * np.log(sanitized), axis=1) / np.log(float(n_classes))
+    return np.clip(1.0 - entropy, 0.0, 1.0)
 
 
 def _ensemble_log_pool_mode(score_normalization):

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -302,7 +302,20 @@ WORST_CLASS_SELECTION_METRICS = (
     "balanced_worst_class_lcb",
 )
 WORST_CLASS_SELECTION_WEIGHT = 0.25
-INNER_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
+INNER_RECALL_BIAS_SMOOTHING = 1.0
+INNER_RECALL_BIAS_STRENGTH = 0.50
+INNER_RECALL_BIAS_CLIP = 1.0
+INNER_RECALL_BIAS_STRENGTH_VARIANTS = {
+    # Keep the existing unsuffixed modes at strength 0.50, but expose a small
+    # leakage-safe sweep for the current BUSH-MEG regime: the w150 source-only
+    # decoder has strong top-2/top-3 signal and uneven class recall, but a fixed
+    # class-bias correction can over- or under-compensate.  The suffixed modes
+    # differ only in source-inner recall-bias strength.
+    "s25": 0.25,
+    "s75": 0.75,
+    "s100": 1.00,
+}
+_DEFAULT_INNER_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
     # Leakage-safe class-bias correction derived from source-inner validation
     # recalls.  It is intended for the current BUSH-MEG regime where the best
     # source-only w150 runs have strong top-2/top-3 signal but still uneven
@@ -314,9 +327,26 @@ INNER_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
     "rank_top3_score_softmax_inner_recall_bias": "rank_top3_score_softmax",
     "rank_top3_margin_blend_inner_recall_bias": "rank_top3_margin_blend",
 }
-INNER_RECALL_BIAS_SMOOTHING = 1.0
-INNER_RECALL_BIAS_STRENGTH = 0.50
-INNER_RECALL_BIAS_CLIP = 1.0
+INNER_RECALL_BIAS_STRENGTH_VARIANT_BASES = {
+    f"{mode}_{suffix}": base
+    for mode, base in _DEFAULT_INNER_RECALL_BIAS_SCORE_NORMALIZATION_BASES.items()
+    for suffix in INNER_RECALL_BIAS_STRENGTH_VARIANTS
+}
+INNER_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
+    **_DEFAULT_INNER_RECALL_BIAS_SCORE_NORMALIZATION_BASES,
+    **INNER_RECALL_BIAS_STRENGTH_VARIANT_BASES,
+}
+INNER_RECALL_BIAS_STRENGTH_BY_MODE = {
+    **{
+        mode: INNER_RECALL_BIAS_STRENGTH
+        for mode in _DEFAULT_INNER_RECALL_BIAS_SCORE_NORMALIZATION_BASES
+    },
+    **{
+        f"{mode}_{suffix}": strength
+        for mode in _DEFAULT_INNER_RECALL_BIAS_SCORE_NORMALIZATION_BASES
+        for suffix, strength in INNER_RECALL_BIAS_STRENGTH_VARIANTS.items()
+    },
+}
 
 _impl = None
 _BaseConfig = None
@@ -977,7 +1007,9 @@ def _inner_recall_bias_metadata(
         }
 
     smoothing = float(INNER_RECALL_BIAS_SMOOTHING)
-    strength = float(INNER_RECALL_BIAS_STRENGTH)
+    strength = float(
+        INNER_RECALL_BIAS_STRENGTH_BY_MODE.get(inner_mode, INNER_RECALL_BIAS_STRENGTH)
+    )
     clip_value = float(INNER_RECALL_BIAS_CLIP)
     n_classes = max(int(class_order.shape[0]), 1)
     true_counts = np.sum(counts, axis=1)
@@ -1013,6 +1045,7 @@ def _inner_recall_bias_metadata(
         "recall_bias_global_recall": global_recall,
         "recall_bias_recalls": recalls,
         "recall_bias_true_predicted_counts": counts,
+        "recall_bias_strength_mode": inner_mode,
     }
 
 
@@ -1030,6 +1063,10 @@ def _add_inner_class_prior_balance_fields(row, metadata):
     )
     row["ensemble_inner_recall_bias_strength"] = metadata.get(
         "recall_bias_strength",
+        "",
+    )
+    row["ensemble_inner_recall_bias_strength_mode"] = metadata.get(
+        "recall_bias_strength_mode",
         "",
     )
     row["ensemble_inner_recall_bias_clip"] = metadata.get("recall_bias_clip", "")

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -98,6 +98,35 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertLess(softer_probabilities[0, 0], default_probabilities[0, 0])
         self.assertGreater(softer_probabilities[0, 1], default_probabilities[0, 1])
 
+    def test_trial_entropy_ensemble_weighting_prefers_sharp_model_per_trial(self):
+        score_matrices = (
+            np.asarray(
+                [
+                    [8.0, 1.0, 0.0],
+                    [1.0, 0.9, 0.8],
+                ],
+                dtype=float,
+            ),
+            np.asarray(
+                [
+                    [1.0, 0.9, 0.8],
+                    [0.0, 1.0, 8.0],
+                ],
+                dtype=float,
+            ),
+        )
+
+        weights = cross_subject._trial_margin_ensemble_weights(  # pylint: disable=protected-access
+            score_matrices,
+            np.asarray([0.5, 0.5], dtype=float),
+            "inner_lcb_trial_entropy_softmax",
+        )
+
+        self.assertEqual(weights.shape, (2, 2))
+        self.assertGreater(weights[0, 0], weights[1, 0])
+        self.assertGreater(weights[1, 1], weights[0, 1])
+        np.testing.assert_allclose(np.sum(weights, axis=0), np.ones(2))
+
     def test_fractional_rank_softmax_inner_confusion_modes_are_supported(self):
         modes = [
             "rank_softmax_t1_5_inner_confusion_soft_guarded",

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -188,6 +188,42 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(metadata["inner_mode"], mode)
         self.assertTrue(metadata["guarded"])
 
+    def test_inner_recall_bias_strength_variants_are_exported_and_scaled(self):
+        weak_mode = "rank_softmax_t0_75_inner_recall_bias_s25"
+        default_mode = "rank_softmax_t0_75_inner_recall_bias"
+        strong_mode = "rank_softmax_t0_75_inner_recall_bias_s100"
+
+        self.assertIn(weak_mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertIn(strong_mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(weak_mode),  # pylint: disable=protected-access
+            "rank_softmax_t0_75",
+        )
+
+        selected_rows = [
+            {
+                "selected_inner_true_predicted_label_pair_counts": "1001:6;1002:2;2001:5;2002:3",
+                "selected_inner_confusion_counts": "",
+            }
+        ]
+        weak_metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows, np.arange(2, dtype=int), np.ones(1, dtype=float), weak_mode
+        )
+        default_metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows, np.arange(2, dtype=int), np.ones(1, dtype=float), default_mode
+        )
+        strong_metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows, np.arange(2, dtype=int), np.ones(1, dtype=float), strong_mode
+        )
+
+        self.assertEqual(weak_metadata["inner_mode"], weak_mode)
+        self.assertAlmostEqual(weak_metadata["recall_bias_strength"], 0.25)
+        self.assertAlmostEqual(default_metadata["recall_bias_strength"], 0.50)
+        self.assertAlmostEqual(strong_metadata["recall_bias_strength"], 1.00)
+        self.assertGreater(weak_metadata["log_adjustment"][1], weak_metadata["log_adjustment"][0])
+        self.assertLess(np.ptp(weak_metadata["log_adjustment"]), np.ptp(default_metadata["log_adjustment"]))
+        self.assertLess(np.ptp(default_metadata["log_adjustment"]), np.ptp(strong_metadata["log_adjustment"]))
+
     def test_guarded_test_prior_balance_is_exported_and_margin_gated(self):
         mode = "rank_softmax_guarded_test_prior_balance"
 


### PR DESCRIPTION
Summary:
- add recall-bias strength sweep modes and workflow bundles
- add trial-entropy ensemble weighting
- expose the new BUSH-MEG workflow variants

Verification:
- python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject.py tests\test_stimulus_cross_subject_next.py
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text())"
- git diff --check

Tests were not run per request.