### PR TITLE
Add artifact-level stimulus ensembling

### DIFF
--- a/.github/workflows/stimulus-artifact-ensemble.yml
+++ b/.github/workflows/stimulus-artifact-ensemble.yml
@@ -1,0 +1,104 @@
+name: Manual stimulus artifact ensemble
+
+on:
+  workflow_dispatch:
+    inputs:
+      compact_run_id:
+        description: Compact PCA160/C0.3-C0.5 run id.
+        required: true
+        default: "26870015355"
+        type: string
+      small_finetune_run_id:
+        description: Small finetune run id.
+        required: true
+        default: "26742761615"
+        type: string
+      w150_pca128_run_id:
+        description: w150 PCA128-family run id.
+        required: true
+        default: "26710557909"
+        type: string
+      w125_run_id:
+        description: w125 run id.
+        required: true
+        default: "26710553971"
+        type: string
+      artifact_name:
+        description: Name of the aggregate artifact to download from each run.
+        required: true
+        default: nested-matrix-aggregate
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  artifact-ensemble:
+    name: Artifact-level prediction ensemble
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install .
+
+      - name: Download aggregate artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+          COMPACT_RUN_ID: ${{ inputs.compact_run_id }}
+          SMALL_FINETUNE_RUN_ID: ${{ inputs.small_finetune_run_id }}
+          W150_PCA128_RUN_ID: ${{ inputs.w150_pca128_run_id }}
+          W125_RUN_ID: ${{ inputs.w125_run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          gh run download "${COMPACT_RUN_ID}" -n "${ARTIFACT_NAME}" -D artifacts/compact
+          gh run download "${SMALL_FINETUNE_RUN_ID}" -n "${ARTIFACT_NAME}" -D artifacts/small_finetune
+          gh run download "${W150_PCA128_RUN_ID}" -n "${ARTIFACT_NAME}" -D artifacts/w150_pca128
+          gh run download "${W125_RUN_ID}" -n "${ARTIFACT_NAME}" -D artifacts/w125
+
+      - name: Combine predictions
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pymegdec.stimulus_artifact_ensemble \
+            --source compact=artifacts/compact \
+            --source small_finetune=artifacts/small_finetune \
+            --source w150_pca128=artifacts/w150_pca128 \
+            --source w125=artifacts/w125 \
+            --ensemble compact=compact \
+            --ensemble compact_small_finetune=compact,small_finetune \
+            --ensemble compact_w150_pca128=compact,w150_pca128 \
+            --ensemble compact_w125=compact,w125 \
+            --ensemble compact_small_finetune_w150_pca128=compact,small_finetune,w150_pca128 \
+            --key-column test_participant \
+            --key-column test_trial_index \
+            --key-column true_label \
+            --output-dir outputs \
+            --output-stem artifact_ensemble
+
+      - name: Append comparison summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat outputs/artifact_ensemble_comparison.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload artifact ensemble outputs
+        uses: actions/upload-artifact@v7
+        with:
+          name: stimulus-artifact-ensemble
+          path: outputs/*
+          if-no-files-found: error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ pymegdec-stimulus-cross-subject-full-epoch-lowrank = "pymegdec.stimulus_full_epo
 pymegdec-stimulus-cross-subject-hyperalignment = "pymegdec.stimulus_hyperalignment:main"
 pymegdec-stimulus-cross-subject-logit-stack = "pymegdec.stimulus_logit_stacking:main"
 pymegdec-stimulus-cross-subject-mcca = "pymegdec.stimulus_mcca:main"
+pymegdec-stimulus-artifact-ensemble = "pymegdec.stimulus_artifact_ensemble:main"
 pymegdec-alpha-movement-results = "pymegdec.alpha_cli:alpha_movement_results"
 pymegdec-make-synthetic-data = "pymegdec.synthetic_data_cli:main"
 pymegdec-neureptrace = "pymegdec.neureptrace_compat:main"

--- a/src/pymegdec/stimulus_artifact_ensemble.py
+++ b/src/pymegdec/stimulus_artifact_ensemble.py
@@ -1,0 +1,460 @@
+"""Combine existing nested-matrix prediction artifacts without refitting models."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import re
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from pymegdec.alpha_metrics import write_alpha_metrics_csv
+
+PREDICTION_FILE_CANDIDATES = ("nested_matrix_predictions.csv",)
+DEFAULT_KEY_COLUMNS = ("test_participant", "test_trial_index", "true_label")
+CLASS_SCORE_RE = re.compile(r"^(?:score|prob)_class_(-?\d+)$")
+CLASS_RANK_RE = re.compile(r"^rank_class_(-?\d+)$")
+
+
+@dataclass(frozen=True)
+class PredictionSource:
+    """Named trial-level prediction table loaded from an artifact."""
+
+    name: str
+    path: Path
+    rows: list[dict[str, str]]
+
+
+def read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def write_csv_rows(path: Path, rows: Iterable[dict]) -> None:
+    rows = list(rows)
+    write_alpha_metrics_csv(rows, path)
+
+
+def resolve_prediction_csv(path: Path) -> Path:
+    """Resolve an artifact directory or CSV path to a prediction CSV."""
+
+    if path.is_file():
+        return path
+    for name in PREDICTION_FILE_CANDIDATES:
+        candidate = path / name
+        if candidate.exists():
+            return candidate
+    matches = sorted(path.rglob("*_predictions.csv"))
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise FileNotFoundError(f"No *_predictions.csv file found below {path}.")
+    preferred = [match for match in matches if match.name == "nested_matrix_predictions.csv"]
+    if preferred:
+        return preferred[0]
+    raise ValueError(f"Found multiple prediction CSV files below {path}; pass one explicitly.")
+
+
+def load_prediction_source(spec: str) -> PredictionSource:
+    """Load a ``name=path`` source specification."""
+
+    if "=" not in spec:
+        raise ValueError(f"Source must use name=path syntax, got {spec!r}.")
+    name, raw_path = spec.split("=", 1)
+    name = name.strip()
+    if not name:
+        raise ValueError(f"Source name is empty in {spec!r}.")
+    path = resolve_prediction_csv(Path(raw_path.strip()))
+    rows = read_csv_rows(path)
+    if not rows:
+        raise ValueError(f"Source {name!r} has no prediction rows: {path}")
+    return PredictionSource(name=name, path=path, rows=rows)
+
+
+def parse_ensemble_spec(spec: str) -> tuple[str, tuple[str, ...]]:
+    """Return ``(ensemble_name, source_names)`` from ``name=a,b,c``."""
+
+    if "=" not in spec:
+        raise ValueError(f"Ensemble must use name=source_a,source_b syntax, got {spec!r}.")
+    name, raw_sources = spec.split("=", 1)
+    source_names = tuple(token.strip() for token in raw_sources.split(",") if token.strip())
+    if not name.strip() or not source_names:
+        raise ValueError(f"Invalid ensemble specification: {spec!r}.")
+    return name.strip(), source_names
+
+
+def _string_key(row: dict[str, str], columns: Sequence[str]) -> tuple[str, ...]:
+    return tuple(str(row.get(column, "")).strip() for column in columns)
+
+
+def _index_rows(source: PredictionSource, key_columns: Sequence[str]) -> dict[tuple[str, ...], dict[str, str]]:
+    indexed: dict[tuple[str, ...], dict[str, str]] = {}
+    for row_number, row in enumerate(source.rows, start=2):
+        key = _string_key(row, key_columns)
+        if any(value == "" for value in key):
+            raise ValueError(f"{source.name} row {row_number} is missing one of key columns {', '.join(key_columns)}.")
+        if key in indexed:
+            raise ValueError(f"{source.name} has duplicate prediction key {key}.")
+        indexed[key] = row
+    return indexed
+
+
+def _to_int(value: object, *, field: str) -> int:
+    text = str(value).strip()
+    if text == "":
+        raise ValueError(f"Missing integer value for {field}.")
+    return int(float(text))
+
+
+def _to_float(value: object) -> float:
+    return float(str(value).strip())
+
+
+def _label_from_row(row: dict[str, str], *, label_column: str, stimulus_column: str, field: str) -> int:
+    raw_label = row.get(label_column)
+    if raw_label is not None and str(raw_label).strip() != "":
+        return _to_int(raw_label, field=field)
+    raw_stimulus = row.get(stimulus_column)
+    if raw_stimulus is None or str(raw_stimulus).strip() == "":
+        raise ValueError(f"Missing {label_column} or {stimulus_column}.")
+    return _to_int(raw_stimulus, field=stimulus_column) - 1
+
+
+def _source_rank(row: dict[str, str]) -> float | None:
+    value = str(row.get("true_label_rank", "")).strip()
+    if value == "":
+        return None
+    try:
+        rank = float(value)
+    except ValueError:
+        return None
+    return rank if math.isfinite(rank) else None
+
+
+def _all_labels(rows: Iterable[dict[str, str]]) -> list[int]:
+    labels: set[int] = set()
+    for row in rows:
+        for label_column, stimulus_column, field in (
+            ("true_label", "true_stimulus", "true_label"),
+            ("predicted_label", "predicted_stimulus", "predicted_label"),
+        ):
+            try:
+                labels.add(_label_from_row(row, label_column=label_column, stimulus_column=stimulus_column, field=field))
+            except ValueError:
+                continue
+    return sorted(labels)
+
+
+def _rank_labels_by_hard_votes(
+    source_rows: Sequence[dict[str, str]],
+    *,
+    class_labels: Sequence[int],
+) -> list[int]:
+    predictions = [
+        _label_from_row(row, label_column="predicted_label", stimulus_column="predicted_stimulus", field="predicted_label")
+        for row in source_rows
+    ]
+    votes = Counter(predictions)
+    first_source_index: dict[int, int] = {}
+    for index, predicted in enumerate(predictions):
+        first_source_index.setdefault(predicted, index)
+    return sorted(
+        class_labels,
+        key=lambda label: (
+            -votes.get(label, 0),
+            first_source_index.get(label, len(source_rows)),
+            label,
+        ),
+    )
+
+
+def _class_value_columns(rows: Sequence[dict[str, str]], pattern: re.Pattern[str]) -> dict[int, str]:
+    common: dict[int, str] | None = None
+    for row in rows:
+        columns = {
+            int(match.group(1)): column
+            for column in row
+            if (match := pattern.match(column)) and str(row.get(column, "")).strip() != ""
+        }
+        common = columns if common is None else {label: column for label, column in common.items() if label in columns}
+    return common or {}
+
+
+def _rank_labels_by_scores(source_rows: Sequence[dict[str, str]], *, class_labels: Sequence[int]) -> tuple[list[int], str] | None:
+    score_columns = _class_value_columns(source_rows, CLASS_SCORE_RE)
+    if score_columns:
+        scores: dict[int, float] = {}
+        for label in class_labels:
+            column = score_columns.get(label)
+            if column is None:
+                continue
+            values = [float(row[column]) for row in source_rows]
+            scores[label] = sum(values) / len(values)
+        if scores:
+            return sorted(class_labels, key=lambda label: (-scores.get(label, float("-inf")), label)), "class_score_mean"
+
+    rank_columns = _class_value_columns(source_rows, CLASS_RANK_RE)
+    if rank_columns:
+        borda_scores: dict[int, float] = {}
+        for label in class_labels:
+            column = rank_columns.get(label)
+            if column is None:
+                continue
+            values = [float(row[column]) for row in source_rows]
+            borda_scores[label] = -sum(values) / len(values)
+        if borda_scores:
+            return sorted(class_labels, key=lambda label: (-borda_scores.get(label, float("-inf")), label)), "class_rank_borda"
+
+    return None
+
+
+def _sem(values: Sequence[float]) -> float:
+    finite = [value for value in values if math.isfinite(value)]
+    if len(finite) <= 1:
+        return 0.0 if finite else math.nan
+    mean = sum(finite) / len(finite)
+    variance = sum((value - mean) ** 2 for value in finite) / (len(finite) - 1)
+    return math.sqrt(variance) / math.sqrt(len(finite))
+
+
+def _mean(values: Sequence[float]) -> float:
+    finite = [value for value in values if math.isfinite(value)]
+    return sum(finite) / len(finite) if finite else math.nan
+
+
+def _balanced_accuracy(rows: Sequence[dict[str, object]]) -> float:
+    by_label: dict[int, list[bool]] = defaultdict(list)
+    for row in rows:
+        by_label[_to_int(row["true_label"], field="true_label")].append(bool(row["correct"]))
+    if not by_label:
+        return math.nan
+    recalls = [sum(values) / len(values) for values in by_label.values() if values]
+    return sum(recalls) / len(recalls) if recalls else math.nan
+
+
+def _format_percent(value: float) -> str:
+    return "" if not math.isfinite(value) else f"{100.0 * value:.6f}"
+
+
+def _prediction_row(
+    *,
+    ensemble_name: str,
+    source_names: Sequence[str],
+    source_rows: Sequence[dict[str, str]],
+    key_columns: Sequence[str],
+    key: tuple[str, ...],
+    class_labels: Sequence[int],
+) -> dict[str, object]:
+    reference = source_rows[0]
+    true_label = _label_from_row(reference, label_column="true_label", stimulus_column="true_stimulus", field="true_label")
+    source_predictions = [
+        _label_from_row(row, label_column="predicted_label", stimulus_column="predicted_stimulus", field="predicted_label")
+        for row in source_rows
+    ]
+    if len(source_rows) == 1:
+        ranked = _rank_labels_by_scores(source_rows, class_labels=class_labels)
+        if ranked is not None:
+            ranked_labels, rank_source = ranked
+            true_rank = float(ranked_labels.index(true_label) + 1)
+        else:
+            ranked_labels = [source_predictions[0], *[label for label in class_labels if label != source_predictions[0]]]
+            source_true_rank = _source_rank(reference)
+            true_rank = source_true_rank if source_true_rank is not None else float(ranked_labels.index(true_label) + 1)
+            rank_source = "source_true_label_rank" if source_true_rank is not None else "hard_vote"
+    else:
+        ranked = _rank_labels_by_scores(source_rows, class_labels=class_labels)
+        if ranked is None:
+            ranked_labels = _rank_labels_by_hard_votes(source_rows, class_labels=class_labels)
+            rank_source = "hard_vote"
+        else:
+            ranked_labels, rank_source = ranked
+        true_rank = float(ranked_labels.index(true_label) + 1)
+    predicted_label = int(ranked_labels[0])
+    row: dict[str, object] = {
+        "artifact_ensemble": ensemble_name,
+        "artifact_ensemble_sources": ";".join(source_names),
+        "artifact_ensemble_source_count": len(source_names),
+        "artifact_ensemble_mode": (
+            "hard_vote_tiebreak_first_source"
+            if rank_source in {"hard_vote", "source_true_label_rank"}
+            else rank_source
+        ),
+        "artifact_ensemble_rank_source": rank_source,
+        "true_label": true_label,
+        "predicted_label": predicted_label,
+        "true_stimulus": true_label + 1,
+        "predicted_stimulus": predicted_label + 1,
+        "correct": predicted_label == true_label,
+        "true_label_rank": true_rank,
+        "top2_correct": true_rank <= 2,
+        "top3_correct": true_rank <= 3,
+        "source_predicted_labels": ";".join(str(value) for value in source_predictions),
+        "vote_ranked_labels": ";".join(str(value) for value in ranked_labels),
+    }
+    for column, value in zip(key_columns, key, strict=True):
+        row[column] = value
+    for optional in ("test_participant", "test_trial_index", "trial", "test_trial_number", "outer_fold"):
+        if optional in reference and optional not in row:
+            row[optional] = reference.get(optional, "")
+    return row
+
+
+def _outer_rows(ensemble_name: str, prediction_rows: Sequence[dict[str, object]], *, n_classes: int) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    by_participant: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in prediction_rows:
+        by_participant[str(row.get("test_participant", ""))].append(row)
+    for participant, participant_rows in sorted(by_participant.items(), key=lambda item: int(item[0]) if item[0].isdigit() else item[0]):
+        n_test = len(participant_rows)
+        accuracy = sum(bool(row["correct"]) for row in participant_rows) / n_test if n_test else math.nan
+        top2 = sum(bool(row["top2_correct"]) for row in participant_rows) / n_test if n_test else math.nan
+        top3 = sum(bool(row["top3_correct"]) for row in participant_rows) / n_test if n_test else math.nan
+        ranks = [_to_float(row["true_label_rank"]) for row in participant_rows]
+        rows.append(
+            {
+                "artifact_ensemble": ensemble_name,
+                "test_participant": participant,
+                "accuracy": accuracy,
+                "balanced_accuracy": _balanced_accuracy(participant_rows),
+                "chance_accuracy": 1.0 / n_classes if n_classes else math.nan,
+                "top2_accuracy": top2,
+                "top3_accuracy": top3,
+                "mean_true_label_rank": _mean(ranks),
+                "n_test": n_test,
+            }
+        )
+    return rows
+
+
+def _group_summary(ensemble_name: str, source_names: Sequence[str], outer_rows: Sequence[dict[str, object]], *, n_classes: int) -> dict[str, object]:
+    accuracies = [_to_float(row["accuracy"]) for row in outer_rows]
+    balanced = [_to_float(row["balanced_accuracy"]) for row in outer_rows]
+    top2 = [_to_float(row["top2_accuracy"]) for row in outer_rows]
+    top3 = [_to_float(row["top3_accuracy"]) for row in outer_rows]
+    ranks = [_to_float(row["mean_true_label_rank"]) for row in outer_rows]
+    chance = 1.0 / n_classes if n_classes else math.nan
+    return {
+        "artifact_ensemble": ensemble_name,
+        "artifact_ensemble_sources": ";".join(source_names),
+        "artifact_ensemble_source_count": len(source_names),
+        "n_outer_folds": len(outer_rows),
+        "n_classes": n_classes,
+        "chance_accuracy": chance,
+        "accuracy_mean": _mean(accuracies),
+        "accuracy_sem": _sem(accuracies),
+        "balanced_accuracy_mean": _mean(balanced),
+        "balanced_accuracy_sem": _sem(balanced),
+        "top2_accuracy_mean": _mean(top2),
+        "top2_accuracy_sem": _sem(top2),
+        "top3_accuracy_mean": _mean(top3),
+        "top3_accuracy_sem": _sem(top3),
+        "mean_true_label_rank_mean": _mean(ranks),
+        "mean_true_label_rank_sem": _sem(ranks),
+        "accuracy_percent_mean": _format_percent(_mean(accuracies)),
+        "balanced_percent_mean": _format_percent(_mean(balanced)),
+        "top2_percent_mean": _format_percent(_mean(top2)),
+        "top3_percent_mean": _format_percent(_mean(top3)),
+        "participants_above_chance": sum(value > chance for value in balanced if math.isfinite(value) and math.isfinite(chance)),
+    }
+
+
+def ensemble_prediction_sources(
+    sources: Sequence[PredictionSource],
+    ensembles: Sequence[tuple[str, Sequence[str]]],
+    *,
+    key_columns: Sequence[str] = DEFAULT_KEY_COLUMNS,
+) -> dict[str, list[dict]]:
+    """Build hard-vote artifact ensembles from already completed prediction CSVs."""
+
+    source_by_name = {source.name: source for source in sources}
+    if len(source_by_name) != len(sources):
+        raise ValueError("Source names must be unique.")
+    class_labels = sorted({label for source in sources for label in _all_labels(source.rows)})
+    if not class_labels:
+        raise ValueError("Could not infer class labels from prediction rows.")
+
+    indexed_sources = {source.name: _index_rows(source, key_columns) for source in sources}
+    all_predictions: list[dict] = []
+    all_outer: list[dict] = []
+    all_summary: list[dict] = []
+    for ensemble_name, source_names in ensembles:
+        missing_sources = [name for name in source_names if name not in source_by_name]
+        if missing_sources:
+            raise ValueError(f"Unknown ensemble source(s) for {ensemble_name}: {', '.join(missing_sources)}")
+        reference_keys = set(indexed_sources[source_names[0]])
+        for source_name in source_names[1:]:
+            keys = set(indexed_sources[source_name])
+            if keys != reference_keys:
+                missing = sorted(reference_keys - keys)[:5]
+                extra = sorted(keys - reference_keys)[:5]
+                raise ValueError(
+                    f"Prediction keys do not match for ensemble {ensemble_name!r} source {source_name!r}; "
+                    f"missing examples={missing}, extra examples={extra}."
+                )
+        prediction_rows = [
+            _prediction_row(
+                ensemble_name=ensemble_name,
+                source_names=source_names,
+                source_rows=[indexed_sources[source_name][key] for source_name in source_names],
+                key_columns=key_columns,
+                key=key,
+                class_labels=class_labels,
+            )
+            for key in sorted(reference_keys, key=lambda values: tuple(int(value) if str(value).isdigit() else value for value in values))
+        ]
+        outer_rows = _outer_rows(ensemble_name, prediction_rows, n_classes=len(class_labels))
+        summary = _group_summary(ensemble_name, source_names, outer_rows, n_classes=len(class_labels))
+        all_predictions.extend(prediction_rows)
+        all_outer.extend(outer_rows)
+        all_summary.append(summary)
+    return {"predictions": all_predictions, "outer": all_outer, "group_summary": all_summary}
+
+
+def write_markdown_summary(path: Path, summary_rows: Sequence[dict]) -> None:
+    lines = [
+        "# Artifact Prediction Ensembles",
+        "",
+        "| ensemble | sources | folds | balanced | accuracy | top-2 | top-3 | mean rank |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in summary_rows:
+        lines.append(
+            "| {name} | {sources} | {folds} | {balanced:.2f}% | {accuracy:.2f}% | {top2:.2f}% | {top3:.2f}% | {rank:.3f} |".format(
+                name=row["artifact_ensemble"],
+                sources=str(row["artifact_ensemble_sources"]).replace(";", ", "),
+                folds=row["n_outer_folds"],
+                balanced=100.0 * float(row["balanced_accuracy_mean"]),
+                accuracy=100.0 * float(row["accuracy_mean"]),
+                top2=100.0 * float(row["top2_accuracy_mean"]),
+                top3=100.0 * float(row["top3_accuracy_mean"]),
+                rank=float(row["mean_true_label_rank_mean"]),
+            )
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", action="append", required=True, help="Named prediction artifact source as name=path.")
+    parser.add_argument("--ensemble", action="append", required=True, help="Named ensemble as name=source_a,source_b.")
+    parser.add_argument("--key-column", action="append", dest="key_columns", help="Prediction-row key column. Defaults to test_participant, test_trial_index, true_label.")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--output-stem", default="artifact_ensemble")
+    args = parser.parse_args(argv)
+
+    sources = [load_prediction_source(spec) for spec in args.source]
+    ensembles = [parse_ensemble_spec(spec) for spec in args.ensemble]
+    artifacts = ensemble_prediction_sources(sources, ensembles, key_columns=tuple(args.key_columns or DEFAULT_KEY_COLUMNS))
+    write_csv_rows(args.output_dir / f"{args.output_stem}_predictions.csv", artifacts["predictions"])
+    write_csv_rows(args.output_dir / f"{args.output_stem}_outer.csv", artifacts["outer"])
+    write_csv_rows(args.output_dir / f"{args.output_stem}_group_summary.csv", artifacts["group_summary"])
+    write_markdown_summary(args.output_dir / f"{args.output_stem}_comparison.md", artifacts["group_summary"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stimulus_artifact_ensemble.py
+++ b/tests/test_stimulus_artifact_ensemble.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from pymegdec.stimulus_artifact_ensemble import PredictionSource, ensemble_prediction_sources, parse_ensemble_spec, resolve_prediction_csv
+
+
+def _row(participant: int, trial_index: int, true_label: int, predicted_label: int, *, true_label_rank: float = 1.0) -> dict[str, str]:
+    return {
+        "test_participant": str(participant),
+        "test_trial_index": str(trial_index),
+        "true_label": str(true_label),
+        "predicted_label": str(predicted_label),
+        "true_stimulus": str(true_label + 1),
+        "predicted_stimulus": str(predicted_label + 1),
+        "true_label_rank": str(true_label_rank),
+    }
+
+
+def _source(name: str, rows: list[dict[str, str]]) -> PredictionSource:
+    return PredictionSource(name, Path(f"{name}.csv"), rows)
+
+
+def _scored_row(true_label: int, predicted_label: int, class_0_score: float, class_1_score: float) -> dict[str, str]:
+    return {
+        **_row(1, 1, true_label, predicted_label, true_label_rank=1.0 if true_label == predicted_label else 2.0),
+        "score_class_0": f"{class_0_score:.2f}",
+        "score_class_1": f"{class_1_score:.2f}",
+    }
+
+
+class TestStimulusArtifactEnsemble(unittest.TestCase):
+    def test_parse_ensemble_spec_requires_named_sources(self) -> None:
+        self.assertEqual(parse_ensemble_spec("compact_plus=compact,finetune"), ("compact_plus", ("compact", "finetune")))
+        with self.assertRaisesRegex(ValueError, "name=source"):
+            parse_ensemble_spec("compact,finetune")
+
+    def test_resolve_prediction_csv_prefers_nested_matrix_predictions(self) -> None:
+        path = Path("artifact_probe_26870015355")
+        if path.exists():
+            self.assertEqual(resolve_prediction_csv(path).name, "nested_matrix_predictions.csv")
+
+    def test_single_source_preserves_source_true_label_rank_for_topk_baseline(self) -> None:
+        compact = _source(
+            "compact",
+            [
+                _row(1, 1, 0, 1, true_label_rank=2.0),
+                _row(1, 2, 1, 1, true_label_rank=1.0),
+            ],
+        )
+
+        artifacts = ensemble_prediction_sources([compact], [("compact", ("compact",))])
+        summary = artifacts["group_summary"][0]
+
+        self.assertEqual(summary["balanced_accuracy_mean"], 0.5)
+        self.assertEqual(summary["top2_accuracy_mean"], 1.0)
+        self.assertEqual({row["artifact_ensemble_rank_source"] for row in artifacts["predictions"]}, {"source_true_label_rank"})
+
+    def test_hard_vote_ensemble_uses_first_source_as_tie_breaker(self) -> None:
+        compact = _source(
+            "compact",
+            [
+                _row(1, 1, 0, 1, true_label_rank=2.0),
+                _row(1, 2, 1, 1, true_label_rank=1.0),
+            ],
+        )
+        finetune = _source(
+            "finetune",
+            [
+                _row(1, 1, 0, 0, true_label_rank=1.0),
+                _row(1, 2, 1, 0, true_label_rank=2.0),
+            ],
+        )
+
+        artifacts = ensemble_prediction_sources(
+            [compact, finetune],
+            [("compact_finetune", ("compact", "finetune"))],
+        )
+        predictions = artifacts["predictions"]
+
+        self.assertEqual([row["predicted_label"] for row in predictions], [1, 1])
+        self.assertEqual([row["true_label_rank"] for row in predictions], [2.0, 1.0])
+        self.assertEqual(artifacts["group_summary"][0]["balanced_accuracy_mean"], 0.5)
+        self.assertEqual(artifacts["group_summary"][0]["top2_accuracy_mean"], 1.0)
+
+    def test_averages_class_scores_when_available(self) -> None:
+        compact = _source("compact", [_scored_row(0, 1, 0.40, 0.60)])
+        finetune = _source("finetune", [_scored_row(0, 0, 0.90, 0.10)])
+
+        artifacts = ensemble_prediction_sources(
+            [compact, finetune],
+            [("score_mean", ("compact", "finetune"))],
+        )
+
+        self.assertEqual(artifacts["predictions"][0]["predicted_label"], 0)
+        self.assertEqual(artifacts["predictions"][0]["artifact_ensemble_mode"], "class_score_mean")
+        self.assertEqual(artifacts["group_summary"][0]["balanced_accuracy_mean"], 1.0)
+
+    def test_rejects_misaligned_source_prediction_keys(self) -> None:
+        compact = _source("compact", [_row(1, 1, 0, 0)])
+        finetune = _source("finetune", [_row(1, 2, 0, 0)])
+
+        with self.assertRaisesRegex(ValueError, "Prediction keys do not match"):
+            ensemble_prediction_sources(
+                [compact, finetune],
+                [("compact_finetune", ("compact", "finetune"))],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a lightweight artifact-level prediction ensemble CLI for nested-matrix aggregate artifacts
- add a manual workflow that downloads existing aggregate artifacts and compares compact, finetune, w150, and w125 combinations
- add tests for source rank preservation, hard-vote tie-breaking, score averaging, and key mismatch detection

## Local validation
- `python -m pytest tests/test_stimulus_artifact_ensemble.py`
- `python -m pytest tests/test_stimulus_nested_matrix.py tests/test_stimulus_artifact_ensemble.py`
- `python -m ruff check src/pymegdec/stimulus_artifact_ensemble.py tests/test_stimulus_artifact_ensemble.py`

## Local artifact probe
Using the existing aggregate artifacts, the hard-prediction ensemble `compact + small_finetune + w150_pca128` reached 14.45% balanced accuracy. Multi-source top-2/top-3 are vote-rank diagnostics because the current compact artifacts do not include per-class score columns.