### PR TITLE
Add trial margin entropy weighting

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -93,6 +93,7 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w150_margin_entropy_weighting
           - windowed_logreg_175_w150_worstclass_lcb
           - windowed_logreg_175_w150_time_bins7
           - windowed_logreg_175_w150_trial_margin
@@ -477,6 +478,7 @@ on:
           - inner_lcb_softmax
           - inner_lcb_trial_margin_softmax
           - inner_lcb_trial_entropy_softmax
+          - inner_lcb_trial_margin_entropy_softmax
           - inner_selection_softmax
           - inner_selection_lcb_softmax
       selection_metric_override:
@@ -1743,6 +1745,21 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_margin_entropy_weighting": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_trial_margin_entropy_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_w150_trial_margin": {

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -74,6 +74,7 @@ SELECTION_ENSEMBLE_WEIGHTING_MODES = (
     "inner_lcb_softmax",
     "inner_lcb_trial_margin_softmax",
     "inner_lcb_trial_entropy_softmax",
+    "inner_lcb_trial_margin_entropy_softmax",
     "inner_selection_softmax",
     "inner_selection_lcb_softmax",
 )
@@ -319,6 +320,7 @@ RANK_MEDIAN_CONSENSUS_TEMPERATURE = 0.75
 RANK_MEDIAN_CONSENSUS_TOP_AGREEMENT_BONUS = 0.50
 TRIAL_MARGIN_ENSEMBLE_WEIGHT_FLOOR = 0.25
 TRIAL_ENTROPY_ENSEMBLE_WEIGHT_FLOOR = 0.25
+TRIAL_MARGIN_ENTROPY_ENSEMBLE_WEIGHT_FLOOR = 0.25
 TRIAL_ENTROPY_EPSILON = 1e-12
 SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "none",
@@ -1801,6 +1803,11 @@ def _nested_ensemble_weight_scores(selected_rows, *, weighting):
         weighting = "inner_lcb_softmax"
     if weighting == "inner_lcb_trial_entropy_softmax":
         weighting = "inner_lcb_softmax"
+    if weighting == "inner_lcb_trial_margin_entropy_softmax":
+        # Trial-adaptive confidence is applied later, after selected models have
+        # produced held-out score matrices.  Candidate-level priors still come
+        # from the source-inner LCB score.
+        weighting = "inner_lcb_softmax"
     if weighting == "inner_lcb_softmax":
         means = np.asarray([float(row["selected_inner_balanced_accuracy_mean"]) for row in selected_rows], dtype=float)
         sems = np.asarray([float(row.get("selected_inner_balanced_accuracy_sem", 0.0)) for row in selected_rows], dtype=float)
@@ -2335,7 +2342,12 @@ def _trial_margin_ensemble_weights(score_matrices, base_weights, weighting):
     weighting = _normalize_selection_ensemble_weighting(weighting)
     score_matrices = tuple(score_matrices)
     base_weights = _normalized_ensemble_weights(base_weights, len(score_matrices))
-    if weighting not in {"inner_lcb_trial_margin_softmax", "inner_lcb_trial_entropy_softmax"}:
+    confidence_weightings = {
+        "inner_lcb_trial_margin_softmax",
+        "inner_lcb_trial_entropy_softmax",
+        "inner_lcb_trial_margin_entropy_softmax",
+    }
+    if weighting not in confidence_weightings:
         return base_weights
 
     score_tensor = np.stack(tuple(np.asarray(matrix, dtype=float) for matrix in score_matrices), axis=0)
@@ -2347,6 +2359,22 @@ def _trial_margin_ensemble_weights(score_matrices, base_weights, weighting):
             for model_index in range(score_tensor.shape[0])
         ])
         floor = float(TRIAL_ENTROPY_ENSEMBLE_WEIGHT_FLOOR)
+    elif weighting == "inner_lcb_trial_margin_entropy_softmax":
+        margin_confidences = np.vstack([
+            _rank_margin_blend_confidence(score_tensor[model_index])
+            for model_index in range(score_tensor.shape[0])
+        ])
+        entropy_confidences = np.vstack([
+            _score_entropy_confidence(score_tensor[model_index])
+            for model_index in range(score_tensor.shape[0])
+        ])
+        # Use a geometric mean so a candidate receives a trial-specific boost
+        # only when both confidence signals agree that the model is decisive.
+        confidences = np.sqrt(
+            np.clip(margin_confidences, 0.0, 1.0)
+            * np.clip(entropy_confidences, 0.0, 1.0)
+        )
+        floor = float(TRIAL_MARGIN_ENTROPY_ENSEMBLE_WEIGHT_FLOOR)
     else:
         confidences = np.vstack([
             _rank_margin_blend_confidence(score_tensor[model_index])

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -127,6 +127,41 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertGreater(weights[1, 1], weights[0, 1])
         np.testing.assert_allclose(np.sum(weights, axis=0), np.ones(2))
 
+    def test_trial_margin_entropy_ensemble_weighting_prefers_jointly_confident_model_per_trial(self):
+        score_matrices = (
+            np.asarray(
+                [
+                    [8.0, 1.0, 0.0],
+                    [1.0, 0.9, 0.8],
+                ],
+                dtype=float,
+            ),
+            np.asarray(
+                [
+                    [1.0, 0.9, 0.8],
+                    [0.0, 1.0, 8.0],
+                ],
+                dtype=float,
+            ),
+        )
+
+        self.assertEqual(
+            cross_subject._normalize_selection_ensemble_weighting(  # pylint: disable=protected-access
+                "inner-lcb-trial-margin-entropy-softmax"
+            ),
+            "inner_lcb_trial_margin_entropy_softmax",
+        )
+        weights = cross_subject._trial_margin_ensemble_weights(  # pylint: disable=protected-access
+            score_matrices,
+            np.asarray([0.5, 0.5], dtype=float),
+            "inner_lcb_trial_margin_entropy_softmax",
+        )
+
+        self.assertEqual(weights.shape, (2, 2))
+        self.assertGreater(weights[0, 0], weights[1, 0])
+        self.assertGreater(weights[1, 1], weights[0, 1])
+        np.testing.assert_allclose(np.sum(weights, axis=0), np.ones(2))
+
     def test_fractional_rank_softmax_inner_confusion_modes_are_supported(self):
         modes = [
             "rank_softmax_t1_5_inner_confusion_soft_guarded",


### PR DESCRIPTION
## Summary
- add trial margin/entropy ensemble weighting mode
- expose the mode and matching preset in the nested stimulus workflow
- cover per-trial weighting behavior in the existing cross-subject tests

## Checks
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py tests\test_stimulus_cross_subject.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text(encoding='utf-8'))"`
- `git diff --check`