### PR TITLE
Add compact score calibration split bundles

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -124,6 +124,8 @@ on:
           - windowed_logreg_175_w150_pca160_prediction_bias
           - windowed_logreg_175_w150_pca160_c03_c05_ranksoft_t0_75_inner_confusion_guarded
           - windowed_logreg_175_w150_pca160_c03_c05_scorecal
+          - windowed_logreg_175_w150_pca160_c03_c05_inner_class_bias
+          - windowed_logreg_175_w150_pca160_c03_c05_inner_rank_bias_guarded
           - windowed_logreg_175_w150_pca160_cgrid
           - windowed_logreg_175_w150_pca160_cgrid_top3_margin
           - windowed_logreg_175_w150_pca160_cgrid_inner_confusion_guarded
@@ -2679,6 +2681,44 @@ jobs:
                   "components_pca_values": "160",
                   "sample_weightings": "none",
                   "score_calibrations": "none,inner_class_bias,inner_rank_bias_guarded",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_c03_c05_inner_class_bias": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "sample_weightings": "none",
+                  "score_calibrations": "inner_class_bias",
+                  "alignment_alphas": "1.0",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_pca160_c03_c05_inner_rank_bias_guarded": {
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,0.5",
+                  "components_pca_values": "160",
+                  "sample_weightings": "none",
+                  "score_calibrations": "inner_rank_bias_guarded",
                   "alignment_alphas": "1.0",
                   "selection_metric": "balanced_top2_top3_rank_lcb",
                   "selection_ensemble_size": "3",


### PR DESCRIPTION
## Summary
- add two compact split bundles for the PCA160/C0.3-C0.5 score-calibration follow-up
- split the broad scorecal candidate set into one inner_class_bias bundle and one inner_rank_bias_guarded bundle
- keep each split bundle at 4 candidates: 2 classifiers x 2 C values x 1 score calibration

## Context
The combined scorecal replacement run 26985892014 reached decoding but p02 and p04 hit the 300-minute shard timeout. These smaller bundles are the fallback path for testing score calibration without the 12-candidate search.

## Verification
- parsed stimulus-cross-subject-nested-matrix.yml with PyYAML
- ran git diff --check