### PR TITLE
Add stimulus bias calibration follow-ups

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -172,6 +172,9 @@ on:
           - windowed_logreg_175_w150_pca160_top3_adaptive_score_softmax
           - windowed_logreg_175_w150_pca160_top3_adaptive_score_softmax_inner_recall_bias
           - windowed_logreg_175_w150_pca160_top3_adaptive_score_softmax_inner_confusion
+          - windowed_logreg_175_w150_top2_score_prbias
+          - windowed_logreg_175_w150_top2_margin_prbias
+          - windowed_logreg_175_w150_top3_adaptive_prbias
           - windowed_logreg_175_w150_pca160_top2_score_softmax_quota
           - windowed_logreg_175_w150_pca160_top3_score_softmax_quota
           - windowed_logreg_175_w150_pca160_top3_score_softmax_log_pool
@@ -268,6 +271,11 @@ on:
           - rank_softmax_t0_75_inner_recall_bias_s100
           - rank_softmax_t0_75_inner_prediction_bias_s25
           - rank_top3_margin_blend_inner_prediction_bias_s25
+          - rank_softmax_inner_prediction_bias_top2
+          - rank_softmax_inner_prediction_bias_top3
+          - rank_softmax_t0_75_inner_prediction_bias_top2
+          - rank_top2_score_softmax_inner_prediction_bias
+          - rank_top3_score_softmax_inner_prediction_bias
           - rank_softmax_t1_25_inner_recall_bias
           - rank_softmax_inner_recall_bias_top2
           - rank_softmax_inner_recall_bias_top3
@@ -289,8 +297,17 @@ on:
           - rank_top3_margin_blend_inner_precision_recall_bias_guarded
           - rank_top3_margin_blend_inner_precision_recall_bias_s25
           - rank_top3_margin_blend_inner_precision_recall_bias_s50
+          - rank_top2_score_softmax_inner_precision_recall_bias
+          - rank_top2_score_softmax_inner_precision_recall_bias_s25
+          - rank_top2_score_softmax_inner_precision_recall_bias_s50
+          - rank_top2_margin_blend_inner_precision_recall_bias
+          - rank_top2_margin_blend_inner_precision_recall_bias_s25
+          - rank_top2_margin_blend_inner_precision_recall_bias_s50
           - rank_top3_margin_blend_inner_precision_recall_bias_recall_s50
           - rank_top3_margin_blend_inner_precision_recall_bias_precision_s50
+          - rank_top3_adaptive_score_softmax_inner_precision_recall_bias
+          - rank_top3_adaptive_score_softmax_inner_precision_recall_bias_s25
+          - rank_top3_adaptive_score_softmax_inner_precision_recall_bias_s50
           - rank_adaptive_softmax
           - rank_median_consensus
           - row_z_softmax_log_pool
