### PR TITLE
Add nested artifact ensemble selector

### DIFF
--- a/.github/workflows/stimulus-artifact-ensemble.yml
+++ b/.github/workflows/stimulus-artifact-ensemble.yml
@@ -87,6 +87,7 @@ jobs:
             --key-column test_participant \
             --key-column test_trial_index \
             --key-column true_label \
+            --nested-selector-name nested_subject_selector \
             --output-dir outputs \
             --output-stem artifact_ensemble
 

--- a/src/pymegdec/stimulus_artifact_ensemble.py
+++ b/src/pymegdec/stimulus_artifact_ensemble.py
@@ -33,9 +33,18 @@ def read_csv_rows(path: Path) -> list[dict[str, str]]:
         return list(csv.DictReader(handle))
 
 
-def write_csv_rows(path: Path, rows: Iterable[dict]) -> None:
+def _rows_with_consistent_fields(rows: Iterable[dict]) -> list[dict]:
     rows = list(rows)
-    write_alpha_metrics_csv(rows, path)
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    return [{key: row.get(key, "") for key in fieldnames} for row in rows]
+
+
+def write_csv_rows(path: Path, rows: Iterable[dict]) -> None:
+    write_alpha_metrics_csv(_rows_with_consistent_fields(rows), path)
 
 
 def resolve_prediction_csv(path: Path) -> Path:
