### PR TITLE
Add latent assignment and LCB sweep controls

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -94,6 +94,9 @@ on:
           - windowed_logreg_175_w125
           - windowed_logreg_175_w150
           - windowed_logreg_175_w150_lcb_pruned
+          - windowed_logreg_175_w150_lcb_pruned_t0_5
+          - windowed_logreg_175_w150_lcb_pruned_t1_5
+          - windowed_logreg_175_w150_lcb_pruned_t2
           - windowed_logreg_175_w150_score_borda_blend
           - windowed_logreg_175_w150_margin_entropy_weighting
           - windowed_logreg_175_w150_worstclass_lcb
@@ -232,6 +235,9 @@ on:
           - window_classifier
           - inner_confusion_complement
           - lcb_pruned
+          - lcb_pruned_t0_5
+          - lcb_pruned_t1_5
+          - lcb_pruned_t2
           - window_feature_classifier_score_calibration
           - full_config
       selection_ensemble_score_normalization_override:
@@ -1776,6 +1782,63 @@ jobs:
                   "components_pca_values": "128",
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "lcb_pruned",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_lcb_pruned_t0_5": {
+                  # More aggressive than lcb_pruned: the lower-confidence-bound
+                  # overlap test uses 0.5 SEM.  This can reduce a noisy top-3
+                  # ensemble to the strongest source-inner candidates while still
+                  # using only source-inner validation statistics.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "lcb_pruned_t0_5",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_lcb_pruned_t1_5": {
+                  # Looser than lcb_pruned: the overlap test uses 1.5 SEM and
+                  # therefore keeps near-tied ensemble members more often.  This
+                  # checks whether the w150 source-only branch benefits from
+                  # retaining extra diversity when source-inner scores overlap.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "lcb_pruned_t1_5",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_lcb_pruned_t2": {
+                  # Most permissive variant in this sweep: 2 SEM overlap keeps
+                  # tail candidates unless their source-inner lower bound is well
+                  # separated from the leader.  This tests whether the fixed
+                  # top-3 behavior should be nearly preserved but still guarded.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "lcb_pruned_t2",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",

--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -54,6 +54,16 @@ on:
         required: true
         default: "0.05"
         type: string
+      supervised_contrastive_weight:
+        description: Source-only supervised contrastive latent loss weight; 0 disables it.
+        required: true
+        default: "0"
+        type: string
+      supervised_contrastive_temperature:
+        description: Temperature for the optional supervised contrastive latent loss.
+        required: true
+        default: "0.2"
+        type: string
       validation_prediction_balance_weight:
         description: Early-stopping penalty for source-validation class-prediction imbalance; 0 disables it.
         required: true
@@ -130,6 +140,14 @@ on:
         required: true
         default: "0.0"
         type: string
+      prediction_postprocessing:
+        description: Optional source-prior postprocessing of held-out scores.
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - source_prior_balanced_assignment
 
 permissions:
   contents: read
@@ -179,6 +197,8 @@ jobs:
             --prediction-balance-weight "${{ inputs.prediction_balance_weight }}"
             --prediction-balance-target-smoothing "${{ inputs.prediction_balance_target_smoothing }}"
             --label-smoothing "${{ inputs.label_smoothing }}"
+            --supervised-contrastive-weight "${{ inputs.supervised_contrastive_weight }}"
+            --supervised-contrastive-temperature "${{ inputs.supervised_contrastive_temperature }}"
             --validation-prediction-balance-weight "${{ inputs.validation_prediction_balance_weight }}"
             --epochs "${{ inputs.epochs }}"
             --batch-size 256
@@ -192,6 +212,7 @@ jobs:
             --score-calibration-confusion-smoothing "${{ inputs.score_calibration_confusion_smoothing }}"
             --score-calibration-selection-metric "${{ inputs.score_calibration_selection_metric }}"
             --score-calibration-guard-tolerance "${{ inputs.score_calibration_guard_tolerance }}"
