### PR TITLE
Add guarded calibration and balanced latent batches

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -93,6 +93,7 @@ on:
           - windowed_logreg_175_w075
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
+          - windowed_logreg_175_w150_lcb_pruned
           - windowed_logreg_175_w150_margin_entropy_weighting
           - windowed_logreg_175_w150_worstclass_lcb
           - windowed_logreg_175_w150_time_bins7
@@ -227,6 +228,7 @@ on:
           - classifier
           - window_classifier
           - inner_confusion_complement
+          - lcb_pruned
           - window_feature_classifier_score_calibration
           - full_config
       selection_ensemble_score_normalization_override:
@@ -1748,6 +1750,27 @@ jobs:
                   "components_pca_values": "128",
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_lcb_pruned": {
+                  # Same clean source-only w150 family as the current best run,
+                  # but let source-inner uncertainty prune weak tail candidates
+                  # from the fixed top-3 selected ensemble.  This tests whether
+                  # the useful w150 score ensemble is helped by dropping a third
+                  # model whose source-inner LCB no longer overlaps the leader.
+                  # No cue data, alignment, or held-out labels are used.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "lcb_pruned",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",

--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -54,6 +54,11 @@ on:
         required: true
         default: "0.0"
         type: string
+      balanced_batch_sampling:
+        description: Interleave classes within training epochs so minibatches are class-diverse.
+        required: true
+        default: false
+        type: boolean
       latent_dim:
         description: Shared latent dimension.
         required: true
@@ -87,6 +92,7 @@ on:
         options:
           - none
           - validation_class_bias
+          - validation_class_bias_guarded
       score_calibration_alphas:
         description: Candidate alpha strengths for validation_class_bias.
         required: true
@@ -96,6 +102,20 @@ on:
         description: Additive smoothing for validation_class_bias priors.
         required: true
         default: "1.0"
+        type: string
+      score_calibration_selection_metric:
+        description: Source-validation objective for guarded score calibration.
+        required: true
+        default: balanced_top2_top3_rank_balance
+        type: choice
+        options:
+          - balanced_accuracy
+          - balanced_top2_top3_rank
+          - balanced_top2_top3_rank_balance
+      score_calibration_guard_tolerance:
+        description: Allowed guarded-calibration balanced-accuracy drop on source validation.
+        required: true
+        default: "0.0"
         type: string
 
 permissions:
@@ -127,6 +147,7 @@ jobs:
         env:
           LABEL_SHUFFLE: ${{ inputs.label_shuffle_control }}
           OUTER_PARTICIPANTS: ${{ inputs.outer_participants }}
+          BALANCED_BATCH_SAMPLING: ${{ inputs.balanced_batch_sampling }}
         run: |
           mkdir -p outputs
           ARGS=(
@@ -154,6 +175,8 @@ jobs:
             --score-calibration "${{ inputs.score_calibration }}"
             --score-calibration-alphas "${{ inputs.score_calibration_alphas }}"
             --score-calibration-smoothing "${{ inputs.score_calibration_smoothing }}"
+            --score-calibration-selection-metric "${{ inputs.score_calibration_selection_metric }}"
+            --score-calibration-guard-tolerance "${{ inputs.score_calibration_guard_tolerance }}"
             --seed 0
             --outer-output "outputs/${{ inputs.output_stem }}_outer.csv"
             --summary-output "outputs/${{ inputs.output_stem }}_group_summary.csv"
@@ -164,6 +187,9 @@ jobs:
           )
           if [ -n "${OUTER_PARTICIPANTS}" ]; then
             ARGS+=(--outer-participants "${OUTER_PARTICIPANTS}")
+          fi
+          if [ "${BALANCED_BATCH_SAMPLING}" = "true" ]; then
+            ARGS+=(--balanced-batch-sampling)
           fi
           if [ "${LABEL_SHUFFLE}" = "true" ]; then
             ARGS+=(--label-shuffle-control --label-shuffle-seed "${{ inputs.label_shuffle_seed }}")

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -280,6 +280,8 @@ INNER_CONFUSION_CORRECTION_SOFT_BLEND = 0.35
 INNER_CONFUSION_CORRECTION_MARGIN_QUANTILE = 0.50
 INNER_CONFUSION_CORRECTION_GUARDED_POWER = 0.5
 INNER_CONFUSION_COMPLEMENTARITY_PENALTY = 0.0025
