### PR TITLE
Harden MEG data cache restore

### DIFF
--- a/.github/actions/prepare-meg-data/action.yml
+++ b/.github/actions/prepare-meg-data/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: Maximum seconds allowed for each WebDAV file copy.
     required: false
     default: "1800"
+  cache-segment-download-timeout-minutes:
+    description: Maximum minutes allowed for one Actions cache download segment on GitHub-hosted runners.
+    required: false
+    default: "60"
 
 outputs:
   data-dir:
@@ -107,6 +111,8 @@ runs:
       id: restore
       if: ${{ runner.environment != 'self-hosted' && steps.resolve.outputs.local-cache-hit != 'true' }}
       uses: actions/cache/restore@v5
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: ${{ inputs.cache-segment-download-timeout-minutes }}
       with:
         path: ${{ steps.resolve.outputs.cache-data-dir }}
         key: ${{ steps.resolve.outputs.cache-key }}
@@ -174,6 +180,8 @@ runs:
       if: ${{ runner.environment != 'self-hosted' && steps.resolve.outputs.local-cache-hit != 'true' && steps.restore.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v5
       continue-on-error: true
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: ${{ inputs.cache-segment-download-timeout-minutes }}
       with:
         path: ${{ steps.resolve.outputs.cache-data-dir }}
         key: ${{ steps.resolve.outputs.cache-key }}

--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -3656,7 +3656,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Prepare main MEG data
-        timeout-minutes: 120
+        timeout-minutes: 180
         uses: ./.github/actions/prepare-meg-data
         with:
           data-dir: ${{ env.DATA_DIR }}


### PR DESCRIPTION
## Summary
- increase the Actions cache segment download timeout for the shared MEG data preparation action
- give nested-matrix shard data preparation 180 minutes instead of 120 minutes

## Verification
- parsed the edited YAML files with PyYAML
- ran git diff --check

This targets the cache restore timeout/abort pattern seen in runs 26931946034, 26946955719, and 26947061376.