### PR TITLE
Add argmax calibration and Borda blend controls

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -93,6 +93,7 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w150_score_borda_blend
           - windowed_logreg_175_w150_margin_entropy_weighting
           - windowed_logreg_175_w150_worstclass_lcb
           - windowed_logreg_175_w150_time_bins7
@@ -257,6 +258,8 @@ on:
           - rank_top3_score_softmax
           - rank_top2_adaptive_score_softmax
           - rank_top3_adaptive_score_softmax
+          - rank_top2_score_borda_blend
+          - rank_top3_score_borda_blend
           - rank_top3_adaptive_score_softmax_inner_recall_bias
           - rank_top2_adaptive_score_softmax_inner_confusion_soft_guarded
           - rank_top3_adaptive_score_softmax_inner_confusion_soft_guarded
@@ -1749,6 +1752,27 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_score_borda_blend": {
+                  # Same clean source-only w150 family as the 14.10% baseline,
+                  # but use a score/Borda hybrid posterior.  This targets the
+                  # observed top-k/top-1 gap: high-margin rows keep score-softmax
+                  # information, while ambiguous rows fall back toward robust
+                  # truncated Borda pooling. No cue data, alignment, or held-out
+                  # labels are used.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_score_borda_blend",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -87,13 +87,14 @@ on:
         options:
           - none
           - validation_class_bias
+          - validation_argmax_class_bias
       score_calibration_alphas:
-        description: Candidate alpha strengths for validation_class_bias.
+        description: Candidate alpha strengths for source-validation class-bias calibration.
         required: true
         default: "0,0.25,0.5,0.75,1"
         type: string
       score_calibration_smoothing:
-        description: Additive smoothing for validation_class_bias priors.
+        description: Additive smoothing for score-calibration priors.
         required: true
         default: "1.0"
         type: string

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -272,6 +272,15 @@ TOPK_ADAPTIVE_SCORE_SOFTMAX_SCORE_NORMALIZATIONS = {
 }
 TOPK_ADAPTIVE_SCORE_SOFTMAX_LOW_TEMPERATURE = 0.50
 TOPK_ADAPTIVE_SCORE_SOFTMAX_HIGH_TEMPERATURE = 2.00
+TOPK_SCORE_BORDA_BLEND_SCORE_NORMALIZATIONS = {
+    # Confidence-gated blend between score-sensitive sparse top-k softmax and
+    # robust truncated Borda pooling.  The current BUSH-MEG w150 source-only run
+    # has strong top-2/top-3 signal; this normalizer trusts score gaps on
+    # high-margin trials, but falls back toward Borda when the top classes are
+    # tightly clustered.  It uses only each held-out trial's unlabeled score row.
+    "rank_top2_score_borda_blend": 2,
+    "rank_top3_score_borda_blend": 3,
+}
 TOPK_SCORE_SOFTMAX_LOG_POOL_SCORE_NORMALIZATIONS = {
     f"{mode}_log_pool": mode
     for mode in (
@@ -937,6 +946,7 @@ def _install_topk_score_softmax_score_normalizations(impl) -> None:
                 *TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS,
                 *TOPK_ADAPTIVE_SCORE_SOFTMAX_SCORE_NORMALIZATIONS,
                 *TOPK_SCORE_SOFTMAX_LOG_POOL_SCORE_NORMALIZATIONS,
+                *TOPK_SCORE_BORDA_BLEND_SCORE_NORMALIZATIONS,
             )
         )
     )
@@ -1915,6 +1925,9 @@ def _class_score_probabilities(scores, *, score_normalization=None):
     top_k = TOPK_ADAPTIVE_SCORE_SOFTMAX_SCORE_NORMALIZATIONS.get(base_mode)
     if top_k is not None:
         return _rank_topk_adaptive_score_softmax_probabilities(scores, top_k=top_k)