+LCB_PRUNED_ENSEMBLE_DIVERSITY = "lcb_pruned"
+LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIER = 1.0
 LOG_POOL_SUFFIX = "_log_pool"
 ENSEMBLE_LOG_POOL_EPSILON = 1e-12
 BALANCED_QUOTA_SUFFIX = "_balanced_quota"
@@ -333,6 +335,7 @@ SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "window_feature_classifier_sample_weighting_score_calibration_pca",
     "window_feature_classifier_param_sample_weighting_score_calibration_pca",
     "inner_confusion_complement",
+    LCB_PRUNED_ENSEMBLE_DIVERSITY,
     "full_config",
 )
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
@@ -1603,6 +1606,10 @@ def _select_diverse_nested_rows(ranked_rows, *, requested_size, candidate_config
         return _select_inner_confusion_complement_rows(
             ranked_rows, requested_size=requested_size
         )
+    if diversity == LCB_PRUNED_ENSEMBLE_DIVERSITY:
+        return _select_lcb_pruned_nested_rows(
+            ranked_rows, requested_size=requested_size
+        )
 
     selected = []
     selected_indices = set()
@@ -1662,6 +1669,67 @@ def _select_inner_confusion_complement_rows(ranked_rows, *, requested_size):
         selected.append(best_row)
         selected_indices.add(int(best_row["selected_candidate_index"]))
     return tuple(selected)
+
+
+def _select_lcb_pruned_nested_rows(ranked_rows, *, requested_size):
+    """Select the top-ranked nested rows, then drop low-confidence tail members.
+
+    The BUSH-MEG source-only w150 branch now gets useful signal from a small
+    score ensemble, but a fixed top-K ensemble can still include a weak third
+    candidate when source-inner model selection is nearly tied.  This pruning
+    rule is deliberately leakage-safe: it uses only source-inner selection
+    scores and their source-subject SEMs.  A candidate is retained only when
+    its lower confidence bound remains within one top-candidate SEM of the
+    best candidate's source-inner selection score.
+    """
+
+    ranked_rows = tuple(ranked_rows)
+    requested_size = min(
+        _normalize_selection_ensemble_size(requested_size), len(ranked_rows)
+    )
+    if requested_size <= 1 or not ranked_rows:
+        return tuple(ranked_rows[:requested_size])
+
+    candidates = tuple(ranked_rows[:requested_size])
+    best_score = _nested_lcb_pruning_score(candidates[0])
+    if not np.isfinite(best_score):
+        return candidates
+    threshold = best_score - (
+        float(LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIER)
+        * _nested_lcb_pruning_sem(candidates[0])
+    )
+
+    selected = [candidates[0]]
+    for row in candidates[1:]:
+        row_lcb = _nested_lcb_pruning_score(row) - _nested_lcb_pruning_sem(row)
+        if np.isfinite(row_lcb) and row_lcb >= threshold:
+            selected.append(row)
+    return tuple(selected)
+
+
+def _nested_lcb_pruning_score(row):
+    """Return the source-inner score used for LCB ensemble pruning."""
+
+    return _finite_sort_value(
+        row.get(
+            "selected_inner_selection_ranking_score",
+            row.get("selected_inner_selection_score_mean", np.nan),
+        )
+    )
+
+
+def _nested_lcb_pruning_sem(row):
+    """Return a finite, non-negative SEM for source-inner ensemble pruning."""
+
+    for key in ("selected_inner_selection_score_sem", "selected_inner_balanced_accuracy_sem"):
+        sem = row.get(key, 0.0)
+        try:
+            sem = float(sem)
+        except (TypeError, ValueError):
+            sem = 0.0
+        if np.isfinite(sem) and sem > 0.0:
+            return sem
+    return 0.0
 
 
 def _inner_selection_score_for_complement(row):
@@ -1758,6 +1826,8 @@ def _ensemble_diversity_key(config, diversity):
         )
     if diversity == "inner_confusion_complement":
         return "inner_confusion_complement"