@@ -2358,6 +2375,57 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_top3_adaptive_score_softmax_log_pool",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_top2_score_prbias": {
+                  # Conservative source-inner precision/recall bias on a sparse
+                  # top-2 posterior.  This targets the BUSH w150 top-k/top-1 gap
+                  # without cue data, target labels, or cross-subject alignment.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "128,160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top2_score_softmax_inner_precision_recall_bias_s25",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_top2_margin_prbias": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "128,160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top2_margin_blend_inner_precision_recall_bias_s25",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_top3_adaptive_prbias": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "128,160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_adaptive_score_softmax_inner_precision_recall_bias_s25",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -34,6 +34,16 @@ on:
         required: true
         default: "0.03"
         type: string
+      prediction_balance_weight:
+        description: Minibatch predicted-class balance regularization weight; 0 disables it.
+        required: true
+        default: "0"
+        type: string
+      prediction_balance_target_smoothing:
+        description: Balance target smoothing; 0=batch labels, 1=uniform.
+        required: true
+        default: "1"
+        type: string
       latent_dim:
         description: Shared latent dimension.
         required: true
@@ -58,6 +68,24 @@ on:
         description: Seed for label-shuffle control.
         required: true
         default: "0"
+        type: string
+      score_calibration:
+        description: Source-validation-only score calibration mode.
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - validation_class_bias
+      score_calibration_alphas:
+        description: Candidate alpha strengths for validation_class_bias.
+        required: true
+        default: "0,0.25,0.5,0.75,1"
+        type: string
+      score_calibration_smoothing:
+        description: Additive smoothing for validation_class_bias priors.
+        required: true
+        default: "1.0"
         type: string
 
 permissions:
@@ -103,12 +131,17 @@ jobs:
             --latent-dim "${{ inputs.latent_dim }}"
             --hidden-dim "${{ inputs.hidden_dim }}"
             --reconstruction-weight "${{ inputs.reconstruction_weight }}"
+            --prediction-balance-weight "${{ inputs.prediction_balance_weight }}"
+            --prediction-balance-target-smoothing "${{ inputs.prediction_balance_target_smoothing }}"
             --epochs "${{ inputs.epochs }}"
             --batch-size 256
             --validation-source-count 2
             --patience 12
             --device cpu
             --num-threads 1
+            --score-calibration "${{ inputs.score_calibration }}"
+            --score-calibration-alphas "${{ inputs.score_calibration_alphas }}"
+            --score-calibration-smoothing "${{ inputs.score_calibration_smoothing }}"
             --seed 0
             --outer-output "outputs/${{ inputs.output_stem }}_outer.csv"
             --summary-output "outputs/${{ inputs.output_stem }}_group_summary.csv"

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -448,6 +448,12 @@ _DEFAULT_INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES = {
     "rank_softmax_inner_prediction_bias": "rank_softmax",
     "rank_softmax_t0_75_inner_prediction_bias": "rank_softmax_t0_75",
     "rank_top3_margin_blend_inner_prediction_bias": "rank_top3_margin_blend",
+    # Sparse top-k base posteriors plus prediction-bias correction.  These keep
+    # the correction in the same leakage-safe source-inner path, but focus the
+    # posterior on the classes that are already near the top for each trial.
+    "rank_top2_score_softmax_inner_prediction_bias": "rank_top2_score_softmax",
+    "rank_top3_score_softmax_inner_prediction_bias": "rank_top3_score_softmax",
+    "rank_top2_margin_blend_inner_prediction_bias": "rank_top2_margin_blend",
 }
 INNER_PREDICTION_BIAS_STRENGTH_VARIANTS = {
     "s25": 0.25,
@@ -459,9 +465,23 @@ INNER_PREDICTION_BIAS_STRENGTH_VARIANT_BASES = {
     for mode, base in _DEFAULT_INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES.items()
     for suffix in INNER_PREDICTION_BIAS_STRENGTH_VARIANTS
 }
-INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES = {
+BASE_INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES = {
     **_DEFAULT_INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES,
     **INNER_PREDICTION_BIAS_STRENGTH_VARIANT_BASES,
+}
+TOPK_GATED_INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES = {
+    # Apply the source-inner prediction-bias multiplier only inside each row's
+    # original top-k classes under the uncorrected ensemble posterior.  This is a
+    # conservative reranker for the BUSH-MEG w150 top-k/top-1 gap: it can reorder
+    # plausible near-top classes, but cannot pull a low-ranked class into first
+    # solely because source-inner folds say that class is under-predicted.
+    f"{mode}_{suffix}": base
+    for mode, base in BASE_INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES.items()
+    for suffix in INNER_RECALL_BIAS_TOPK_GATES
+}
+INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES = {
+    **BASE_INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES,
+    **TOPK_GATED_INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES,
 }
 INNER_PREDICTION_BIAS_STRENGTH_BY_MODE = {
     **{
@@ -474,6 +494,20 @@ INNER_PREDICTION_BIAS_STRENGTH_BY_MODE = {
         for suffix, strength in INNER_PREDICTION_BIAS_STRENGTH_VARIANTS.items()
     },
 }
+INNER_PREDICTION_BIAS_STRENGTH_BY_MODE.update(
+    {
+        f"{mode}_{suffix}": strength
+        for mode, strength in tuple(INNER_PREDICTION_BIAS_STRENGTH_BY_MODE.items())
+        for suffix in INNER_RECALL_BIAS_TOPK_GATES
+    }
+)
+INNER_RECALL_BIAS_TOP_K_BY_MODE.update(
+    {
+        f"{mode}_{suffix}": top_k
+        for mode in BASE_INNER_PREDICTION_BIAS_SCORE_NORMALIZATION_BASES
+        for suffix, top_k in INNER_RECALL_BIAS_TOPK_GATES.items()
+    }
+)
 _DEFAULT_INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
     # Leakage-safe class-bias correction derived from source-inner validation
     # confusion counts.  Recall bias alone can rescue weak classes, but it may
@@ -491,6 +525,7 @@ _DEFAULT_INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
     "rank_top2_margin_blend_inner_precision_recall_bias": "rank_top2_margin_blend",
     "rank_top3_score_softmax_inner_precision_recall_bias": "rank_top3_score_softmax",
     "rank_top3_margin_blend_inner_precision_recall_bias": "rank_top3_margin_blend",
+    "rank_top3_adaptive_score_softmax_inner_precision_recall_bias": "rank_top3_adaptive_score_softmax",
 }
 INNER_PRECISION_RECALL_BIAS_STRENGTH_VARIANTS = {
     # The default precision/recall correction is intentionally conservative, but

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -60,6 +60,8 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     hidden_dim: int = DEFAULT_LATENT_HIDDEN_DIM
     dropout: float = 0.10
     reconstruction_weight: float = DEFAULT_LATENT_RECONSTRUCTION_WEIGHT
+    prediction_balance_weight: float = 0.0
+    prediction_balance_target_smoothing: float = 1.0
     epochs: int = 80
     batch_size: int = 256
     learning_rate: float = 1e-3
@@ -71,6 +73,9 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     chance_classes: int = 16
     label_shuffle_control: bool = False
     label_shuffle_seed: int = 0
+    score_calibration: str = "none"
+    score_calibration_alphas: tuple[float, ...] = (0.0, 0.25, 0.5, 0.75, 1.0)
+    score_calibration_smoothing: float = 1.0
     device: str = "auto"
     num_threads: int = 1
 
@@ -101,6 +106,12 @@ def _parse_time_window(value: str) -> tuple[float, float]:
     if start > stop:
         raise argparse.ArgumentTypeError("Time-window start must be before stop.")
     return start, stop
+
+
+def _parse_float_sequence(value: str) -> tuple[float, ...]:
+    """Parse a comma/semicolon separated float sequence."""
+
+    return tuple(float(token.strip()) for token in value.replace(";", ",").split(",") if token.strip())
 
 
 def _parse_participants(value: str | None) -> tuple[int, ...]:
@@ -209,6 +220,23 @@ def _class_weights(y_index: np.ndarray, n_classes: int) -> np.ndarray:
     return weights / np.mean(weights)
 
 
+def _prediction_balance_loss(logits, label_indices, *, target_smoothing: float):
+    """Penalize minibatch-level predicted-class collapse."""
+
+    torch, _nn, F = _lazy_torch()
+    if int(logits.shape[0]) == 0:
+        return torch.zeros((), dtype=logits.dtype, device=logits.device)
+    probabilities = F.softmax(logits, dim=1)
+    predicted_distribution = probabilities.mean(dim=0)
+    label_distribution = (
+        F.one_hot(label_indices, num_classes=int(logits.shape[1])).to(dtype=logits.dtype).mean(dim=0)
+    )
+    uniform_distribution = torch.full_like(predicted_distribution, 1.0 / float(logits.shape[1]))
+    smoothing = min(max(float(target_smoothing), 0.0), 1.0)
+    target_distribution = (1.0 - smoothing) * label_distribution + smoothing * uniform_distribution
+    return F.mse_loss(predicted_distribution, target_distribution)
+
+
 def _fit_pca(train_features: np.ndarray, test_features: np.ndarray | None, *, components_pca: int, seed: int):
     n_components = int(min(int(components_pca), train_features.shape[0], train_features.shape[1]))
     if n_components < 1:
@@ -289,6 +317,13 @@ def _train_model(  # pylint: disable=too-many-arguments,too-many-locals
                     reconstruction_losses.append(F.mse_loss(reconstruction, xb[mask]))
             reconstruction_loss = torch.stack(reconstruction_losses).mean() if reconstruction_losses else torch.zeros((), device=device)
             loss = class_loss + float(config.reconstruction_weight) * reconstruction_loss
+            if float(config.prediction_balance_weight) > 0.0:
+                balance_loss = _prediction_balance_loss(
+                    logits,
+                    yb,
+                    target_smoothing=config.prediction_balance_target_smoothing,
+                )
+                loss = loss + float(config.prediction_balance_weight) * balance_loss
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
             optimizer.step()
@@ -343,6 +378,97 @@ def _true_label_ranks(true_labels: np.ndarray, scores: np.ndarray, classes: np.n
     return ranks
 
 
+def _softmax_scores(scores: np.ndarray) -> np.ndarray:
+    scores = np.asarray(scores, dtype=float)
+    shifted = scores - np.max(scores, axis=1, keepdims=True)
+    exp_scores = np.exp(shifted)
+    denominator = np.sum(exp_scores, axis=1, keepdims=True)
+    denominator[denominator <= 0.0] = 1.0
+    return exp_scores / denominator
+
+
+def _empty_score_calibration_metadata(config: LatentAutoencoderConfig, status: str) -> dict:
+    return {
+        "score_calibration": config.score_calibration,
+        "score_calibration_status": status,
+        "score_calibration_alpha": 0.0,
+        "score_calibration_validation_balanced_accuracy": np.nan,
+        "score_calibration_uncalibrated_validation_balanced_accuracy": np.nan,
+        "score_calibration_bias_min": 0.0,
+        "score_calibration_bias_max": 0.0,
+        "score_calibration_bias_mean_abs": 0.0,
+    }
+
+
+def _fit_validation_score_calibration(
+    validation_scores: np.ndarray | None,
+    validation_labels: np.ndarray | None,
+    classes: np.ndarray,
+    config: LatentAutoencoderConfig,
+) -> tuple[np.ndarray, dict]:
+    """Fit a source-validation-only logit bias to reduce class collapse.
+
+    The latent AE smoke run showed strong prediction-frequency imbalance.  This
+    calibrator estimates the mismatch between true validation class prior and
+    mean validation softmax prior, then tunes a scalar bias strength on the
+    source-validation split only.  Held-out-subject labels are never used.
+    """
+
+    zero_bias = np.zeros(int(classes.shape[0]), dtype=float)
+    if config.score_calibration == "none":
+        return zero_bias, _empty_score_calibration_metadata(config, "not_requested")
+    if config.score_calibration != "validation_class_bias":
+        raise ValueError(f"Unsupported latent AE score calibration: {config.score_calibration!r}")
+    if validation_scores is None or validation_labels is None or len(validation_labels) == 0:
+        return zero_bias, _empty_score_calibration_metadata(config, "no_validation")
+
+    validation_scores = np.asarray(validation_scores, dtype=float)
+    validation_labels = np.asarray(validation_labels, dtype=int)
+    label_indices = _class_index(validation_labels, classes)
+    n_classes = int(classes.shape[0])
+    smoothing = max(0.0, float(config.score_calibration_smoothing))
+
+    true_counts = np.bincount(label_indices, minlength=n_classes).astype(float)
+    true_prior = (true_counts + smoothing) / (float(np.sum(true_counts)) + smoothing * n_classes)
+    probability_counts = np.sum(_softmax_scores(validation_scores), axis=0)
+    predicted_prior = (probability_counts + smoothing) / (float(np.sum(probability_counts)) + smoothing * n_classes)
+    base_bias = np.log(true_prior) - np.log(predicted_prior)
+    base_bias = base_bias - float(np.mean(base_bias))
+
+    uncalibrated_predictions = classes[np.argmax(validation_scores, axis=1)]
+    uncalibrated_balanced = float(balanced_accuracy_score(validation_labels, uncalibrated_predictions))
+    alphas = tuple(float(alpha) for alpha in config.score_calibration_alphas)
+    if not alphas:
+        alphas = (1.0,)
+    best_alpha = 0.0
+    best_balanced = -math.inf
+    for alpha in alphas:
+        calibrated_scores = validation_scores + float(alpha) * base_bias
+        calibrated_predictions = classes[np.argmax(calibrated_scores, axis=1)]
+        balanced = float(balanced_accuracy_score(validation_labels, calibrated_predictions))
+        if balanced > best_balanced + 1e-12 or (abs(balanced - best_balanced) <= 1e-12 and abs(float(alpha)) < abs(best_alpha)):
+            best_balanced = balanced
+            best_alpha = float(alpha)
+    bias = best_alpha * base_bias
+    metadata = {
+        "score_calibration": config.score_calibration,
+        "score_calibration_status": "ok",
+        "score_calibration_alpha": best_alpha,
+        "score_calibration_validation_balanced_accuracy": best_balanced,
+        "score_calibration_uncalibrated_validation_balanced_accuracy": uncalibrated_balanced,
+        "score_calibration_bias_min": float(np.min(bias)),
+        "score_calibration_bias_max": float(np.max(bias)),
+        "score_calibration_bias_mean_abs": float(np.mean(np.abs(bias))),
+    }
+    return bias, metadata
+
+
+def _apply_score_calibration(scores: np.ndarray, bias: np.ndarray | None) -> np.ndarray:
+    if bias is None or len(bias) == 0:
+        return np.asarray(scores, dtype=float)
+    return np.asarray(scores, dtype=float) + np.asarray(bias, dtype=float).reshape(1, -1)
+
+
 def _display_label_map(classes: np.ndarray) -> dict[int, int]:
     """Return CSV display labels without double-shifting already 1-based labels."""
 
@@ -392,6 +518,9 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
             "latent_dim": config.latent_dim,
             "hidden_dim": config.hidden_dim,
             "reconstruction_weight": config.reconstruction_weight,
+            "prediction_balance_weight": config.prediction_balance_weight,
+            "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
+            "score_calibration": config.score_calibration,
             "label_shuffle_control": config.label_shuffle_control,
             "label_shuffle_seed": config.label_shuffle_seed if config.label_shuffle_control else np.nan,
         }
@@ -467,6 +596,17 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "hidden_dim": config.hidden_dim,
         "dropout": config.dropout,
         "reconstruction_weight": config.reconstruction_weight,
+        "prediction_balance_weight": config.prediction_balance_weight,
+        "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
+        "score_calibration": config.score_calibration,
+        "score_calibration_status": fit_metadata.get("score_calibration_status", "unknown"),
+        "score_calibration_alpha": fit_metadata.get("score_calibration_alpha", np.nan),
+        "score_calibration_validation_balanced_accuracy": fit_metadata.get("score_calibration_validation_balanced_accuracy", np.nan),
+        "score_calibration_uncalibrated_validation_balanced_accuracy": fit_metadata.get(
+            "score_calibration_uncalibrated_validation_balanced_accuracy", np.nan
+        ),
+        "score_calibration_bias_min": fit_metadata.get("score_calibration_bias_min", np.nan),
+        "score_calibration_bias_max": fit_metadata.get("score_calibration_bias_max", np.nan),
         "epochs_requested": config.epochs,
         "best_epoch": fit_metadata.get("best_epoch", np.nan),
         "best_validation_balanced_accuracy": fit_metadata.get("best_validation_balanced_accuracy", np.nan),
@@ -523,7 +663,13 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "latent_dim": config.latent_dim,
             "hidden_dim": config.hidden_dim,
             "reconstruction_weight": config.reconstruction_weight,
+            "prediction_balance_weight": config.prediction_balance_weight,
+            "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "dropout": config.dropout,
+            "score_calibration": config.score_calibration,
+            "score_calibration_alphas": ";".join(str(float(alpha)) for alpha in config.score_calibration_alphas),
+            "score_calibration_smoothing": config.score_calibration_smoothing,
+            "score_calibration_status_counts": _format_counter(Counter(row.get("score_calibration_status", "unknown") for row in outer_rows)),
             "epochs_requested": config.epochs,
             "validation_source_count": config.validation_source_count,
             "refit_all_sources": config.refit_all_sources,
@@ -556,6 +702,7 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "one_sided_exact_sign_p_value": _one_sided_exact_sign_p_value(differences),
             "best_epoch_mean": float(np.mean([float(row["best_epoch"]) for row in outer_rows])),
             "actual_components_pca_counts": _format_counter(Counter(int(row["actual_components_pca"]) for row in outer_rows)),
+            "score_calibration_alpha_mean": float(np.nanmean([float(row.get("score_calibration_alpha", np.nan)) for row in outer_rows])),
         }
     ]
 
@@ -615,6 +762,9 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
         validation_tuple = None
         selected_epoch = config.epochs
         fit_metadata: dict = {"best_epoch": config.epochs, "best_validation_balanced_accuracy": np.nan}
+        score_calibration_bias = np.zeros(0, dtype=float)
+        initial_calibration_status = "not_requested" if config.score_calibration == "none" else "no_validation"
+        score_calibration_metadata = _empty_score_calibration_metadata(config, initial_calibration_status)
         if validation_participants:
             validation_features_raw, validation_labels_raw, _validation_subjects = _concat_features(feature_sets, validation_participants)
             train_labels_epoch = train_labels_raw
@@ -641,7 +791,13 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
                 config=config,
                 validation=validation_tuple,
             )
+            device = _resolve_device(config.device)
+            validation_scores = _predict_scores(_model, validation_features_pca, device=device, batch_size=config.batch_size)
+            score_calibration_bias, score_calibration_metadata = _fit_validation_score_calibration(
+                validation_scores, validation_labels_epoch, classes_epoch, config
+            )
             selected_epoch = int(fit_metadata.get("best_epoch", config.epochs))
+            fit_metadata = {**fit_metadata, **score_calibration_metadata}
 
         final_train_features_raw, final_train_labels, final_train_subjects = _concat_features(feature_sets, source_participants)
         if config.label_shuffle_control:
@@ -667,6 +823,7 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
         fit_metadata = {**fit_metadata, "best_epoch": selected_epoch, "final_epochs": final_fit_metadata.get("best_epoch", selected_epoch)}
         device = _resolve_device(config.device)
         scores = _predict_scores(final_model, test_features_pca, device=device, batch_size=config.batch_size)
+        scores = _apply_score_calibration(scores, score_calibration_bias)
         predicted_labels = classes[np.argmax(scores, axis=1)]
         outer_row = _outer_row(
             test_participant=test_participant,
@@ -754,6 +911,13 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument("--hidden-dim", type=int, default=DEFAULT_LATENT_HIDDEN_DIM)
     parser.add_argument("--dropout", type=float, default=0.10)
     parser.add_argument("--reconstruction-weight", type=float, default=DEFAULT_LATENT_RECONSTRUCTION_WEIGHT)
+    parser.add_argument("--prediction-balance-weight", type=float, default=0.0)
+    parser.add_argument(
+        "--prediction-balance-target-smoothing",
+        type=float,
+        default=1.0,
+        help="0=batch label histogram, 1=uniform target distribution.",
+    )
     parser.add_argument("--epochs", type=int, default=80)
     parser.add_argument("--batch-size", type=int, default=256)
     parser.add_argument("--learning-rate", type=float, default=1e-3)
@@ -765,6 +929,19 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument("--chance-classes", type=int, default=16)
     parser.add_argument("--label-shuffle-control", action="store_true")
     parser.add_argument("--label-shuffle-seed", type=int, default=0)
+    parser.add_argument(
+        "--score-calibration",
+        choices=("none", "validation_class_bias"),
+        default="none",
+        help="Optional source-validation-only logit calibration for latent AE predictions.",
+    )
+    parser.add_argument(
+        "--score-calibration-alphas",
+        type=_parse_float_sequence,
+        default=(0.0, 0.25, 0.5, 0.75, 1.0),
+        help="Candidate strengths for validation_class_bias calibration.",
+    )
+    parser.add_argument("--score-calibration-smoothing", type=float, default=1.0)
     parser.add_argument("--device", default="auto", help="auto, cpu, cuda, or another torch device string.")
     parser.add_argument("--num-threads", type=int, default=1)
     parser.add_argument("--outer-output", default="outputs/latent_autoencoder_outer.csv")
@@ -790,6 +967,8 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         hidden_dim=args.hidden_dim,
         dropout=args.dropout,
         reconstruction_weight=args.reconstruction_weight,
+        prediction_balance_weight=args.prediction_balance_weight,
+        prediction_balance_target_smoothing=args.prediction_balance_target_smoothing,
         epochs=args.epochs,
         batch_size=args.batch_size,
         learning_rate=args.learning_rate,
@@ -801,6 +980,9 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         chance_classes=args.chance_classes,
         label_shuffle_control=bool(args.label_shuffle_control),
         label_shuffle_seed=args.label_shuffle_seed,
+        score_calibration=args.score_calibration,
+        score_calibration_alphas=args.score_calibration_alphas,
+        score_calibration_smoothing=args.score_calibration_smoothing,
         device=args.device,
         num_threads=args.num_threads,
     )

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -504,6 +504,53 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_allclose(np.sum(adjusted, axis=1), np.ones(1))
         self.assertGreater(adjusted[0, 1], probabilities[0, 1])
 
+    def test_topk_gated_inner_prediction_bias_only_adjusts_near_top_classes(self):
+        mode = "rank_softmax_inner_prediction_bias_top2"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_softmax",
+        )
+
+        selected_rows = [
+            {
+                "selected_inner_true_predicted_label_pair_counts": (
+                    "1001:4;2001:4;2002:4;3001:4;3003:4;4004:4"
+                ),
+                "selected_inner_confusion_counts": "",
+            }
+        ]
+        metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows,
+            np.arange(4, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertEqual(metadata["prediction_bias_status"], "applied")
+        self.assertEqual(metadata["inner_bias_top_k"], 2)
+
+        probabilities = np.asarray(
+            [[0.50, 0.30, 0.15, 0.05]],
+            dtype=float,
+        )
+        adjusted = cross_subject._apply_inner_class_prior_balance(  # pylint: disable=protected-access
+            probabilities,
+            metadata,
+        )
+
+        np.testing.assert_allclose(np.sum(adjusted, axis=1), np.ones(1))
+        self.assertFalse(np.allclose(adjusted, probabilities))
+        # Classes 3 and 4 are outside the row's original top-2.  They may be
+        # rescaled by row renormalization, but they must keep their original
+        # relative odds because no class-specific prediction-bias multiplier was
+        # applied to either of them.
+        self.assertAlmostEqual(adjusted[0, 2] / adjusted[0, 3], 3.0)
+        self.assertEqual(metadata["inner_bias_top_k_status"], "applied")
+        self.assertEqual(metadata["inner_bias_top_k_adjusted_trials"], 1)
+
     def test_top2_precision_recall_bias_modes_are_exported_and_conservative(self):
         mode = "rank_top2_margin_blend_inner_precision_recall_bias"
         weak_mode = "rank_top2_margin_blend_inner_precision_recall_bias_s25"
@@ -582,6 +629,59 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
             metadata["precision_recall_bias_precisions"][1],
             metadata["precision_recall_bias_precisions"][0],
         )
+
+    def test_topk_precision_recall_bias_expanded_modes_are_exported(self):
+        expectations = {
+            "rank_top2_score_softmax_inner_precision_recall_bias": (
+                "rank_top2_score_softmax",
+                2,
+                0.35,
+                0.35,
+            ),
+            "rank_top2_margin_blend_inner_precision_recall_bias_s25": (
+                "rank_top2_margin_blend",
+                4,
+                0.25,
+                0.25,
+            ),
+            "rank_top3_adaptive_score_softmax_inner_precision_recall_bias_s25": (
+                "rank_top3_adaptive_score_softmax",
+                3,
+                0.25,
+                0.25,
+            ),
+        }
+        scores = np.asarray([[4.0, 3.0, 2.0, 1.0]], dtype=float)
+        selected_rows = [
+            {
+                "selected_inner_true_predicted_label_pair_counts": "1001:8;2001:6;2002:2",
+                "selected_inner_confusion_counts": "",
+            }
+        ]
+
+        for mode, (base_mode, expected_nonzero, recall_strength, precision_strength) in expectations.items():
+            with self.subTest(mode=mode):
+                self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+                self.assertEqual(
+                    cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+                    base_mode,
+                )
+
+                probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+                    scores,
+                    score_normalization=mode,
+                )
+                np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(1))
+                self.assertEqual(np.count_nonzero(probabilities[0]), expected_nonzero)
+
+                metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+                    selected_rows, np.arange(2, dtype=int), np.ones(1, dtype=float), mode
+                )
+                self.assertEqual(metadata["inner_mode"], mode)
+                self.assertEqual(metadata["precision_recall_bias_status"], "applied")
+                self.assertAlmostEqual(metadata["precision_recall_bias_recall_strength"], recall_strength)
+                self.assertAlmostEqual(metadata["precision_recall_bias_precision_strength"], precision_strength)
+                self.assertGreater(metadata["log_adjustment"][1], metadata["log_adjustment"][0])
 
     def test_inner_precision_recall_bias_strength_variants_are_exported_and_scaled(self):
         weak_mode = "rank_top3_margin_blend_inner_precision_recall_bias_s25"

