### PR TITLE
Add BUSH follow-up ensemble bundles

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -108,6 +108,10 @@ on:
           - windowed_logreg_175_w150_pca160_recall_bias_s75
           - windowed_logreg_175_w150_pca160_recall_bias_s100
           - windowed_logreg_175_w150_pca160_precision_recall_bias
+          - windowed_logreg_175_w150_pca160_precision_recall_bias_s25
+          - windowed_logreg_175_w150_pca160_precision_recall_bias_s50
+          - windowed_logreg_175_w150_pca160_precision_recall_bias_recall_s50
+          - windowed_logreg_175_w150_pca160_precision_recall_bias_precision_s50
           - windowed_logreg_175_w150_pca160_ranksoft_t0_75
           - windowed_logreg_175_w150_pca160_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_pca160_c03_c05
@@ -260,6 +264,10 @@ on:
           - rank_softmax_t1_25_inner_precision_recall_bias
           - rank_top3_score_softmax_inner_precision_recall_bias
           - rank_top3_margin_blend_inner_precision_recall_bias
+          - rank_top3_margin_blend_inner_precision_recall_bias_s25
+          - rank_top3_margin_blend_inner_precision_recall_bias_s50
+          - rank_top3_margin_blend_inner_precision_recall_bias_recall_s50
+          - rank_top3_margin_blend_inner_precision_recall_bias_precision_s50
           - rank_adaptive_softmax
           - rank_median_consensus
           - row_z_softmax_log_pool
@@ -2053,6 +2061,74 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_top3_margin_blend_inner_precision_recall_bias",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_precision_recall_bias_s25": {
+                  # Weaker precision/recall correction than the default 0.35/0.35
+                  # mode.  This is a low-risk follow-up to the current 14%+ w150
+                  # branch: it targets class-specific top-1 mistakes while reducing
+                  # the chance of over-correcting the already strong top-k signal.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend_inner_precision_recall_bias_s25",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_precision_recall_bias_s50": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend_inner_precision_recall_bias_s50",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_precision_recall_bias_recall_s50": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend_inner_precision_recall_bias_recall_s50",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_precision_recall_bias_precision_s50": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend_inner_precision_recall_bias_precision_s50",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -145,6 +145,7 @@ on:
           - windowed_logreg_175_w150_rank_consensus
           - windowed_logreg_175_w150_adaptive_ranksoft_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_gaussian_taper_mix
+          - windowed_logreg_175_w150_gaussian_taper_pyramid
           - windowed_logreg_175_w150_ranksoft_t0_5
           - windowed_logreg_175_w150_ranksoft_t0_75
           - windowed_logreg_175_w150_ranksoft_t1_25
@@ -2554,6 +2555,22 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_gaussian_taper_pyramid": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_gaussian_taper_time_pyramid",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "128,160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_w150_binned_shape": {

--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -152,6 +152,7 @@ on:
           - windowed_logreg_175_w150_top2_borda_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_top3_borda_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_top2_margin_blend
+          - windowed_logreg_175_w150_top2_margin_recall_bias
           - windowed_logreg_175_w150_pca160_top3_score_softmax
           - windowed_logreg_175_w150_pca160_top3_score_softmax_inner_confusion
           - windowed_logreg_175_w150_top2_recall_bias
@@ -160,6 +161,8 @@ on:
           - windowed_logreg_175_w150_pca160_top3_adaptive_score_softmax_inner_confusion
           - windowed_logreg_175_w150_pca160_top2_score_softmax_quota
           - windowed_logreg_175_w150_pca160_top3_score_softmax_quota
+          - windowed_logreg_175_w150_pca160_top3_score_softmax_log_pool
+          - windowed_logreg_175_w150_pca160_top3_adaptive_score_softmax_log_pool
           - windowed_logreg_175_w150_agreement_log_pool
           - windowed_logreg_175_w150_pca160_c03_c05_agreement_log_pool
           - windowed_logreg_175_w150_top3_margin_blend
@@ -2089,6 +2092,53 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_top2_score_softmax_inner_recall_bias",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_top2_margin_recall_bias": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top2_margin_blend_inner_recall_bias",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_top3_score_softmax_log_pool": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_score_softmax_log_pool",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_top3_adaptive_score_softmax_log_pool": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_adaptive_score_softmax_log_pool",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -381,7 +381,7 @@ INNER_PRECISION_RECALL_BIAS_SMOOTHING = 1.0
 INNER_PRECISION_RECALL_BIAS_RECALL_STRENGTH = 0.35
 INNER_PRECISION_RECALL_BIAS_PRECISION_STRENGTH = 0.35
 INNER_PRECISION_RECALL_BIAS_CLIP = 1.0
-INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
+_DEFAULT_INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
     # Leakage-safe class-bias correction derived from source-inner validation
     # confusion counts.  Recall bias alone can rescue weak classes, but it may
     # also boost classes that are already noisy false positives.  This mode
@@ -393,6 +393,39 @@ INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_t1_25_inner_precision_recall_bias": "rank_softmax_t1_25",
     "rank_top3_score_softmax_inner_precision_recall_bias": "rank_top3_score_softmax",
     "rank_top3_margin_blend_inner_precision_recall_bias": "rank_top3_margin_blend",
+}
+INNER_PRECISION_RECALL_BIAS_STRENGTH_VARIANTS = {
+    # The default precision/recall correction is intentionally conservative, but
+    # recent BUSH-MEG w150 runs show that tiny post-processing changes can move
+    # top-1 accuracy.  Expose a low-cost source-inner sweep without adding any
+    # target-label, cue, or transductive calibration path.
+    "s25": (0.25, 0.25),
+    "s50": (0.50, 0.50),
+    "recall_s50": (0.50, 0.25),
+    "precision_s50": (0.25, 0.50),
+}
+INNER_PRECISION_RECALL_BIAS_STRENGTH_VARIANT_BASES = {
+    f"{mode}_{suffix}": base
+    for mode, base in _DEFAULT_INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES.items()
+    for suffix in INNER_PRECISION_RECALL_BIAS_STRENGTH_VARIANTS
+}
+INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
+    **_DEFAULT_INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES,
+    **INNER_PRECISION_RECALL_BIAS_STRENGTH_VARIANT_BASES,
+}
+INNER_PRECISION_RECALL_BIAS_STRENGTH_BY_MODE = {
+    **{
+        mode: (
+            INNER_PRECISION_RECALL_BIAS_RECALL_STRENGTH,
+            INNER_PRECISION_RECALL_BIAS_PRECISION_STRENGTH,
+        )
+        for mode in _DEFAULT_INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES
+    },
+    **{
+        f"{mode}_{suffix}": strengths
+        for mode in _DEFAULT_INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES
+        for suffix, strengths in INNER_PRECISION_RECALL_BIAS_STRENGTH_VARIANTS.items()
+    },
 }
 
 _impl = None