+            --prediction-postprocessing "${{ inputs.prediction_postprocessing }}"
             --seed 0
             --outer-output "outputs/${{ inputs.output_stem }}_outer.csv"
             --summary-output "outputs/${{ inputs.output_stem }}_group_summary.csv"

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -282,6 +282,13 @@ INNER_CONFUSION_CORRECTION_GUARDED_POWER = 0.5
 INNER_CONFUSION_COMPLEMENTARITY_PENALTY = 0.0025
 LCB_PRUNED_ENSEMBLE_DIVERSITY = "lcb_pruned"
 LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIER = 1.0
+LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIERS = {
+    LCB_PRUNED_ENSEMBLE_DIVERSITY: LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIER,
+    "lcb_pruned_t0_5": 0.5,
+    "lcb_pruned_t1_5": 1.5,
+    "lcb_pruned_t2": 2.0,
+}
+LCB_PRUNED_ENSEMBLE_DIVERSITY_MODES = tuple(LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIERS)
 LOG_POOL_SUFFIX = "_log_pool"
 ENSEMBLE_LOG_POOL_EPSILON = 1e-12
 BALANCED_QUOTA_SUFFIX = "_balanced_quota"
@@ -335,7 +342,7 @@ SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "window_feature_classifier_sample_weighting_score_calibration_pca",
     "window_feature_classifier_param_sample_weighting_score_calibration_pca",
     "inner_confusion_complement",