@@ -329,6 +338,20 @@ def _outer_rows(ensemble_name: str, prediction_rows: Sequence[dict[str, object]]
     return rows
 
 
+def _participant_sort_key(value: object) -> tuple[int, str]:
+    text = str(value)
+    return (0, f"{int(text):012d}") if text.isdigit() else (1, text)
+
+
+def _metric_mean(rows: Sequence[dict[str, object]], metric: str) -> float:
+    return _mean([_to_float(row[metric]) for row in rows])
+
+
+def _counts_text(values: Iterable[str]) -> str:
+    counts = Counter(values)
+    return ";".join(f"{value}:{counts[value]}" for value in sorted(counts, key=_participant_sort_key))
+
+
 def _group_summary(ensemble_name: str, source_names: Sequence[str], outer_rows: Sequence[dict[str, object]], *, n_classes: int) -> dict[str, object]:
     accuracies = [_to_float(row["accuracy"]) for row in outer_rows]
     balanced = [_to_float(row["balanced_accuracy"]) for row in outer_rows]
@@ -361,11 +384,97 @@ def _group_summary(ensemble_name: str, source_names: Sequence[str], outer_rows: 
     }
 
 
+def _nested_subject_selector(
+    *,
+    selector_name: str,
+    ensemble_order: Sequence[str],
+    ensemble_sources: dict[str, Sequence[str]],
+    prediction_rows_by_ensemble: dict[str, list[dict]],
+    outer_rows_by_ensemble: dict[str, list[dict]],
+    n_classes: int,
+) -> tuple[list[dict], list[dict], list[dict], dict[str, object]]:
+    """Select an artifact ensemble recipe for each subject using other subjects only."""
+
+    outer_by_ensemble_participant = {
+        ensemble: {str(row.get("test_participant", "")): row for row in rows}
+        for ensemble, rows in outer_rows_by_ensemble.items()
+    }
+    prediction_by_ensemble_participant: dict[str, dict[str, list[dict]]] = {}
+    for ensemble, rows in prediction_rows_by_ensemble.items():
+        by_participant: dict[str, list[dict]] = defaultdict(list)
+        for row in rows:
+            by_participant[str(row.get("test_participant", ""))].append(row)
+        prediction_by_ensemble_participant[ensemble] = by_participant
+
+    participants = sorted(
+        set().union(*(set(rows) for rows in outer_by_ensemble_participant.values())),
+        key=_participant_sort_key,
+    )
+    if not participants:
+        raise ValueError("Nested subject selector requires test_participant values.")
+
+    selected_predictions: list[dict] = []
+    selection_rows: list[dict] = []
+    for participant in participants:
+        candidates: list[tuple[float, int, str, list[dict]]] = []
+        for ensemble_index, ensemble in enumerate(ensemble_order):
+            train_outer_rows = [
+                row
+                for other_participant, row in outer_by_ensemble_participant[ensemble].items()
+                if other_participant != participant
+            ]
+            if not train_outer_rows:
+                raise ValueError(f"Cannot select an artifact ensemble for participant {participant}; no source subjects remain.")
+            balanced = _metric_mean(train_outer_rows, "balanced_accuracy")
+            candidates.append((balanced, -ensemble_index, ensemble, train_outer_rows))
+
+        selected_balanced, _, selected_ensemble, train_outer_rows = max(candidates)
+        selected_sources = ensemble_sources[selected_ensemble]
+        participant_predictions = prediction_by_ensemble_participant[selected_ensemble].get(participant)
+        if not participant_predictions:
+            raise ValueError(f"Selected ensemble {selected_ensemble!r} has no predictions for participant {participant}.")
+
+        selection_rows.append(
+            {
+                "test_participant": participant,
+                "artifact_ensemble": selector_name,
+                "selected_artifact_ensemble": selected_ensemble,
+                "selected_artifact_ensemble_sources": ";".join(selected_sources),
+                "selection_metric": "other_subjects_balanced_accuracy",
+                "selection_metric_value": selected_balanced,
+                "selection_accuracy": _metric_mean(train_outer_rows, "accuracy"),
+                "selection_top2_accuracy": _metric_mean(train_outer_rows, "top2_accuracy"),
+                "selection_top3_accuracy": _metric_mean(train_outer_rows, "top3_accuracy"),
+                "selection_n_subjects": len(train_outer_rows),
+                "candidate_artifact_ensembles": ";".join(ensemble_order),
+            }
+        )
+        for row in participant_predictions:
+            selected_row = dict(row)
+            selected_row["artifact_ensemble"] = selector_name
+            selected_row["artifact_ensemble_recipe_selection"] = "leave_subject_out"
+            selected_row["selected_artifact_ensemble"] = selected_ensemble
+            selected_row["selected_artifact_ensemble_sources"] = ";".join(selected_sources)
+            selected_row["selection_metric"] = "other_subjects_balanced_accuracy"
+            selected_row["selection_metric_value"] = selected_balanced
+            selected_predictions.append(selected_row)
+
+    outer_rows = _outer_rows(selector_name, selected_predictions, n_classes=n_classes)
+    summary = _group_summary(selector_name, ensemble_order, outer_rows, n_classes=n_classes)
+    summary["artifact_ensemble_recipe_selection"] = "leave_subject_out"
+    summary["selection_metric"] = "other_subjects_balanced_accuracy"
+    summary["selected_artifact_ensemble_counts"] = _counts_text(
+        str(row["selected_artifact_ensemble"]) for row in selection_rows
+    )
+    return selected_predictions, outer_rows, selection_rows, summary
+
+
 def ensemble_prediction_sources(
     sources: Sequence[PredictionSource],
     ensembles: Sequence[tuple[str, Sequence[str]]],
     *,
     key_columns: Sequence[str] = DEFAULT_KEY_COLUMNS,
+    nested_selector_name: str | None = None,
 ) -> dict[str, list[dict]]:
     """Build hard-vote artifact ensembles from already completed prediction CSVs."""
 
@@ -380,10 +489,16 @@ def ensemble_prediction_sources(
     all_predictions: list[dict] = []
     all_outer: list[dict] = []
     all_summary: list[dict] = []
+    prediction_rows_by_ensemble: dict[str, list[dict]] = {}
+    outer_rows_by_ensemble: dict[str, list[dict]] = {}
+    ensemble_sources: dict[str, Sequence[str]] = {}
     for ensemble_name, source_names in ensembles:
         missing_sources = [name for name in source_names if name not in source_by_name]
         if missing_sources:
             raise ValueError(f"Unknown ensemble source(s) for {ensemble_name}: {', '.join(missing_sources)}")
+        if ensemble_name in ensemble_sources:
+            raise ValueError(f"Artifact ensemble names must be unique; got duplicate {ensemble_name!r}.")
+        ensemble_sources[ensemble_name] = tuple(source_names)
         reference_keys = set(indexed_sources[source_names[0]])
         for source_name in source_names[1:]:
             keys = set(indexed_sources[source_name])
@@ -407,10 +522,26 @@ def ensemble_prediction_sources(
         ]
         outer_rows = _outer_rows(ensemble_name, prediction_rows, n_classes=len(class_labels))
         summary = _group_summary(ensemble_name, source_names, outer_rows, n_classes=len(class_labels))
+        prediction_rows_by_ensemble[ensemble_name] = prediction_rows
+        outer_rows_by_ensemble[ensemble_name] = outer_rows
         all_predictions.extend(prediction_rows)
         all_outer.extend(outer_rows)
         all_summary.append(summary)
-    return {"predictions": all_predictions, "outer": all_outer, "group_summary": all_summary}
+    artifacts: dict[str, list[dict]] = {"predictions": all_predictions, "outer": all_outer, "group_summary": all_summary}
+    if nested_selector_name:
+        nested_predictions, nested_outer, nested_selection, nested_summary = _nested_subject_selector(
+            selector_name=nested_selector_name,
+            ensemble_order=[name for name, _ in ensembles],
+            ensemble_sources=ensemble_sources,
+            prediction_rows_by_ensemble=prediction_rows_by_ensemble,
+            outer_rows_by_ensemble=outer_rows_by_ensemble,
+            n_classes=len(class_labels),
+        )
+        artifacts["predictions"].extend(nested_predictions)
+        artifacts["outer"].extend(nested_outer)
+        artifacts["group_summary"].append(nested_summary)
+        artifacts["nested_selection"] = nested_selection
+    return artifacts
 
 
 def write_markdown_summary(path: Path, summary_rows: Sequence[dict]) -> None:
@@ -442,16 +573,27 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--source", action="append", required=True, help="Named prediction artifact source as name=path.")
     parser.add_argument("--ensemble", action="append", required=True, help="Named ensemble as name=source_a,source_b.")
     parser.add_argument("--key-column", action="append", dest="key_columns", help="Prediction-row key column. Defaults to test_participant, test_trial_index, true_label.")
+    parser.add_argument(
+        "--nested-selector-name",
+        help="Optional leakage-safe leave-subject-out artifact recipe selector row to add to the outputs.",
+    )
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--output-stem", default="artifact_ensemble")
     args = parser.parse_args(argv)
 
     sources = [load_prediction_source(spec) for spec in args.source]
     ensembles = [parse_ensemble_spec(spec) for spec in args.ensemble]
-    artifacts = ensemble_prediction_sources(sources, ensembles, key_columns=tuple(args.key_columns or DEFAULT_KEY_COLUMNS))
+    artifacts = ensemble_prediction_sources(
+        sources,
+        ensembles,
+        key_columns=tuple(args.key_columns or DEFAULT_KEY_COLUMNS),
+        nested_selector_name=args.nested_selector_name,
+    )
     write_csv_rows(args.output_dir / f"{args.output_stem}_predictions.csv", artifacts["predictions"])
     write_csv_rows(args.output_dir / f"{args.output_stem}_outer.csv", artifacts["outer"])
     write_csv_rows(args.output_dir / f"{args.output_stem}_group_summary.csv", artifacts["group_summary"])
+    if "nested_selection" in artifacts:
+        write_csv_rows(args.output_dir / f"{args.output_stem}_nested_selection.csv", artifacts["nested_selection"])
     write_markdown_summary(args.output_dir / f"{args.output_stem}_comparison.md", artifacts["group_summary"])
     return 0
 

--- a/tests/test_stimulus_artifact_ensemble.py
+++ b/tests/test_stimulus_artifact_ensemble.py
@@ -107,6 +107,57 @@ class TestStimulusArtifactEnsemble(unittest.TestCase):
                 [("compact_finetune", ("compact", "finetune"))],
             )
 
+    def test_nested_subject_selector_uses_other_subjects_only(self) -> None:
+        compact = _source(
+            "compact",
+            [
+                _row(1, 1, 0, 0),
+                _row(2, 1, 0, 1),
+                _row(3, 1, 0, 0),
+            ],
+        )
+        alt_a = _source(
+            "alt_a",
+            [
+                _row(1, 1, 0, 1),
+                _row(2, 1, 0, 0),
+                _row(3, 1, 0, 0),
+            ],
+        )
+        alt_b = _source(
+            "alt_b",
+            [
+                _row(1, 1, 0, 1),
+                _row(2, 1, 0, 0),
+                _row(3, 1, 0, 0),
+            ],
+        )
+
+        artifacts = ensemble_prediction_sources(
+            [compact, alt_a, alt_b],
+            [
+                ("compact", ("compact",)),
+                ("compact_alt", ("compact", "alt_a", "alt_b")),
+            ],
+            nested_selector_name="nested_subject_selector",
+        )
+
+        selections = {
+            row["test_participant"]: row["selected_artifact_ensemble"]
+            for row in artifacts["nested_selection"]
+        }
+        self.assertEqual(selections, {"1": "compact_alt", "2": "compact", "3": "compact"})
+
+        nested_summary = next(
+            row for row in artifacts["group_summary"] if row["artifact_ensemble"] == "nested_subject_selector"
+        )
+        self.assertAlmostEqual(nested_summary["balanced_accuracy_mean"], 1.0 / 3.0)
+        self.assertEqual(nested_summary["selected_artifact_ensemble_counts"], "compact:2;compact_alt:1")
+        nested_predictions = [
+            row for row in artifacts["predictions"] if row["artifact_ensemble"] == "nested_subject_selector"
+        ]
+        self.assertEqual([row["predicted_label"] for row in nested_predictions], [1, 1, 0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add a leave-subject-out artifact recipe selector to `pymegdec.stimulus_artifact_ensemble`
- make the manual artifact-ensemble workflow emit a leakage-safe `nested_subject_selector` row and nested selection CSV
- normalize mixed output rows before CSV writing so selector metadata can coexist with ordinary ensemble rows

## Why

The previous artifact-level comparison selected the best recipe after evaluating all 23 held-out subjects. This PR keeps the no-refit artifact ensemble idea, but selects the recipe for subject `s` using only the other 22 subjects and then applies that recipe to `s`.

## Local probe on downloaded artifacts

Using the existing completed artifacts for compact, small finetune, w150 PCA128, and w125:

| Row | Balanced | Accuracy | Top-2 | Top-3 |
|---|---:|---:|---:|---:|
| compact | 14.341787% | 14.341787% | 25.289855% | 34.136473% |
| compact_small_finetune_w150_pca128 | 14.450483% | 14.450483% | 21.745169% | 27.548309% |
| nested_subject_selector | 14.450483% | 14.450483% | 21.745169% | 27.548309% |

The nested selector chose `compact_small_finetune_w150_pca128` for all 23 held-out subjects based on the other 22 subjects. The multi-source top-2/top-3 values remain hard-vote rank diagnostics because the source artifacts do not expose per-class scores.

## Checks

- `python -m pytest tests/test_stimulus_artifact_ensemble.py`
- `python -m pytest tests/test_stimulus_nested_matrix.py tests/test_stimulus_artifact_ensemble.py`
- `python -m ruff check src/pymegdec/stimulus_artifact_ensemble.py tests/test_stimulus_artifact_ensemble.py`
- `python -m mypy src/pymegdec/stimulus_artifact_ensemble.py`
- real-artifact CLI probe with `--nested-selector-name nested_subject_selector`