--- a/tests/test_stimulus_latent_autoencoder_score_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_score_calibration.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from pymegdec.stimulus_latent_autoencoder import (
+    LatentAutoencoderConfig,
+    _apply_score_calibration,
+    _fit_validation_score_calibration,
+    _parse_float_sequence,
+)
+
+
+def test_parse_float_sequence_accepts_commas_and_semicolons():
+    assert _parse_float_sequence("0,0.25;0.5") == (0.0, 0.25, 0.5)
+
+
+def test_validation_class_bias_calibration_improves_validation_balance():
+    classes = np.asarray([1, 2])
+    labels = np.asarray([1, 1, 2, 2])
+    scores = np.asarray(
+        [
+            [0.9, 0.0],
+            [0.8, 0.0],
+            [0.1, 0.0],
+            [0.0, 0.8],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_class_bias",
+        score_calibration_alphas=(0.0, 0.5, 1.0, 2.0),
+        score_calibration_smoothing=0.0,
+    )
+    bias, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
+    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, bias), axis=1)]
+    assert metadata["score_calibration_status"] == "ok"
+    assert np.mean(calibrated_predictions == labels) >= np.mean(uncalibrated_predictions == labels)
+    assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]


### PR DESCRIPTION
## Summary
- add BUSH top-k prediction and precision/recall bias follow-up candidates
- add latent-autoencoder prediction-balance regularization controls
- add source-validation score calibration for latent-autoencoder outputs

## Validation
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_cross_subject_next.py tests\test_stimulus_latent_autoencoder_score_calibration.py`
- YAML parse for `.github/workflows/stimulus-cross-subject-nested-matrix.yml` and `.github/workflows/stimulus-latent-autoencoder.yml`
- `git diff --check`

Tests were not run per request.