### PR TITLE
Add prediction bias calibration controls

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -170,6 +170,8 @@ on:
           - windowed_logreg_175_w150_top2_recall_bias
           - windowed_logreg_175_w150_pca160_top2_precision_recall_bias
           - windowed_logreg_175_w150_pca160_top2_precision_recall_bias_s25
+          - windowed_logreg_175_w150_pca160_prbias_top2_gate
+          - windowed_logreg_175_w150_pca160_prbias_s25_top2_gate
           - windowed_logreg_175_w150_pca160_top3_adaptive_score_softmax
           - windowed_logreg_175_w150_pca160_top3_adaptive_score_softmax_inner_recall_bias
           - windowed_logreg_175_w150_pca160_top3_adaptive_score_softmax_inner_confusion
@@ -297,6 +299,9 @@ on:
           - rank_top3_margin_blend_inner_precision_recall_bias
           - rank_top3_margin_blend_inner_precision_recall_bias_guarded
           - rank_top3_margin_blend_inner_precision_recall_bias_s25
+          - rank_top3_margin_blend_inner_precision_recall_bias_top2
+          - rank_top3_margin_blend_inner_precision_recall_bias_s25_top2
+          - rank_top3_margin_blend_inner_precision_recall_bias_s25_top2_guarded
           - rank_top3_margin_blend_inner_precision_recall_bias_s50
           - rank_top2_score_softmax_inner_precision_recall_bias
           - rank_top2_score_softmax_inner_precision_recall_bias_s25
@@ -2306,6 +2311,47 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_top3_margin_blend_inner_precision_recall_bias_precision_s50",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_prbias_top2_gate": {
+                  # Conservative near-top reranker for the current BUSH-MEG
+                  # source-only w150 branch. It keeps the promising PCA-160 /
+                  # C=0.3,0.5 family and applies source-inner precision/recall
+                  # class-bias correction only to each held-out trial's original
+                  # top-2 classes under the uncorrected ensemble posterior.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend_inner_precision_recall_bias_top2",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_prbias_s25_top2_gate": {
+                  # Lower-strength companion to the top-2 gated precision/recall
+                  # correction. This is the safer first full LOSO run if the
+                  # default correction over-reranks the already useful top-k
+                  # signal.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_margin_blend_inner_precision_recall_bias_s25_top2",
                   "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -560,6 +560,42 @@ INNER_PRECISION_RECALL_BIAS_STRENGTH_BY_MODE = {
         for suffix, strengths in INNER_PRECISION_RECALL_BIAS_STRENGTH_VARIANTS.items()
     },
 }