@@ -1189,8 +1222,15 @@ def _inner_precision_recall_bias_metadata(
         }
 
     smoothing = float(INNER_PRECISION_RECALL_BIAS_SMOOTHING)
-    recall_strength = float(INNER_PRECISION_RECALL_BIAS_RECALL_STRENGTH)
-    precision_strength = float(INNER_PRECISION_RECALL_BIAS_PRECISION_STRENGTH)
+    recall_strength, precision_strength = INNER_PRECISION_RECALL_BIAS_STRENGTH_BY_MODE.get(
+        inner_mode,
+        (
+            INNER_PRECISION_RECALL_BIAS_RECALL_STRENGTH,
+            INNER_PRECISION_RECALL_BIAS_PRECISION_STRENGTH,
+        ),
+    )
+    recall_strength = float(recall_strength)
+    precision_strength = float(precision_strength)
     clip_value = float(INNER_PRECISION_RECALL_BIAS_CLIP)
     n_classes = max(int(class_order.shape[0]), 1)
 

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -99,6 +99,7 @@ BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_smooth",
     "sensor_flat_taper",
     "sensor_flat_gaussian_taper",
+    "sensor_flat_gaussian_taper_time_pyramid",
     "sensor_flat_centered",
     "sensor_flat_delta",
     "sensor_flat_delta2",
@@ -120,6 +121,7 @@ EXTENDED_FEATURE_MODES = (
     "sensor_flat_smooth",
     "sensor_flat_taper",
     "sensor_flat_gaussian_taper",
+    "sensor_flat_gaussian_taper_time_pyramid",
     "sensor_flat_centered",
     "sensor_flat_delta",
     "sensor_flat_delta2",
@@ -1887,6 +1889,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_flat_taper_feature(signal)
         elif feature_mode == "sensor_flat_gaussian_taper":
             feature = _sensor_flat_gaussian_taper_feature(signal)
+        elif feature_mode == "sensor_flat_gaussian_taper_time_pyramid":
+            feature = _sensor_flat_gaussian_taper_time_pyramid_feature(signal)
         elif feature_mode == "sensor_flat_centered":
             feature = _sensor_flat_centered_feature(signal)
         elif feature_mode == "sensor_flat_delta":
@@ -2019,6 +2023,20 @@ def _sensor_flat_gaussian_taper_feature(window_signal):
         raise ValueError("window_signal must be a channel x time matrix.")
     weights = _sensor_flat_gaussian_taper_weights(signal.shape[1])
     return (signal * weights[None, :]).reshape(-1, order="F")
+
+
+def _sensor_flat_gaussian_taper_time_pyramid_feature(window_signal):
+    """Return Gaussian-tapered flat samples plus temporal-pyramid summaries."""
+
+    signal = np.asarray(window_signal, dtype=float)
+    if signal.ndim != 2:
+        raise ValueError("window_signal must be a channel x time matrix.")
+    return np.concatenate(
+        (
+            _sensor_flat_gaussian_taper_feature(signal),
+            _sensor_time_pyramid_feature(signal),
+        )
+    )
 
 
 def _sensor_flat_centered_feature(window_signal):
@@ -2278,6 +2296,13 @@ def _baseline_feature_statistics(data, config, n_window_samples, trial_indices):
             n_window_samples,
             trial_indices,
         )