-    LCB_PRUNED_ENSEMBLE_DIVERSITY,
+    *LCB_PRUNED_ENSEMBLE_DIVERSITY_MODES,
     "full_config",
 )
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
@@ -1606,9 +1613,11 @@ def _select_diverse_nested_rows(ranked_rows, *, requested_size, candidate_config
         return _select_inner_confusion_complement_rows(
             ranked_rows, requested_size=requested_size
         )
-    if diversity == LCB_PRUNED_ENSEMBLE_DIVERSITY:
+    if diversity in LCB_PRUNED_ENSEMBLE_DIVERSITY_MODES:
         return _select_lcb_pruned_nested_rows(
-            ranked_rows, requested_size=requested_size
+            ranked_rows,
+            requested_size=requested_size,
+            sem_multiplier=_lcb_pruned_ensemble_sem_multiplier(diversity),
         )
 
     selected = []
@@ -1671,7 +1680,7 @@ def _select_inner_confusion_complement_rows(ranked_rows, *, requested_size):
     return tuple(selected)
 
 
-def _select_lcb_pruned_nested_rows(ranked_rows, *, requested_size):
+def _select_lcb_pruned_nested_rows(ranked_rows, *, requested_size, sem_multiplier=None):
     """Select the top-ranked nested rows, then drop low-confidence tail members.
 
     The BUSH-MEG source-only w150 branch now gets useful signal from a small
@@ -1690,21 +1699,34 @@ def _select_lcb_pruned_nested_rows(ranked_rows, *, requested_size):
     if requested_size <= 1 or not ranked_rows:
         return tuple(ranked_rows[:requested_size])
 
+    if sem_multiplier is None:
+        sem_multiplier = LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIER
+    sem_multiplier = max(float(sem_multiplier), 0.0)
+
     candidates = tuple(ranked_rows[:requested_size])
     best_score = _nested_lcb_pruning_score(candidates[0])
     if not np.isfinite(best_score):
         return candidates
     threshold = best_score - (
-        float(LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIER)
+        sem_multiplier
         * _nested_lcb_pruning_sem(candidates[0])
     )
 
     selected = [candidates[0]]
     for row in candidates[1:]:
-        row_lcb = _nested_lcb_pruning_score(row) - _nested_lcb_pruning_sem(row)
+        row_lcb = _nested_lcb_pruning_score(row) - (
+            sem_multiplier * _nested_lcb_pruning_sem(row)
+        )
         if np.isfinite(row_lcb) and row_lcb >= threshold:
             selected.append(row)
     return tuple(selected)
+
+
+def _lcb_pruned_ensemble_sem_multiplier(diversity):
+    diversity = str(diversity).strip().lower().replace("-", "_")
+    if diversity not in LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIERS:
+        raise ValueError(f"Unsupported LCB-pruned ensemble diversity: {diversity}")
+    return float(LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIERS[diversity])
 
 
 def _nested_lcb_pruning_score(row):
@@ -1826,8 +1848,8 @@ def _ensemble_diversity_key(config, diversity):
         )
     if diversity == "inner_confusion_complement":
         return "inner_confusion_complement"
-    if diversity == LCB_PRUNED_ENSEMBLE_DIVERSITY:
-        return LCB_PRUNED_ENSEMBLE_DIVERSITY
+    if diversity in LCB_PRUNED_ENSEMBLE_DIVERSITY_MODES:
+        return diversity
     return (
         f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
         f"feature={config.feature_mode},norm={config.normalization},alignment={config.alignment},"

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -64,6 +64,8 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     prediction_balance_weight: float = 0.0
     prediction_balance_target_smoothing: float = 1.0
     label_smoothing: float = 0.0
+    supervised_contrastive_weight: float = 0.0
+    supervised_contrastive_temperature: float = 0.20
     balanced_batch_sampling: bool = False
     validation_prediction_balance_weight: float = 0.0
     epochs: int = 80
@@ -301,6 +303,39 @@ def _prediction_balance_loss(logits, label_indices, *, target_smoothing: float):
     return F.mse_loss(predicted_distribution, target_distribution)
 
 
+def _supervised_contrastive_loss(latent, label_indices, *, temperature: float):
+    """Supervised contrastive loss for class-preserving shared latent spaces.
+
+    The source-only latent AE can reconstruct source-subject structure while still
+    producing a class-biased classifier.  This optional loss directly encourages
+    trials with the same stimulus label to occupy nearby latent locations across
+    source subjects, while using different-label trials in the same minibatch as
+    negatives.  It is source-only and uses no held-out-subject labels.
+    """
+
+    torch, _nn, F = _lazy_torch()
+    if int(latent.shape[0]) <= 1:
+        return torch.zeros((), dtype=latent.dtype, device=latent.device)
+    labels = label_indices.reshape(-1, 1)
+    positive_mask = labels.eq(labels.T)
+    self_mask = torch.eye(int(latent.shape[0]), dtype=torch.bool, device=latent.device)
+    positive_mask = positive_mask & ~self_mask
+    if not bool(torch.any(positive_mask)):
+        return torch.zeros((), dtype=latent.dtype, device=latent.device)
+
+    normalized = F.normalize(latent, dim=1)
+    scale = max(float(temperature), 1e-6)
+    logits = normalized @ normalized.T / scale
+    logits = logits - torch.max(logits, dim=1, keepdim=True).values.detach()
+    logits = logits.masked_fill(self_mask, -torch.inf)
+    log_prob = logits - torch.logsumexp(logits, dim=1, keepdim=True)
+    positive_counts = positive_mask.sum(dim=1)
+    valid_rows = positive_counts > 0
+    positive_log_prob = torch.where(positive_mask, log_prob, torch.zeros_like(log_prob)).sum(dim=1)
+    mean_positive_log_prob = positive_log_prob[valid_rows] / positive_counts[valid_rows].to(dtype=latent.dtype)
+    return -mean_positive_log_prob.mean()
+
+
 def _balanced_epoch_indices(label_indices: np.ndarray, *, rng: np.random.Generator) -> np.ndarray:
     """Return one epoch order that interleaves classes before batching.
 
@@ -484,6 +519,13 @@ def _train_model(  # pylint: disable=too-many-arguments,too-many-locals
                     target_smoothing=config.prediction_balance_target_smoothing,
                 )
                 loss = loss + float(config.prediction_balance_weight) * balance_loss
+            if float(config.supervised_contrastive_weight) > 0.0:
+                contrastive_loss = _supervised_contrastive_loss(
+                    latent,
+                    yb,
+                    temperature=config.supervised_contrastive_temperature,
+                )
+                loss = loss + float(config.supervised_contrastive_weight) * contrastive_loss
             optimizer.zero_grad(set_to_none=True)
             loss.backward()
             optimizer.step()
@@ -926,8 +968,11 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
             "prediction_balance_weight": config.prediction_balance_weight,
             "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "label_smoothing": config.label_smoothing,
+            "supervised_contrastive_weight": config.supervised_contrastive_weight,
+            "supervised_contrastive_temperature": config.supervised_contrastive_temperature,
             "balanced_batch_sampling": config.balanced_batch_sampling,
             "score_calibration": config.score_calibration,
+            "prediction_postprocessing": config.prediction_postprocessing,
             "label_shuffle_control": config.label_shuffle_control,
             "label_shuffle_seed": config.label_shuffle_seed if config.label_shuffle_control else np.nan,
         }