+    if diversity == LCB_PRUNED_ENSEMBLE_DIVERSITY:
+        return LCB_PRUNED_ENSEMBLE_DIVERSITY
     return (
         f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
         f"feature={config.feature_mode},norm={config.normalization},alignment={config.alignment},"

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -63,6 +63,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     prediction_balance_weight: float = 0.0
     prediction_balance_target_smoothing: float = 1.0
     label_smoothing: float = 0.0
+    balanced_batch_sampling: bool = False
     validation_prediction_balance_weight: float = 0.0
     epochs: int = 80
     batch_size: int = 256
@@ -82,6 +83,8 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     score_calibration: str = "none"
     score_calibration_alphas: tuple[float, ...] = (0.0, 0.25, 0.5, 0.75, 1.0)
     score_calibration_smoothing: float = 1.0
+    score_calibration_selection_metric: str = "balanced_accuracy"
+    score_calibration_guard_tolerance: float = 0.0
     device: str = "auto"
     num_threads: int = 1
 
@@ -249,6 +252,36 @@ def _prediction_balance_loss(logits, label_indices, *, target_smoothing: float):
     return F.mse_loss(predicted_distribution, target_distribution)
 
 
+def _balanced_epoch_indices(label_indices: np.ndarray, *, rng: np.random.Generator) -> np.ndarray:
+    """Return one epoch order that interleaves classes before batching.
+
+    The latent autoencoder smoke run showed hard-prediction collapse onto a
+    small subset of classes even though the source labels are globally balanced.
+    Random pooled minibatches can still produce short-run class skew and noisy
+    class-gradient estimates.  This helper keeps every training row exactly once
+    per epoch, but constructs the epoch order by cycling through per-class
+    shuffled buckets so most contiguous minibatches see all classes.
+    """
+
+    label_indices = np.asarray(label_indices, dtype=np.int64).ravel()
+    if label_indices.size == 0:
+        return np.asarray([], dtype=np.int64)
+    buckets: list[list[int]] = []
+    for class_index in sorted(int(value) for value in np.unique(label_indices)):
+        indices = np.flatnonzero(label_indices == class_index).astype(np.int64)
+        indices = np.asarray(rng.permutation(indices), dtype=np.int64)
+        buckets.append(indices.tolist())
+    order: list[int] = []
+    while any(buckets):
+        cycle: list[int] = []
+        for bucket in buckets:
+            if bucket:
+                cycle.append(bucket.pop())
+        rng.shuffle(cycle)
+        order.extend(cycle)
+    return np.asarray(order, dtype=np.int64)
+
+
 def _fit_pca(train_features: np.ndarray, test_features: np.ndarray | None, *, components_pca: int, seed: int):
     n_components = int(min(int(components_pca), train_features.shape[0], train_features.shape[1]))
     if n_components < 1:
@@ -360,9 +393,14 @@ def _train_model(  # pylint: disable=too-many-arguments,too-many-locals
 
     for epoch in range(1, max_epochs + 1):
         model.train()
-        permutation = torch.tensor(rng.permutation(train_features.shape[0]), dtype=torch.long, device=device)
+        if config.balanced_batch_sampling:
+            epoch_indices = _balanced_epoch_indices(y_index, rng=rng)
+        else:
+            epoch_indices = rng.permutation(train_features.shape[0])
+        permutation = torch.tensor(epoch_indices, dtype=torch.long, device=device)
         epoch_loss = 0.0
         batches = 0
+
         for start in range(0, int(permutation.shape[0]), int(config.batch_size)):
             batch_index = permutation[start : start + int(config.batch_size)]
             xb = x_tensor[batch_index]
@@ -564,6 +602,10 @@ def _empty_score_calibration_metadata(config: LatentAutoencoderConfig, status: s
         "score_calibration_alpha": 0.0,
         "score_calibration_validation_balanced_accuracy": np.nan,
         "score_calibration_uncalibrated_validation_balanced_accuracy": np.nan,
+        "score_calibration_selection_metric": config.score_calibration_selection_metric,
+        "score_calibration_validation_selection_score": np.nan,
+        "score_calibration_uncalibrated_validation_selection_score": np.nan,
+        "score_calibration_guard_tolerance": config.score_calibration_guard_tolerance,
         "score_calibration_bias_min": 0.0,
         "score_calibration_bias_max": 0.0,
         "score_calibration_bias_mean_abs": 0.0,
@@ -581,13 +623,16 @@ def _fit_validation_score_calibration(
     The latent AE smoke run showed strong prediction-frequency imbalance.  This
     calibrator estimates the mismatch between true validation class prior and a
     model-implied prior, then tunes a scalar bias strength on the source-validation
-    split only.  Held-out-subject labels are never used.
+    split only.  The guarded variant can optimize a richer rank/balance
+    source-validation objective while rejecting any alpha whose validation
+    balanced accuracy drops below the configured guard tolerance.
+    Held-out-subject labels are never used.
     """
 
     zero_bias = np.zeros(int(classes.shape[0]), dtype=float)
     if config.score_calibration == "none":
         return zero_bias, _empty_score_calibration_metadata(config, "not_requested")
-    supported_calibrations = {"validation_class_bias", "validation_prediction_bias"}
+    supported_calibrations = {"validation_class_bias", "validation_class_bias_guarded", "validation_prediction_bias"}
     if config.score_calibration not in supported_calibrations:
         raise ValueError(f"Unsupported latent AE score calibration: {config.score_calibration!r}")
     if validation_scores is None or validation_labels is None or len(validation_labels) == 0:
@@ -602,7 +647,7 @@ def _fit_validation_score_calibration(
     true_counts = np.bincount(label_indices, minlength=n_classes).astype(float)
     true_prior = (true_counts + smoothing) / (float(np.sum(true_counts)) + smoothing * n_classes)
 
-    if config.score_calibration == "validation_class_bias":
+    if config.score_calibration in {"validation_class_bias", "validation_class_bias_guarded"}:
         prior_source = "mean_softmax"
         predicted_counts = np.sum(_softmax_scores(validation_scores), axis=0)
     else:
@@ -615,19 +660,51 @@ def _fit_validation_score_calibration(
     base_bias = np.log(true_prior) - np.log(predicted_prior)
     base_bias = base_bias - float(np.mean(base_bias))
 
-    uncalibrated_predictions = classes[np.argmax(validation_scores, axis=1)]
-    uncalibrated_balanced = float(balanced_accuracy_score(validation_labels, uncalibrated_predictions))
+    uncalibrated_metrics = _validation_selection_metrics(
+        validation_labels,
+        validation_scores,
+        classes,
+        config.score_calibration_selection_metric,
+    )
+    uncalibrated_balanced = float(uncalibrated_metrics["balanced_accuracy"])
+    uncalibrated_selection = float(uncalibrated_metrics["selection_score"])
     alphas = tuple(float(alpha) for alpha in config.score_calibration_alphas)
     if not alphas:
         alphas = (1.0,)
     best_alpha = 0.0
     best_balanced = -math.inf
+    best_selection = -math.inf
+    best_objective = -math.inf
+    if config.score_calibration == "validation_class_bias_guarded":
+        best_balanced = uncalibrated_balanced
+        best_selection = uncalibrated_selection
+        best_objective = uncalibrated_selection
+    guard_floor = uncalibrated_balanced - max(0.0, float(config.score_calibration_guard_tolerance))
     for alpha in alphas:
         calibrated_scores = validation_scores + float(alpha) * base_bias
-        calibrated_predictions = classes[np.argmax(calibrated_scores, axis=1)]
-        balanced = float(balanced_accuracy_score(validation_labels, calibrated_predictions))
-        if balanced > best_balanced + 1e-12 or (abs(balanced - best_balanced) <= 1e-12 and abs(float(alpha)) < abs(best_alpha)):
+        calibrated_metrics = _validation_selection_metrics(
+            validation_labels,
+            calibrated_scores,
+            classes,
+            config.score_calibration_selection_metric,
+        )
+        balanced = float(calibrated_metrics["balanced_accuracy"])
+        selection_score = float(calibrated_metrics["selection_score"])
+        if config.score_calibration == "validation_class_bias_guarded" and balanced + 1e-12 < guard_floor:
+            continue
+        objective = selection_score if config.score_calibration == "validation_class_bias_guarded" else balanced
+        if (
+            objective > best_objective + 1e-12
+            or (abs(objective - best_objective) <= 1e-12 and balanced > best_balanced + 1e-12)
+            or (
+                abs(objective - best_objective) <= 1e-12
+                and abs(balanced - best_balanced) <= 1e-12
+                and abs(float(alpha)) < abs(best_alpha)
+            )
+        ):
+            best_objective = objective
             best_balanced = balanced
+            best_selection = selection_score
             best_alpha = float(alpha)
     bias = best_alpha * base_bias
     metadata = {
@@ -637,6 +714,10 @@ def _fit_validation_score_calibration(
         "score_calibration_alpha": best_alpha,
         "score_calibration_validation_balanced_accuracy": best_balanced,
         "score_calibration_uncalibrated_validation_balanced_accuracy": uncalibrated_balanced,
+        "score_calibration_selection_metric": config.score_calibration_selection_metric,
+        "score_calibration_validation_selection_score": best_selection,
+        "score_calibration_uncalibrated_validation_selection_score": uncalibrated_selection,
+        "score_calibration_guard_tolerance": config.score_calibration_guard_tolerance,
         "score_calibration_bias_min": float(np.min(bias)),
         "score_calibration_bias_max": float(np.max(bias)),
         "score_calibration_bias_mean_abs": float(np.mean(np.abs(bias))),
@@ -702,6 +783,7 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
             "prediction_balance_weight": config.prediction_balance_weight,
             "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "label_smoothing": config.label_smoothing,
+            "balanced_batch_sampling": config.balanced_batch_sampling,
             "score_calibration": config.score_calibration,
             "label_shuffle_control": config.label_shuffle_control,
             "label_shuffle_seed": config.label_shuffle_seed if config.label_shuffle_control else np.nan,
@@ -781,6 +863,7 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "prediction_balance_weight": config.prediction_balance_weight,
         "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
         "label_smoothing": config.label_smoothing,
+        "balanced_batch_sampling": config.balanced_batch_sampling,
         "validation_prediction_balance_weight": config.validation_prediction_balance_weight,
         "score_calibration": config.score_calibration,
         "score_calibration_status": fit_metadata.get("score_calibration_status", "unknown"),
@@ -789,6 +872,16 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "score_calibration_validation_balanced_accuracy": fit_metadata.get("score_calibration_validation_balanced_accuracy", np.nan),
         "score_calibration_uncalibrated_validation_balanced_accuracy": fit_metadata.get(
             "score_calibration_uncalibrated_validation_balanced_accuracy", np.nan
+        ),
+        "score_calibration_selection_metric": fit_metadata.get(
+            "score_calibration_selection_metric", config.score_calibration_selection_metric
+        ),
+        "score_calibration_validation_selection_score": fit_metadata.get("score_calibration_validation_selection_score", np.nan),
+        "score_calibration_uncalibrated_validation_selection_score": fit_metadata.get(
+            "score_calibration_uncalibrated_validation_selection_score", np.nan
+        ),
+        "score_calibration_guard_tolerance": fit_metadata.get(
+            "score_calibration_guard_tolerance", config.score_calibration_guard_tolerance
         ),
         "score_calibration_bias_min": fit_metadata.get("score_calibration_bias_min", np.nan),
         "score_calibration_bias_max": fit_metadata.get("score_calibration_bias_max", np.nan),
@@ -866,11 +959,14 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "prediction_balance_weight": config.prediction_balance_weight,
             "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "label_smoothing": config.label_smoothing,
+            "balanced_batch_sampling": config.balanced_batch_sampling,
             "validation_prediction_balance_weight": config.validation_prediction_balance_weight,
             "dropout": config.dropout,
             "score_calibration": config.score_calibration,
             "score_calibration_alphas": ";".join(str(float(alpha)) for alpha in config.score_calibration_alphas),
             "score_calibration_smoothing": config.score_calibration_smoothing,
+            "score_calibration_selection_metric": config.score_calibration_selection_metric,
+            "score_calibration_guard_tolerance": config.score_calibration_guard_tolerance,
             "score_calibration_status_counts": _format_counter(Counter(row.get("score_calibration_status", "unknown") for row in outer_rows)),
             "score_calibration_prior_source_counts": _format_counter(Counter(row.get("score_calibration_prior_source", "") for row in outer_rows)),
             "epochs_requested": config.epochs,
@@ -914,6 +1010,12 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             ),
             "actual_components_pca_counts": _format_counter(Counter(int(row["actual_components_pca"]) for row in outer_rows)),
             "score_calibration_alpha_mean": float(np.nanmean([float(row.get("score_calibration_alpha", np.nan)) for row in outer_rows])),
+            "score_calibration_validation_selection_score_mean": float(
+                np.nanmean([float(row.get("score_calibration_validation_selection_score", np.nan)) for row in outer_rows])
+            ),
+            "score_calibration_uncalibrated_validation_selection_score_mean": float(
+                np.nanmean([float(row.get("score_calibration_uncalibrated_validation_selection_score", np.nan)) for row in outer_rows])
+            ),
             "score_calibration_bias_mean_abs_mean": float(np.nanmean([float(row.get("score_calibration_bias_mean_abs", np.nan)) for row in outer_rows])),
             "best_validation_selection_score_mean": float(
                 np.nanmean([float(row.get("best_validation_selection_score", np.nan)) for row in outer_rows])
@@ -1149,6 +1251,12 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         help="Cross-entropy label smoothing for latent AE training; useful for reducing overconfident class collapse.",
     )
     parser.add_argument(
+        "--balanced-batch-sampling",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Interleave classes within each training epoch so minibatches are class-diverse.",
+    )
+    parser.add_argument(
         "--validation-prediction-balance-weight",
         type=float,
         default=0.0,
@@ -1189,7 +1297,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument("--label-shuffle-seed", type=int, default=0)
     parser.add_argument(
         "--score-calibration",
-        choices=("none", "validation_class_bias", "validation_prediction_bias"),
+        choices=("none", "validation_class_bias", "validation_class_bias_guarded", "validation_prediction_bias"),
         default="none",
         help="Optional source-validation-only logit calibration for latent AE predictions.",
     )
@@ -1200,6 +1308,24 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         help="Candidate strengths for validation_class_bias calibration.",
     )
     parser.add_argument("--score-calibration-smoothing", type=float, default=1.0)
+    parser.add_argument(
+        "--score-calibration-selection-metric",
+        choices=("balanced_accuracy", "balanced_top2_top3_rank", "balanced_top2_top3_rank_balance"),
+        default="balanced_accuracy",
+        help=(
+            "Source-validation objective used by validation_class_bias_guarded. "
+            "validation_class_bias keeps the legacy balanced-accuracy objective."
+        ),
+    )
+    parser.add_argument(
+        "--score-calibration-guard-tolerance",
+        type=float,
+        default=0.0,
+        help=(
+            "Maximum allowed validation balanced-accuracy drop for validation_class_bias_guarded; "
+            "0 enforces no validation balanced-accuracy regression."
+        ),
+    )
     parser.add_argument("--device", default="auto", help="auto, cpu, cuda, or another torch device string.")
     parser.add_argument("--num-threads", type=int, default=1)
     parser.add_argument("--outer-output", default="outputs/latent_autoencoder_outer.csv")
@@ -1228,6 +1354,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         prediction_balance_weight=args.prediction_balance_weight,
         prediction_balance_target_smoothing=args.prediction_balance_target_smoothing,
         label_smoothing=args.label_smoothing,
+        balanced_batch_sampling=bool(args.balanced_batch_sampling),
         validation_prediction_balance_weight=args.validation_prediction_balance_weight,
         epochs=args.epochs,
         batch_size=args.batch_size,
@@ -1247,6 +1374,8 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         score_calibration=args.score_calibration,
         score_calibration_alphas=args.score_calibration_alphas,
         score_calibration_smoothing=args.score_calibration_smoothing,
+        score_calibration_selection_metric=args.score_calibration_selection_metric,
+        score_calibration_guard_tolerance=args.score_calibration_guard_tolerance,
         device=args.device,
         num_threads=args.num_threads,
     )

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -127,6 +127,41 @@ class TestStimulusCrossSubject(unittest.TestCase):
         self.assertGreater(weights[1, 1], weights[0, 1])
         np.testing.assert_allclose(np.sum(weights, axis=0), np.ones(2))
 
+    def test_lcb_pruned_ensemble_diversity_drops_low_confidence_tail_candidates(self):
+        ranked_rows = (
+            {
+                "selected_candidate_index": 1,
+                "selected_inner_selection_ranking_score": 0.150,
+                "selected_inner_selection_score_mean": 0.150,
+                "selected_inner_selection_score_sem": 0.005,
+                "selected_inner_balanced_accuracy_mean": 0.150,
+                "selected_inner_balanced_accuracy_sem": 0.005,
+            },
+            {
+                "selected_candidate_index": 2,
+                "selected_inner_selection_ranking_score": 0.149,
+                "selected_inner_selection_score_mean": 0.149,
+                "selected_inner_selection_score_sem": 0.001,
+                "selected_inner_balanced_accuracy_mean": 0.149,
+                "selected_inner_balanced_accuracy_sem": 0.001,
+            },
+            {
+                "selected_candidate_index": 3,
+                "selected_inner_selection_ranking_score": 0.145,
+                "selected_inner_selection_score_mean": 0.145,
+                "selected_inner_selection_score_sem": 0.004,
+                "selected_inner_balanced_accuracy_mean": 0.145,
+                "selected_inner_balanced_accuracy_sem": 0.004,
+            },
+        )
+        configs = tuple(CrossSubjectStimulusConfig(classifier_param=0.3) for _ in ranked_rows)
+
+        selected = cross_subject._select_diverse_nested_rows(  # pylint: disable=protected-access
+            ranked_rows, requested_size=3, candidate_configs=configs, diversity="lcb-pruned"
+        )
+
+        self.assertEqual([int(row["selected_candidate_index"]) for row in selected], [1, 2])
+
     def test_trial_margin_entropy_ensemble_weighting_prefers_jointly_confident_model_per_trial(self):
         score_matrices = (
             np.asarray(

--- a/tests/test_stimulus_latent_autoencoder_controls.py
+++ b/tests/test_stimulus_latent_autoencoder_controls.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from pymegdec.stimulus_latent_autoencoder import (
     LatentAutoencoderConfig,
+    _balanced_epoch_indices,
     _final_refit_epochs,
     _prediction_balance_score,
     _split_source_participants,
@@ -71,3 +72,15 @@ def test_validation_selection_metrics_rank_balance_variant_rewards_balanced_pred
 
     assert math.isfinite(balanced["selection_score"])
     assert balanced["selection_score"] > collapsed["selection_score"]
+
+
+def test_balanced_epoch_indices_interleaves_classes_and_preserves_rows():
+    labels = np.asarray([0] * 5 + [1] * 3 + [2] * 4)
+    rng = np.random.default_rng(0)
+
+    order = _balanced_epoch_indices(labels, rng=rng)
+
+    assert sorted(order.tolist()) == list(range(labels.shape[0]))
+    first_cycle_labels = set(labels[order[:3]].tolist())
+    assert first_cycle_labels == {0, 1, 2}
+    assert np.bincount(labels[order], minlength=3).tolist() == [5, 3, 4]

--- a/tests/test_stimulus_latent_autoencoder_score_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_score_calibration.py
@@ -41,3 +41,35 @@ def test_validation_class_bias_calibration_improves_validation_balance():
     assert metadata["score_calibration_status"] == "ok"
     assert np.mean(calibrated_predictions == labels) >= np.mean(uncalibrated_predictions == labels)
     assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
+
+
+def test_guarded_validation_class_bias_uses_rank_balance_selection_without_balanced_regression():
+    classes = np.asarray([1, 2, 3])
+    labels = np.asarray([1, 1, 2, 2, 3, 3])
+    scores = np.asarray(
+        [
+            [2.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [2.0, 1.9, 0.0],
+            [2.0, 1.8, 0.0],
+            [2.0, 0.0, 1.9],
+            [2.0, 0.0, 1.8],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_class_bias_guarded",
+        score_calibration_alphas=(0.0, 0.5, 1.0, 2.0),
+        score_calibration_smoothing=0.0,
+        score_calibration_selection_metric="balanced_top2_top3_rank_balance",
+        score_calibration_guard_tolerance=0.0,
+    )
+
+    bias, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, bias), axis=1)]
+    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
+
+    assert metadata["score_calibration_status"] == "ok"
+    assert metadata["score_calibration_alpha"] > 0.0
+    assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
+    assert metadata["score_calibration_validation_selection_score"] >= metadata["score_calibration_uncalibrated_validation_selection_score"]
+    assert len(set(calibrated_predictions.tolist())) > len(set(uncalibrated_predictions.tolist()))


### PR DESCRIPTION
## Summary
- add guarded latent AE score calibration and balanced batch controls
- add pruned LCB ensemble options for stimulus cross-subject workflows
- update workflow inputs and focused regression coverage

## Verification
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_cross_subject.py tests\test_stimulus_latent_autoencoder_controls.py tests\test_stimulus_latent_autoencoder_score_calibration.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text(encoding='utf-8')); yaml.safe_load(pathlib.Path('.github/workflows/stimulus-latent-autoencoder.yml').read_text(encoding='utf-8'))"`
- `git diff --check`

Tests were not run per request.