+    if feature_mode == "sensor_flat_gaussian_taper_time_pyramid":
+        return _sensor_flat_gaussian_taper_time_pyramid_baseline_statistics(
+            data,
+            config,
+            n_window_samples,
+            trial_indices,
+        )
     if feature_mode == "sensor_flat_centered":
         return _sensor_flat_centered_baseline_statistics(data, config, n_window_samples, trial_indices)
     if feature_mode == "sensor_flat_delta":
@@ -2404,6 +2429,40 @@ def _sensor_flat_gaussian_taper_baseline_statistics(
     flat_mean = np.tile(channel_mean, n_window_samples) * repeated_weights
     flat_std = np.tile(channel_std, n_window_samples) * repeated_weights
     return flat_mean[None, :], _impl._nonzero_std(flat_std[None, :]), n_baseline_samples
+
+
+def _sensor_flat_gaussian_taper_time_pyramid_baseline_statistics(
+    data,
+    config,
+    n_window_samples,
+    trial_indices,
+):
+    """Baseline stats for Gaussian-tapered flat samples plus time pyramid."""
+
+    channel_mean, channel_std, n_baseline_samples = _impl._baseline_channel_statistics(
+        data,
+        config.baseline_window,
+        trial_indices,
+    )
+    n_window_samples = int(n_window_samples)
+    weights = _sensor_flat_gaussian_taper_weights(n_window_samples)
+    n_channels = int(channel_mean.shape[0])
+    repeated_weights = np.repeat(weights, n_channels)
+    tapered_mean = np.tile(channel_mean, n_window_samples) * repeated_weights
+    tapered_std = np.tile(channel_std, n_window_samples) * repeated_weights
+
+    pyramid_features, _ = _extract_window_features(
+        data,
+        config.baseline_window,
+        feature_mode="sensor_time_pyramid",
+        trial_indices=trial_indices,
+    )
+    pyramid_mean = np.mean(pyramid_features, axis=0)
+    pyramid_std = np.std(pyramid_features, axis=0)
+
+    mean = np.concatenate((tapered_mean, pyramid_mean))[None, :]
+    std = np.concatenate((tapered_std, pyramid_std))[None, :]
+    return mean, _impl._nonzero_std(std), n_baseline_samples
 
 
 def _sensor_flat_centered_baseline_statistics(data, config, n_window_samples, trial_indices):

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -369,6 +369,52 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
             metadata["precision_recall_bias_precisions"][0],
         )
 
+    def test_inner_precision_recall_bias_strength_variants_are_exported_and_scaled(self):
+        weak_mode = "rank_top3_margin_blend_inner_precision_recall_bias_s25"
+        default_mode = "rank_top3_margin_blend_inner_precision_recall_bias"
+        recall_heavy_mode = "rank_top3_margin_blend_inner_precision_recall_bias_recall_s50"
+        precision_heavy_mode = "rank_top3_margin_blend_inner_precision_recall_bias_precision_s50"
+
+        self.assertIn(weak_mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertIn(recall_heavy_mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertIn(precision_heavy_mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(weak_mode),  # pylint: disable=protected-access
+            "rank_top3_margin_blend",
+        )
+
+        selected_rows = [
+            {
+                "selected_inner_true_predicted_label_pair_counts": "1001:8;2001:6;2002:2",
+                "selected_inner_confusion_counts": "",
+            }
+        ]
+        weak_metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows, np.arange(2, dtype=int), np.ones(1, dtype=float), weak_mode
+        )
+        default_metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows, np.arange(2, dtype=int), np.ones(1, dtype=float), default_mode
+        )
+        recall_heavy_metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows, np.arange(2, dtype=int), np.ones(1, dtype=float), recall_heavy_mode
+        )
+        precision_heavy_metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows, np.arange(2, dtype=int), np.ones(1, dtype=float), precision_heavy_mode
+        )
+
+        self.assertEqual(weak_metadata["inner_mode"], weak_mode)
+        self.assertAlmostEqual(weak_metadata["precision_recall_bias_recall_strength"], 0.25)
+        self.assertAlmostEqual(weak_metadata["precision_recall_bias_precision_strength"], 0.25)
+        self.assertLess(np.ptp(weak_metadata["log_adjustment"]), np.ptp(default_metadata["log_adjustment"]))
+        self.assertAlmostEqual(recall_heavy_metadata["precision_recall_bias_recall_strength"], 0.50)
+        self.assertAlmostEqual(recall_heavy_metadata["precision_recall_bias_precision_strength"], 0.25)
+        self.assertAlmostEqual(precision_heavy_metadata["precision_recall_bias_recall_strength"], 0.25)
+        self.assertAlmostEqual(precision_heavy_metadata["precision_recall_bias_precision_strength"], 0.50)
+        self.assertEqual(
+            recall_heavy_metadata["precision_recall_bias_strength_mode"],
+            recall_heavy_mode,
+        )
+
     def test_guarded_test_prior_balance_is_exported_and_margin_gated(self):
         mode = "rank_softmax_guarded_test_prior_balance"
 

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -115,6 +115,34 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertGreater(probabilities[0, 1], probabilities[0, 2])
         self.assertEqual(probabilities[0, 3], 0.0)
 