@@ -1007,6 +1052,8 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "prediction_balance_weight": config.prediction_balance_weight,
         "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
         "label_smoothing": config.label_smoothing,
+        "supervised_contrastive_weight": config.supervised_contrastive_weight,
+        "supervised_contrastive_temperature": config.supervised_contrastive_temperature,
         "balanced_batch_sampling": config.balanced_batch_sampling,
         "validation_prediction_balance_weight": config.validation_prediction_balance_weight,
         "score_calibration": config.score_calibration,
@@ -1028,6 +1075,11 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "score_calibration_guard_tolerance": fit_metadata.get(
             "score_calibration_guard_tolerance", config.score_calibration_guard_tolerance
         ),
+        "prediction_postprocessing": config.prediction_postprocessing,
+        "prediction_postprocessing_status": fit_metadata.get("prediction_postprocessing_status", "not_requested"),
+        "prediction_postprocessing_quota_source": fit_metadata.get("prediction_postprocessing_quota_source", "none"),
+        "prediction_postprocessing_class_quota_counts": fit_metadata.get("prediction_postprocessing_class_quota_counts", ""),
+        "prediction_postprocessing_objective_delta": fit_metadata.get("prediction_postprocessing_objective_delta", np.nan),
         "score_calibration_bias_min": fit_metadata.get("score_calibration_bias_min", np.nan),
         "score_calibration_bias_max": fit_metadata.get("score_calibration_bias_max", np.nan),
         "score_calibration_bias_mean_abs": fit_metadata.get("score_calibration_bias_mean_abs", np.nan),
@@ -1107,6 +1159,8 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "prediction_balance_weight": config.prediction_balance_weight,
             "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "label_smoothing": config.label_smoothing,
+            "supervised_contrastive_weight": config.supervised_contrastive_weight,
+            "supervised_contrastive_temperature": config.supervised_contrastive_temperature,
             "balanced_batch_sampling": config.balanced_batch_sampling,
             "validation_prediction_balance_weight": config.validation_prediction_balance_weight,
             "dropout": config.dropout,
@@ -1120,6 +1174,10 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "score_calibration_prior_source_counts": _format_counter(Counter(row.get("score_calibration_prior_source", "") for row in outer_rows)),
             "score_calibration_predicted_prior_source_counts": _format_counter(
                 Counter(row.get("score_calibration_predicted_prior_source", "none") for row in outer_rows)
+            ),
+            "prediction_postprocessing": config.prediction_postprocessing,
+            "prediction_postprocessing_status_counts": _format_counter(
+                Counter(row.get("prediction_postprocessing_status", "not_requested") for row in outer_rows)
             ),
             "epochs_requested": config.epochs,
             "validation_selection_metric": config.validation_selection_metric,
@@ -1184,6 +1242,107 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
 
 def _format_counter(counter: Counter) -> str:
     return ";".join(f"{key}:{counter[key]}" for key in sorted(counter, key=lambda value: str(value)))