+    top_k = TOPK_SCORE_BORDA_BLEND_SCORE_NORMALIZATIONS.get(base_mode)
+    if top_k is not None:
+        return _rank_topk_score_borda_blend_probabilities(scores, top_k=top_k)
     topk_margin_blend = TOPK_MARGIN_BLEND_SCORE_NORMALIZATIONS.get(base_mode)
     if topk_margin_blend is not None:
         top_k, sharp_temperature = topk_margin_blend
@@ -2270,6 +2283,43 @@ def _rank_topk_adaptive_score_softmax_probabilities(scores, *, top_k):
         else:
             probabilities[row_index, ordered_columns] = exp_logits / total
     return probabilities
+
+
+def _rank_topk_score_borda_blend_probabilities(scores, *, top_k):
+    """Blend sparse top-k score softmax with truncated Borda by score margin.
+
+    Sparse score softmax can be useful when candidate scores strongly separate
+    the leading classes, but it can over-interpret noisy score differences when
+    the top-k classes are tightly clustered.  This leakage-safe normalizer uses
+    the existing row-wise rank-margin confidence: high-margin trials stay close
+    to score softmax, while low-margin trials move toward truncated Borda.
+    """
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError(
+            "Nested score ensembling requires a non-empty two-dimensional "
+            "class-score matrix."
+        )
+    top_k = int(top_k)
+    if top_k < 1:
+        raise ValueError("top_k must be at least one.")
+
+    score_softmax = _rank_topk_score_softmax_probabilities(scores, top_k=top_k)
+    borda = _rank_topk_borda_probabilities(scores, top_k=top_k)
+    confidence = np.asarray(
+        _impl._rank_margin_blend_confidence(scores),
+        dtype=float,
+    )[:, None]
+    confidence = np.clip(confidence, 0.0, 1.0)
+    blended = confidence * score_softmax + (1.0 - confidence) * borda
+    row_sums = np.sum(blended, axis=1, keepdims=True)
+    return np.divide(
+        blended,
+        row_sums,
+        out=np.full_like(blended, 1.0 / blended.shape[1]),
+        where=row_sums > 0.0,
+    )
 
 
 def _keeps_dense_topk_margin_blend(score_normalization):

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -561,6 +561,7 @@ def _empty_score_calibration_metadata(config: LatentAutoencoderConfig, status: s
         "score_calibration": config.score_calibration,
         "score_calibration_status": status,
         "score_calibration_prior_source": "",
+        "score_calibration_predicted_prior_source": "none",
         "score_calibration_alpha": 0.0,
         "score_calibration_validation_balanced_accuracy": np.nan,
         "score_calibration_uncalibrated_validation_balanced_accuracy": np.nan,
@@ -587,7 +588,11 @@ def _fit_validation_score_calibration(
     zero_bias = np.zeros(int(classes.shape[0]), dtype=float)
     if config.score_calibration == "none":
         return zero_bias, _empty_score_calibration_metadata(config, "not_requested")
-    supported_calibrations = {"validation_class_bias", "validation_prediction_bias"}
+    supported_calibrations = {
+        "validation_class_bias",
+        "validation_prediction_bias",
+        "validation_argmax_class_bias",
+    }
     if config.score_calibration not in supported_calibrations:
         raise ValueError(f"Unsupported latent AE score calibration: {config.score_calibration!r}")
     if validation_scores is None or validation_labels is None or len(validation_labels) == 0:
@@ -634,6 +639,9 @@ def _fit_validation_score_calibration(
         "score_calibration": config.score_calibration,
         "score_calibration_status": "ok",
         "score_calibration_prior_source": prior_source,
+        "score_calibration_predicted_prior_source": (
+            "softmax_mean" if prior_source == "mean_softmax" else "argmax"
+        ),
         "score_calibration_alpha": best_alpha,
         "score_calibration_validation_balanced_accuracy": best_balanced,
         "score_calibration_uncalibrated_validation_balanced_accuracy": uncalibrated_balanced,
@@ -785,6 +793,7 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "score_calibration": config.score_calibration,
         "score_calibration_status": fit_metadata.get("score_calibration_status", "unknown"),
         "score_calibration_prior_source": fit_metadata.get("score_calibration_prior_source", ""),
+        "score_calibration_predicted_prior_source": fit_metadata.get("score_calibration_predicted_prior_source", "none"),
         "score_calibration_alpha": fit_metadata.get("score_calibration_alpha", np.nan),
         "score_calibration_validation_balanced_accuracy": fit_metadata.get("score_calibration_validation_balanced_accuracy", np.nan),
         "score_calibration_uncalibrated_validation_balanced_accuracy": fit_metadata.get(
@@ -873,6 +882,9 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "score_calibration_smoothing": config.score_calibration_smoothing,
             "score_calibration_status_counts": _format_counter(Counter(row.get("score_calibration_status", "unknown") for row in outer_rows)),
             "score_calibration_prior_source_counts": _format_counter(Counter(row.get("score_calibration_prior_source", "") for row in outer_rows)),
+            "score_calibration_predicted_prior_source_counts": _format_counter(
+                Counter(row.get("score_calibration_predicted_prior_source", "none") for row in outer_rows)
+            ),
             "epochs_requested": config.epochs,
             "validation_selection_metric": config.validation_selection_metric,
             "validation_source_count": config.validation_source_count,
@@ -1189,7 +1201,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument("--label-shuffle-seed", type=int, default=0)
     parser.add_argument(
         "--score-calibration",
-        choices=("none", "validation_class_bias", "validation_prediction_bias"),
+        choices=("none", "validation_class_bias", "validation_prediction_bias", "validation_argmax_class_bias"),
         default="none",
         help="Optional source-validation-only logit calibration for latent AE predictions.",
     )

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -181,6 +181,48 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(ambiguous[0, 3], 0.0)
         self.assertGreater(confident[0, 0], ambiguous[0, 0])
 
+    def test_topk_score_borda_blend_modes_are_exported_and_margin_gated(self):
+        mode = "rank_top3_score_borda_blend"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            mode,
+        )
+
+        confident_scores = np.asarray([[6.0, 1.0, 0.0, -1.0]], dtype=float)
+        ambiguous_scores = np.asarray([[3.0, 2.9, 2.8, 0.0]], dtype=float)
+        confident = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            confident_scores,
+            score_normalization=mode,
+        )
+        ambiguous = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            ambiguous_scores,
+            score_normalization=mode,
+        )
+
+        np.testing.assert_allclose(np.sum(confident, axis=1), np.ones(1))
+        np.testing.assert_allclose(np.sum(ambiguous, axis=1), np.ones(1))
+        self.assertEqual(np.count_nonzero(confident[0]), 3)
+        self.assertEqual(np.count_nonzero(ambiguous[0]), 3)
+        self.assertEqual(confident[0, 3], 0.0)
+        self.assertEqual(ambiguous[0, 3], 0.0)
+
+        ambiguous_borda = next_hooks._rank_topk_borda_probabilities(  # pylint: disable=protected-access
+            ambiguous_scores,
+            top_k=3,
+        )
+        ambiguous_score_softmax = (
+            next_hooks._rank_topk_score_softmax_probabilities(  # pylint: disable=protected-access
+                ambiguous_scores,
+                top_k=3,
+            )
+        )
+        self.assertLess(
+            np.linalg.norm(ambiguous - ambiguous_borda),
+            np.linalg.norm(ambiguous_score_softmax - ambiguous_borda),
+        )
+
     def test_topk_agreement_log_pool_blends_on_near_top_consensus(self):
         mode = "rank_top3_score_softmax_top3_agreement_log_pool"
 

--- a/tests/test_stimulus_latent_autoencoder_score_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_score_calibration.py
@@ -41,3 +41,29 @@ def test_validation_class_bias_calibration_improves_validation_balance():
     assert metadata["score_calibration_status"] == "ok"
     assert np.mean(calibrated_predictions == labels) >= np.mean(uncalibrated_predictions == labels)
     assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
+
+
+def test_validation_argmax_class_bias_calibration_targets_argmax_collapse():
+    classes = np.asarray([1, 2])
+    labels = np.asarray([1, 1, 2, 2])
+    scores = np.asarray(
+        [
+            [2.0, 0.0],
+            [1.5, 0.0],
+            [0.4, 0.3],
+            [0.4, 0.35],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_argmax_class_bias",
+        score_calibration_alphas=(0.0, 0.25, 0.5, 0.75, 1.0),
+        score_calibration_smoothing=0.1,
+    )
+    bias, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
+    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, bias), axis=1)]
+    assert metadata["score_calibration_status"] == "ok"
+    assert metadata["score_calibration_predicted_prior_source"] == "argmax"
+    assert np.unique(uncalibrated_predictions).tolist() == [1]
+    assert np.mean(calibrated_predictions == labels) > np.mean(uncalibrated_predictions == labels)
+    assert metadata["score_calibration_validation_balanced_accuracy"] > metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]