+    def test_topk_score_softmax_log_pool_modes_are_exported(self):
+        modes = (
+            "rank_top2_score_softmax_log_pool",
+            "rank_top3_score_softmax_log_pool",
+            "rank_top3_adaptive_score_softmax_log_pool",
+        )
+        scores = np.asarray([[4.0, 3.0, 2.0, 1.0]], dtype=float)
+
+        for mode in modes:
+            with self.subTest(mode=mode):
+                base_mode = mode.removesuffix("_log_pool")
+                self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+                self.assertEqual(
+                    cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+                    base_mode,
+                )
+                self.assertEqual(
+                    cross_subject._ensemble_log_pool_mode(mode),  # pylint: disable=protected-access
+                    mode,
+                )
+
+                probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+                    scores,
+                    score_normalization=mode,
+                )
+                np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(1))
+                self.assertGreater(np.count_nonzero(probabilities[0]), 0)
+
     def test_topk_adaptive_score_softmax_modes_are_exported(self):
         mode = "rank_top3_adaptive_score_softmax"
 
@@ -241,6 +269,34 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         )
         self.assertEqual(metadata["inner_mode"], mode)
         self.assertTrue(metadata["guarded"])
+
+    def test_top2_margin_recall_bias_mode_is_exported_and_scaled(self):
+        mode = "rank_top2_margin_blend_inner_recall_bias"
+        strong_mode = "rank_top2_margin_blend_inner_recall_bias_s100"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertIn(strong_mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_top2_margin_blend",
+        )
+
+        selected_rows = [
+            {
+                "selected_inner_true_predicted_label_pair_counts": "1001:6;1002:2;2001:5;2002:3",
+                "selected_inner_confusion_counts": "",
+            }
+        ]
+        metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows,
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertAlmostEqual(metadata["recall_bias_strength"], 0.50)
+        self.assertGreater(metadata["log_adjustment"][1], metadata["log_adjustment"][0])
 
     def test_inner_recall_bias_strength_variants_are_exported_and_scaled(self):
         weak_mode = "rank_softmax_t0_75_inner_recall_bias_s25"

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -10,6 +10,20 @@ from tests.matlab_fixtures import loadmat_side_effect, mat_data_from_trials
 
 
 class TestStimulusCrossSubjectNext(unittest.TestCase):
+    def test_sensor_flat_gaussian_taper_time_pyramid_feature_is_exported(self):
+        mode = "sensor_flat_gaussian_taper_time_pyramid"
+
+        self.assertEqual(cross_subject._normalize_feature_mode(mode), mode)  # pylint: disable=protected-access
+
+        signal = np.arange(15, dtype=float).reshape(3, 5)
+        feature = next_hooks._sensor_flat_gaussian_taper_time_pyramid_feature(signal)  # pylint: disable=protected-access
+        tapered = next_hooks._sensor_flat_gaussian_taper_feature(signal)  # pylint: disable=protected-access
+        pyramid = next_hooks._sensor_time_pyramid_feature(signal)  # pylint: disable=protected-access
+
+        self.assertEqual(feature.shape, (3 * (5 + 1 + 2 + 4),))
+        np.testing.assert_allclose(feature, np.concatenate((tapered, pyramid)))
+        self.assertTrue(np.all(np.isfinite(feature)))
+
     def test_soft_guarded_inner_confusion_score_normalizations_are_exported(self):
         mode = "rank_softmax_t2_inner_confusion_soft_guarded"
 


### PR DESCRIPTION
## Summary
- Add BUSH top-k log-pool and recall-bias ensemble variants
- Add precision/recall bias strength variants
- Add the w150 Gaussian-taper temporal-pyramid feature bundle

## Validation
- python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_cross_subject_next.py
- YAML parse for .github/workflows/stimulus-cross-subject-nested-matrix.yml
- git diff origin/main..HEAD --check

Per request, no test suite was run.