+
+
+def _source_prior_class_quotas(source_labels: np.ndarray, classes: np.ndarray, n_test_trials: int) -> np.ndarray:
+    """Estimate integer target-class quotas from source labels.
+
+    BUSH-MEG main-task folds are class-balanced, and the latent smoke run showed
+    severe hard-argmax class collapse.  This helper supports an optional
+    source-only postprocessor that uses the source-label prior to assign a fixed
+    number of held-out trials to each class.  Held-out labels are never used.
+    """
+
+    n_test_trials = int(n_test_trials)
+    n_classes = int(classes.shape[0])
+    if n_test_trials < 0:
+        raise ValueError("n_test_trials must be non-negative.")
+    if n_classes == 0:
+        return np.asarray([], dtype=int)
+    source_indices = _class_index(np.asarray(source_labels, dtype=int), classes)
+    source_counts = np.bincount(source_indices, minlength=n_classes).astype(float)
+    if float(np.sum(source_counts)) <= 0.0:
+        return _uniform_class_quotas(n_classes, n_test_trials)
+    expected = source_counts / float(np.sum(source_counts)) * float(n_test_trials)
+    return _round_expected_class_quotas(expected, n_test_trials)
+
+
+def _uniform_class_quotas(n_classes: int, n_test_trials: int) -> np.ndarray:
+    n_classes = int(n_classes)
+    n_test_trials = int(n_test_trials)
+    if n_classes <= 0:
+        return np.asarray([], dtype=int)
+    quotas = np.full(n_classes, n_test_trials // n_classes, dtype=int)
+    quotas[: n_test_trials - int(np.sum(quotas))] += 1
+    return quotas
+
+
+def _round_expected_class_quotas(expected: np.ndarray, n_test_trials: int) -> np.ndarray:
+    expected = np.asarray(expected, dtype=float)
+    quotas = np.floor(expected).astype(int)
+    remainder = int(n_test_trials) - int(np.sum(quotas))
+    if remainder > 0:
+        fractions = expected - quotas
+        for index in np.argsort(-fractions)[:remainder]:
+            quotas[int(index)] += 1
+    elif remainder < 0:
+        fractions = expected - quotas
+        for index in np.argsort(fractions)[: abs(remainder)]:
+            if quotas[int(index)] > 0:
+                quotas[int(index)] -= 1
+    return quotas.astype(int)
+
+
+def _balanced_assignment_predictions(scores: np.ndarray, classes: np.ndarray, quotas: np.ndarray) -> tuple[np.ndarray, float]:
+    """Assign predictions by maximizing total score under per-class quotas."""
+
+    try:
+        from scipy.optimize import linear_sum_assignment
+    except ImportError as exc:  # pragma: no cover - scipy is normally installed through sklearn.
+        raise RuntimeError("prediction_postprocessing=source_prior_balanced_assignment requires scipy.") from exc
+
+    scores = np.asarray(scores, dtype=float)
+    classes = np.asarray(classes, dtype=int)
+    quotas = np.asarray(quotas, dtype=int)
+    if int(np.sum(quotas)) != int(scores.shape[0]):
+        raise ValueError("Class quotas must sum to the number of scored trials.")
+    repeated_class_indices = np.repeat(np.arange(int(classes.shape[0])), quotas)
+    cost = -scores[:, repeated_class_indices]
+    row_indices, assignment_columns = linear_sum_assignment(cost)
+    predicted_indices = np.empty(int(scores.shape[0]), dtype=int)
+    predicted_indices[row_indices] = repeated_class_indices[assignment_columns]
+    argmax_score = float(np.sum(np.max(scores, axis=1)))
+    assignment_score = float(np.sum(scores[np.arange(scores.shape[0]), predicted_indices]))
+    return classes[predicted_indices], assignment_score - argmax_score
+
+
+def _postprocess_predictions(
+    scores: np.ndarray,
+    classes: np.ndarray,
+    source_labels: np.ndarray,
+    config: LatentAutoencoderConfig,
+) -> tuple[np.ndarray, dict]:
+    method = str(config.prediction_postprocessing or "none")
+    if method == "none":
+        return classes[np.argmax(scores, axis=1)], {
+            "prediction_postprocessing_status": "not_requested",
+            "prediction_postprocessing_quota_source": "none",
+            "prediction_postprocessing_class_quota_counts": "",
+            "prediction_postprocessing_objective_delta": 0.0,
+        }
+    if method != "source_prior_balanced_assignment":
+        raise ValueError(
+            "prediction_postprocessing must be one of: none, source_prior_balanced_assignment"
+        )
+    quotas = _source_prior_class_quotas(source_labels, classes, int(scores.shape[0]))
+    predicted_labels, objective_delta = _balanced_assignment_predictions(scores, classes, quotas)
+    quota_counts = Counter({int(class_label): int(quota) for class_label, quota in zip(classes, quotas, strict=True)})
+    return predicted_labels, {
+        "prediction_postprocessing_status": "ok",
+        "prediction_postprocessing_quota_source": "source_label_prior",
+        "prediction_postprocessing_class_quota_counts": _format_counter(quota_counts),
+        "prediction_postprocessing_objective_delta": float(objective_delta),
+    }
 
 
 def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
@@ -1305,7 +1464,10 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
         device = _resolve_device(config.device)
         scores = _predict_scores(final_model, test_features_pca, device=device, batch_size=config.batch_size)
         scores = _apply_score_calibration(scores, score_calibration_bias)
-        predicted_labels = classes[np.argmax(scores, axis=1)]
+        predicted_labels, postprocessing_metadata = _postprocess_predictions(
+            scores, classes, final_train_labels, config
+        )
+        fit_metadata = {**fit_metadata, **postprocessing_metadata}
         outer_row = _outer_row(
             test_participant=test_participant,
             train_participants=source_participants,
@@ -1415,6 +1577,21 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         help="Cross-entropy label smoothing for latent AE training; useful for reducing overconfident class collapse.",
     )
     parser.add_argument(
+        "--supervised-contrastive-weight",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional source-only supervised contrastive latent loss.  Values around 0.01-0.10 "
+            "encourage same-class source trials to share latent structure across subjects."
+        ),
+    )
+    parser.add_argument(
+        "--supervised-contrastive-temperature",
+        type=float,
+        default=0.20,
+        help="Temperature for the optional supervised contrastive latent loss.",
+    )
+    parser.add_argument(
         "--balanced-batch-sampling",
         action=argparse.BooleanOptionalAction,
         default=False,
@@ -1506,6 +1683,15 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
             "0 enforces no validation balanced-accuracy regression."
         ),
     )