+_INNER_PRECISION_RECALL_BIAS_TOPK_GATE_SOURCE_MODES = tuple(
+    INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES
+)
+TOPK_GATED_INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
+    # Precision/recall bias is useful for the BUSH-MEG w150 regime, but an
+    # unrestricted class-bias correction can pull a low-ranked class into first
+    # place.  These modes keep the source-inner precision/recall correction, but
+    # apply its class-specific multipliers only inside each held-out trial's
+    # original top-k classes under the uncorrected ensemble posterior.  The
+    # result is a conservative near-top reranker: no cue data, no target labels,
+    # and no transductive alignment are used.
+    f"{mode}_{suffix}": INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES[mode]
+    for mode in _INNER_PRECISION_RECALL_BIAS_TOPK_GATE_SOURCE_MODES
+    for suffix in INNER_RECALL_BIAS_TOPK_GATES
+}
+INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
+    **INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES,
+    **TOPK_GATED_INNER_PRECISION_RECALL_BIAS_SCORE_NORMALIZATION_BASES,
+}
+_INNER_PRECISION_RECALL_BIAS_TOPK_STRENGTH_SOURCE_MODES = tuple(
+    INNER_PRECISION_RECALL_BIAS_STRENGTH_BY_MODE.items()
+)
+INNER_PRECISION_RECALL_BIAS_STRENGTH_BY_MODE.update(
+    {
+        f"{mode}_{suffix}": strengths
+        for mode, strengths in _INNER_PRECISION_RECALL_BIAS_TOPK_STRENGTH_SOURCE_MODES
+        for suffix in INNER_RECALL_BIAS_TOPK_GATES
+    }
+)
+INNER_RECALL_BIAS_TOP_K_BY_MODE.update(
+    {
+        f"{mode}_{suffix}": top_k
+        for mode in _INNER_PRECISION_RECALL_BIAS_TOPK_GATE_SOURCE_MODES
+        for suffix, top_k in INNER_RECALL_BIAS_TOPK_GATES.items()
+    }
+)
 GUARDED_INNER_RECALL_BIAS_SCORE_NORMALIZATION_BASES = {
     # Guarded variants compute the same source-inner class-bias vector as the
     # corresponding unguarded mode, but apply it only to low-margin held-out rows.

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -560,6 +560,7 @@ def _empty_score_calibration_metadata(config: LatentAutoencoderConfig, status: s
     return {
         "score_calibration": config.score_calibration,
         "score_calibration_status": status,
+        "score_calibration_prior_source": "",
         "score_calibration_alpha": 0.0,
         "score_calibration_validation_balanced_accuracy": np.nan,
         "score_calibration_uncalibrated_validation_balanced_accuracy": np.nan,
@@ -578,15 +579,16 @@ def _fit_validation_score_calibration(
     """Fit a source-validation-only logit bias to reduce class collapse.
 
     The latent AE smoke run showed strong prediction-frequency imbalance.  This
-    calibrator estimates the mismatch between true validation class prior and
-    mean validation softmax prior, then tunes a scalar bias strength on the
-    source-validation split only.  Held-out-subject labels are never used.
+    calibrator estimates the mismatch between true validation class prior and a
+    model-implied prior, then tunes a scalar bias strength on the source-validation
+    split only.  Held-out-subject labels are never used.
     """
 
     zero_bias = np.zeros(int(classes.shape[0]), dtype=float)
     if config.score_calibration == "none":
         return zero_bias, _empty_score_calibration_metadata(config, "not_requested")
-    if config.score_calibration != "validation_class_bias":
+    supported_calibrations = {"validation_class_bias", "validation_prediction_bias"}
+    if config.score_calibration not in supported_calibrations:
         raise ValueError(f"Unsupported latent AE score calibration: {config.score_calibration!r}")
     if validation_scores is None or validation_labels is None or len(validation_labels) == 0:
         return zero_bias, _empty_score_calibration_metadata(config, "no_validation")
@@ -599,8 +601,17 @@ def _fit_validation_score_calibration(
 
     true_counts = np.bincount(label_indices, minlength=n_classes).astype(float)
     true_prior = (true_counts + smoothing) / (float(np.sum(true_counts)) + smoothing * n_classes)
-    probability_counts = np.sum(_softmax_scores(validation_scores), axis=0)
-    predicted_prior = (probability_counts + smoothing) / (float(np.sum(probability_counts)) + smoothing * n_classes)
+
+    if config.score_calibration == "validation_class_bias":
+        prior_source = "mean_softmax"
+        predicted_counts = np.sum(_softmax_scores(validation_scores), axis=0)
+    else:
+        # Directly target hard-argmax prediction collapse.  This is useful when
+        # average softmax probabilities look only mildly imbalanced but argmax
+        # predictions collapse onto a small subset of classes.
+        prior_source = "argmax_predictions"
+        predicted_counts = np.bincount(np.argmax(validation_scores, axis=1), minlength=n_classes).astype(float)
+    predicted_prior = (predicted_counts + smoothing) / (float(np.sum(predicted_counts)) + smoothing * n_classes)
     base_bias = np.log(true_prior) - np.log(predicted_prior)
     base_bias = base_bias - float(np.mean(base_bias))
 
@@ -622,6 +633,7 @@ def _fit_validation_score_calibration(
     metadata = {
         "score_calibration": config.score_calibration,
         "score_calibration_status": "ok",
+        "score_calibration_prior_source": prior_source,
         "score_calibration_alpha": best_alpha,
         "score_calibration_validation_balanced_accuracy": best_balanced,
         "score_calibration_uncalibrated_validation_balanced_accuracy": uncalibrated_balanced,
@@ -772,6 +784,7 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "validation_prediction_balance_weight": config.validation_prediction_balance_weight,
         "score_calibration": config.score_calibration,
         "score_calibration_status": fit_metadata.get("score_calibration_status", "unknown"),
+        "score_calibration_prior_source": fit_metadata.get("score_calibration_prior_source", ""),
         "score_calibration_alpha": fit_metadata.get("score_calibration_alpha", np.nan),
         "score_calibration_validation_balanced_accuracy": fit_metadata.get("score_calibration_validation_balanced_accuracy", np.nan),
         "score_calibration_uncalibrated_validation_balanced_accuracy": fit_metadata.get(
@@ -779,6 +792,7 @@ def _outer_row(  # pylint: disable=too-many-arguments
         ),
         "score_calibration_bias_min": fit_metadata.get("score_calibration_bias_min", np.nan),
         "score_calibration_bias_max": fit_metadata.get("score_calibration_bias_max", np.nan),
+        "score_calibration_bias_mean_abs": fit_metadata.get("score_calibration_bias_mean_abs", np.nan),
         "epochs_requested": config.epochs,
         "best_epoch": fit_metadata.get("best_epoch", np.nan),
         "final_epochs": fit_metadata.get("final_epochs", np.nan),
@@ -858,6 +872,7 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "score_calibration_alphas": ";".join(str(float(alpha)) for alpha in config.score_calibration_alphas),
             "score_calibration_smoothing": config.score_calibration_smoothing,
             "score_calibration_status_counts": _format_counter(Counter(row.get("score_calibration_status", "unknown") for row in outer_rows)),
+            "score_calibration_prior_source_counts": _format_counter(Counter(row.get("score_calibration_prior_source", "") for row in outer_rows)),
             "epochs_requested": config.epochs,
             "validation_selection_metric": config.validation_selection_metric,
             "validation_source_count": config.validation_source_count,
@@ -899,6 +914,7 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             ),
             "actual_components_pca_counts": _format_counter(Counter(int(row["actual_components_pca"]) for row in outer_rows)),
             "score_calibration_alpha_mean": float(np.nanmean([float(row.get("score_calibration_alpha", np.nan)) for row in outer_rows])),
+            "score_calibration_bias_mean_abs_mean": float(np.nanmean([float(row.get("score_calibration_bias_mean_abs", np.nan)) for row in outer_rows])),
             "best_validation_selection_score_mean": float(
                 np.nanmean([float(row.get("best_validation_selection_score", np.nan)) for row in outer_rows])
             ),
@@ -1173,7 +1189,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument("--label-shuffle-seed", type=int, default=0)
     parser.add_argument(
         "--score-calibration",
-        choices=("none", "validation_class_bias"),
+        choices=("none", "validation_class_bias", "validation_prediction_bias"),
         default="none",
         help="Optional source-validation-only logit calibration for latent AE predictions.",
     )

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -683,6 +683,65 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
                 self.assertAlmostEqual(metadata["precision_recall_bias_precision_strength"], precision_strength)
                 self.assertGreater(metadata["log_adjustment"][1], metadata["log_adjustment"][0])
 
+    def test_topk_gated_inner_precision_recall_bias_only_adjusts_near_top_classes(self):
+        mode = "rank_top3_margin_blend_inner_precision_recall_bias_top2"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            "rank_top3_margin_blend",
+        )
+
+        selected_rows = [
+            {
+                "selected_inner_true_predicted_label_pair_counts": (
+                    "1001:8;1002:2;2001:6;2002:2;3003:8;4004:8"
+                ),
+                "selected_inner_confusion_counts": "",
+            }
+        ]
+        metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows,
+            np.arange(4, dtype=int),
+            np.ones(1, dtype=float),
+            mode,
+        )
+        self.assertEqual(metadata["inner_mode"], mode)
+        self.assertEqual(metadata["precision_recall_bias_status"], "applied")
+        self.assertEqual(metadata["inner_bias_top_k"], 2)
+
+        probabilities = np.asarray(
+            [[0.50, 0.30, 0.15, 0.05]],
+            dtype=float,
+        )
+        adjusted = cross_subject._apply_inner_class_prior_balance(  # pylint: disable=protected-access
+            probabilities,
+            metadata,
+        )
+
+        np.testing.assert_allclose(np.sum(adjusted, axis=1), np.ones(1))
+        self.assertFalse(np.allclose(adjusted, probabilities))
+        # Classes 3 and 4 are outside the row's original top-2. They may be
+        # rescaled during row renormalization, but no class-specific precision /
+        # recall multiplier should be applied to either of them.
+        self.assertAlmostEqual(adjusted[0, 2] / adjusted[0, 3], 3.0)
+        self.assertEqual(metadata["inner_bias_top_k_status"], "applied")
+        self.assertEqual(metadata["inner_bias_top_k_adjusted_trials"], 1)
+
+        guarded_mode = "rank_top3_margin_blend_inner_precision_recall_bias_s25_top2_guarded"
+        self.assertIn(guarded_mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(guarded_mode),  # pylint: disable=protected-access
+            "rank_top3_margin_blend",
+        )
+        guarded_metadata = cross_subject._inner_class_prior_balance_metadata(  # pylint: disable=protected-access
+            selected_rows, np.arange(4, dtype=int), np.ones(1, dtype=float), guarded_mode
+        )
+        self.assertTrue(guarded_metadata["inner_bias_guarded"])
+        self.assertEqual(guarded_metadata["inner_bias_top_k"], 2)
+        self.assertAlmostEqual(guarded_metadata["precision_recall_bias_recall_strength"], 0.25)
+        self.assertAlmostEqual(guarded_metadata["precision_recall_bias_precision_strength"], 0.25)
+
     def test_inner_precision_recall_bias_strength_variants_are_exported_and_scaled(self):
         weak_mode = "rank_top3_margin_blend_inner_precision_recall_bias_s25"
         default_mode = "rank_top3_margin_blend_inner_precision_recall_bias"

--- a/tests/test_stimulus_latent_autoencoder_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_calibration.py
@@ -1,0 +1,40 @@
+import numpy as np
+from sklearn.metrics import balanced_accuracy_score
+
+from pymegdec.stimulus_latent_autoencoder import LatentAutoencoderConfig, _fit_validation_score_calibration
+
+
+def test_validation_prediction_bias_penalizes_argmax_collapse():
+    classes = np.asarray([1, 2, 3], dtype=int)
+    labels = np.asarray([1, 2, 2, 3, 3, 3], dtype=int)
+    # Every row initially predicts class 1, even though classes 2 and 3 are
+    # present in validation labels.  The hard-prediction prior should therefore
+    # push class 1 down and the missing classes up.
+    scores = np.asarray(
+        [
+            [4.0, 3.0, 2.0],
+            [4.0, 3.8, 1.0],
+            [4.0, 3.7, 1.2],
+            [4.0, 1.0, 3.8],
+            [4.0, 1.0, 3.7],
+            [4.0, 1.5, 3.6],
+        ],
+        dtype=float,
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_prediction_bias",
+        score_calibration_alphas=(0.0, 0.5, 1.0, 2.0),
+        score_calibration_smoothing=0.01,
+    )
+
+    bias, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+
+    assert metadata["score_calibration_status"] == "ok"
+    assert metadata["score_calibration_prior_source"] == "argmax_predictions"
+    assert metadata["score_calibration_alpha"] > 0.0
+    assert bias[0] < 0.0
+    assert bias[1] > 0.0
+    assert bias[2] > 0.0
+    uncalibrated = classes[np.argmax(scores, axis=1)]
+    calibrated = classes[np.argmax(scores + bias, axis=1)]
+    assert balanced_accuracy_score(labels, calibrated) >= balanced_accuracy_score(labels, uncalibrated)


### PR DESCRIPTION
## Summary
- add validation prediction-bias calibration metadata for latent autoencoder scoring
- add top-k gated precision/recall bias modes and workflow presets
- add focused calibration and top-k bias coverage

## Checks
- `python -m py_compile src\pymegdec\stimulus_latent_autoencoder.py src\pymegdec\_stimulus_cross_subject_next.py tests\test_stimulus_latent_autoencoder_calibration.py tests\test_stimulus_cross_subject_next.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text(encoding='utf-8'))"`
- `git diff --check`