--- a/tests/test_stimulus_latent_autoencoder_score_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_score_calibration.py
@@ -19,6 +19,18 @@ def test_bounded_label_smoothing_clamps_to_valid_cross_entropy_range():
     assert _bounded_label_smoothing(1.5) == 0.999
 
 
+def _fit_calibrated_predictions(
+    scores: np.ndarray,
+    labels: np.ndarray,
+    classes: np.ndarray,
+    config: LatentAutoencoderConfig,
+) -> tuple[np.ndarray, np.ndarray, dict[str, object]]:
+    bias, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
+    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, bias), axis=1)]
+    return uncalibrated_predictions, calibrated_predictions, metadata
+
+
 def test_validation_class_bias_calibration_improves_validation_balance():
     classes = np.asarray([1, 2])
     labels = np.asarray([1, 1, 2, 2])
@@ -35,9 +47,12 @@ def test_validation_class_bias_calibration_improves_validation_balance():
         score_calibration_alphas=(0.0, 0.5, 1.0, 2.0),
         score_calibration_smoothing=0.0,
     )
-    bias, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
-    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
-    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, bias), axis=1)]
+    uncalibrated_predictions, calibrated_predictions, metadata = _fit_calibrated_predictions(
+        scores,
+        labels,
+        classes,
+        config,
+    )
     assert metadata["score_calibration_status"] == "ok"
     assert np.mean(calibrated_predictions == labels) >= np.mean(uncalibrated_predictions == labels)
     assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
@@ -59,9 +74,12 @@ def test_validation_argmax_class_bias_calibration_targets_argmax_collapse():
         score_calibration_alphas=(0.0, 0.25, 0.5, 0.75, 1.0),
         score_calibration_smoothing=0.1,
     )
-    bias, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
-    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
-    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, bias), axis=1)]
+    uncalibrated_predictions, calibrated_predictions, metadata = _fit_calibrated_predictions(
+        scores,
+        labels,
+        classes,
+        config,
+    )
     assert metadata["score_calibration_status"] == "ok"
     assert metadata["score_calibration_predicted_prior_source"] == "argmax"
     assert np.unique(uncalibrated_predictions).tolist() == [1]


### PR DESCRIPTION
## Summary
- add validation argmax calibration compatibility and metadata
- add top-k score/Borda blend normalization modes and workflow presets
- add coverage for Borda blend probabilities and argmax calibration behavior

## Checks
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_cross_subject_next.py tests\test_stimulus_latent_autoencoder_score_calibration.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text(encoding='utf-8')); yaml.safe_load(pathlib.Path('.github/workflows/stimulus-latent-autoencoder.yml').read_text(encoding='utf-8'))"`
- `git diff --check`