+    parser.add_argument(
+        "--prediction-postprocessing",
+        choices=("none", "source_prior_balanced_assignment"),
+        default="none",
+        help=(
+            "Optional source-prior balanced assignment over the held-out batch. "
+            "This uses source-label class frequencies and test scores only; report separately as transductive postprocessing."
+        ),
+    )
     parser.add_argument("--device", default="auto", help="auto, cpu, cuda, or another torch device string.")
     parser.add_argument("--num-threads", type=int, default=1)
     parser.add_argument("--outer-output", default="outputs/latent_autoencoder_outer.csv")
@@ -1535,6 +1721,8 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         prediction_balance_weight=args.prediction_balance_weight,
         prediction_balance_target_smoothing=args.prediction_balance_target_smoothing,
         label_smoothing=args.label_smoothing,
+        supervised_contrastive_weight=args.supervised_contrastive_weight,
+        supervised_contrastive_temperature=args.supervised_contrastive_temperature,
         balanced_batch_sampling=bool(args.balanced_batch_sampling),
         validation_prediction_balance_weight=args.validation_prediction_balance_weight,
         epochs=args.epochs,

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -162,6 +162,49 @@ class TestStimulusCrossSubject(unittest.TestCase):
 
         self.assertEqual([int(row["selected_candidate_index"]) for row in selected], [1, 2])
 
+    def test_lcb_pruned_diversity_variant_controls_sem_multiplier(self):
+        ranked_rows = (
+            {
+                "selected_candidate_index": 1,
+                "selected_inner_selection_ranking_score": 0.150,
+                "selected_inner_selection_score_mean": 0.150,
+                "selected_inner_selection_score_sem": 0.005,
+                "selected_inner_balanced_accuracy_mean": 0.150,
+                "selected_inner_balanced_accuracy_sem": 0.005,
+            },
+            {
+                "selected_candidate_index": 2,
+                "selected_inner_selection_ranking_score": 0.144,
+                "selected_inner_selection_score_mean": 0.144,
+                "selected_inner_selection_score_sem": 0.001,
+                "selected_inner_balanced_accuracy_mean": 0.144,
+                "selected_inner_balanced_accuracy_sem": 0.001,
+            },
+            {
+                "selected_candidate_index": 3,
+                "selected_inner_selection_ranking_score": 0.130,
+                "selected_inner_selection_score_mean": 0.130,
+                "selected_inner_selection_score_sem": 0.001,
+                "selected_inner_balanced_accuracy_mean": 0.130,
+                "selected_inner_balanced_accuracy_sem": 0.001,
+            },
+        )
+        configs = tuple(CrossSubjectStimulusConfig(classifier_param=0.3) for _ in ranked_rows)
+
+        default_selected = cross_subject._select_diverse_nested_rows(  # pylint: disable=protected-access
+            ranked_rows, requested_size=3, candidate_configs=configs, diversity="lcb-pruned"
+        )
+        loose_selected = cross_subject._select_diverse_nested_rows(  # pylint: disable=protected-access
+            ranked_rows, requested_size=3, candidate_configs=configs, diversity="lcb-pruned-t2"
+        )
+
+        self.assertEqual(
+            cross_subject._normalize_selection_ensemble_diversity("lcb-pruned-t2"),  # pylint: disable=protected-access
+            "lcb_pruned_t2",
+        )
+        self.assertEqual([int(row["selected_candidate_index"]) for row in default_selected], [1])
+        self.assertEqual([int(row["selected_candidate_index"]) for row in loose_selected], [1, 2])
+
     def test_trial_margin_entropy_ensemble_weighting_prefers_jointly_confident_model_per_trial(self):
         score_matrices = (
             np.asarray(

--- a/tests/test_stimulus_latent_autoencoder_controls.py
+++ b/tests/test_stimulus_latent_autoencoder_controls.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import math
 
 import numpy as np
@@ -11,6 +13,7 @@ from pymegdec.stimulus_latent_autoencoder import (
     _make_model_class,
     _prediction_balance_score,
     _split_source_participants,
+    _supervised_contrastive_loss,
     _validation_selection_metrics,
 )
 
@@ -114,3 +117,33 @@ def test_latent_model_maps_sparse_participant_ids_for_subject_adversary_when_tor
     targets = model.subject_targets(torch.tensor([8, 2, 4, 8]))
 
     assert targets.tolist() == [2, 0, 1, 2]
+
+
+def test_supervised_contrastive_loss_rewards_same_class_latent_neighbors():
+    torch = pytest.importorskip("torch")
+
+    labels = torch.tensor([0, 0, 1, 1], dtype=torch.long)
+    clustered_latent = torch.tensor(
+        [
+            [1.0, 0.0],
+            [0.9, 0.1],
+            [0.0, 1.0],
+            [0.1, 0.9],
+        ],
+        dtype=torch.float32,
+    )
+    mixed_latent = torch.tensor(
+        [
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.9, 0.1],
+            [0.1, 0.9],
+        ],
+        dtype=torch.float32,
+    )
+
+    clustered_loss = _supervised_contrastive_loss(clustered_latent, labels, temperature=0.2)
+    mixed_loss = _supervised_contrastive_loss(mixed_latent, labels, temperature=0.2)
+
+    assert torch.isfinite(clustered_loss)
+    assert clustered_loss < mixed_loss


### PR DESCRIPTION
## Summary
- add latent balanced assignment post-processing and supervised contrastive controls
- add LCB-pruned SEM sweep variants
- update workflow inputs and focused regression coverage

## Verification
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_cross_subject.py tests\test_stimulus_latent_autoencoder_controls.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text(encoding='utf-8')); yaml.safe_load(pathlib.Path('.github/workflows/stimulus-latent-autoencoder.yml').read_text(encoding='utf-8'))"`
- `git diff --check`

Tests were not run per request.