### PR TITLE
Add guarded argmax calibration and seed ensembles

### DIFF
--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -64,6 +64,11 @@ on:
         required: true
         default: "0.2"
         type: string
+      ensemble_seeds:
+        description: Optional comma-separated final-refit seeds for latent score averaging; empty uses --seed only.
+        required: false
+        default: ""
+        type: string
       validation_prediction_balance_weight:
         description: Early-stopping penalty for source-validation class-prediction imbalance; 0 disables it.
         required: true
@@ -110,6 +115,7 @@ on:
           - validation_class_bias_guarded
           - validation_prediction_bias
           - validation_argmax_class_bias
+          - validation_argmax_class_bias_guarded
           - validation_confusion_blend
       score_calibration_alphas:
         description: Candidate alpha strengths for source-validation class-bias calibration.
@@ -178,6 +184,7 @@ jobs:
         env:
           LABEL_SHUFFLE: ${{ inputs.label_shuffle_control }}
           OUTER_PARTICIPANTS: ${{ inputs.outer_participants }}
+          ENSEMBLE_SEEDS: ${{ inputs.ensemble_seeds }}
           BALANCED_BATCH_SAMPLING: ${{ inputs.balanced_batch_sampling }}
         run: |
           mkdir -p outputs
@@ -223,6 +230,9 @@ jobs:
           )
           if [ -n "${OUTER_PARTICIPANTS}" ]; then
             ARGS+=(--outer-participants "${OUTER_PARTICIPANTS}")
+          fi
+          if [ -n "${ENSEMBLE_SEEDS}" ]; then
+            ARGS+=(--ensemble-seeds "${ENSEMBLE_SEEDS}")
           fi
           if [ "${BALANCED_BATCH_SAMPLING}" = "true" ]; then
             ARGS+=(--balanced-batch-sampling)

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -2,6 +2,8 @@
   "gitignore": true,
   "ignore": [
     "**/.github/workflows/**",
+    "ARCHIVE.md",
+    "docs/archive.md",
     "scripts/download_meg_data_files.py",
     "scripts/export_stimulus_confusion_structure.py",
     "scripts/export_stimulus_cross_subject_nested.py",

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -1265,6 +1265,8 @@ def _topk_allowed_assignment_mask(probabilities, *, top_k):
         if k <= 0:
             allowed[row_index, finite] = True
             continue
+        # Keep this mask literal: dense softmax rows would otherwise make
+        # top-k quota modes silently fall back to legacy unconstrained assignment.
         ranked = np.argsort(-np.where(finite, row, -np.inf), kind="mergesort")[:k]
         allowed[row_index, ranked] = True
     return allowed

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -17,7 +17,7 @@ import copy
 import math
 from collections import Counter
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import numpy as np
@@ -80,6 +80,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     final_epoch_multiplier: float = 1.0
     final_min_epochs: int = 0
     seed: int = 0
+    ensemble_seeds: tuple[int, ...] = ()
     chance_classes: int = 16
     label_shuffle_control: bool = False
     label_shuffle_seed: int = 0
@@ -89,6 +90,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     score_calibration_confusion_smoothing: float = 4.0
     score_calibration_selection_metric: str = "balanced_accuracy"
     score_calibration_guard_tolerance: float = 0.0
+    prediction_postprocessing: str = "none"
     device: str = "auto"
     num_threads: int = 1
 
@@ -127,10 +129,33 @@ def _parse_float_sequence(value: str) -> tuple[float, ...]:
     return tuple(float(token.strip()) for token in value.replace(";", ",").split(",") if token.strip())
 
 
+def _parse_int_sequence(value: str | Sequence[int] | None) -> tuple[int, ...]:
+    """Parse a comma/semicolon separated int sequence."""
+
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return tuple(int(token.strip()) for token in value.replace(";", ",").split(",") if token.strip())
+    return tuple(int(token) for token in value)
+
+
 def _parse_participants(value: str | None) -> tuple[int, ...]:
     if value is None or not str(value).strip():
         return tuple(parse_participant_spec(DEFAULT_LATENT_PARTICIPANTS))
     return tuple(parse_participant_spec(value))
+
+
+def _effective_ensemble_seeds(config: LatentAutoencoderConfig) -> tuple[int, ...]:
+    """Return deduplicated final-score ensemble seeds, defaulting to config.seed."""
+
+    seeds = tuple(int(seed) for seed in config.ensemble_seeds)
+    if not seeds:
+        seeds = (int(config.seed),)
+    return tuple(dict.fromkeys(seeds))
+
+
+def _format_seed_sequence(seeds: Sequence[int]) -> str:
+    return ";".join(str(int(seed)) for seed in seeds)
 
 
 def _resolve_device(device: str):
@@ -445,6 +470,9 @@ def _train_model(  # pylint: disable=too-many-arguments,too-many-locals
     max_epochs: int | None = None,
 ):
     torch, _nn, F = _lazy_torch()
+    torch.manual_seed(int(config.seed))
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(int(config.seed))
     Model = _make_model_class()
     device = _resolve_device(config.device)
     max_epochs = int(max_epochs if max_epochs is not None else config.epochs)
@@ -733,11 +761,16 @@ def _fit_validation_score_calibration(
     zero_bias = np.zeros(int(classes.shape[0]), dtype=float)
     if config.score_calibration == "none":
         return zero_bias, _empty_score_calibration_metadata(config, "not_requested")
+    guarded_calibrations = {
+        "validation_class_bias_guarded",
+        "validation_argmax_class_bias_guarded",
+    }
     supported_calibrations = {
         "validation_class_bias",
         "validation_class_bias_guarded",
         "validation_prediction_bias",
         "validation_argmax_class_bias",
+        "validation_argmax_class_bias_guarded",
         "validation_confusion_blend",
     }
     if config.score_calibration not in supported_calibrations:
@@ -749,6 +782,7 @@ def _fit_validation_score_calibration(
 
     validation_scores = np.asarray(validation_scores, dtype=float)
     validation_labels = np.asarray(validation_labels, dtype=int)
+    guarded_calibration = config.score_calibration.endswith("_guarded")
     label_indices = _class_index(validation_labels, classes)
     n_classes = int(classes.shape[0])
     smoothing = max(0.0, float(config.score_calibration_smoothing))
@@ -784,7 +818,7 @@ def _fit_validation_score_calibration(
     best_balanced = -math.inf
     best_selection = -math.inf
     best_objective = -math.inf
-    if config.score_calibration == "validation_class_bias_guarded":
+    if guarded_calibration:
         best_balanced = uncalibrated_balanced
         best_selection = uncalibrated_selection
         best_objective = uncalibrated_selection
@@ -799,9 +833,9 @@ def _fit_validation_score_calibration(
         )
         balanced = float(calibrated_metrics["balanced_accuracy"])
         selection_score = float(calibrated_metrics["selection_score"])
-        if config.score_calibration == "validation_class_bias_guarded" and balanced + 1e-12 < guard_floor:
+        if guarded_calibration and balanced + 1e-12 < guard_floor:
             continue
-        objective = selection_score if config.score_calibration == "validation_class_bias_guarded" else balanced
+        objective = selection_score if guarded_calibration else balanced
         if (
             objective > best_objective + 1e-12
             or (abs(objective - best_objective) <= 1e-12 and balanced > best_balanced + 1e-12)
@@ -963,6 +997,9 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
             "pca_explained_variance_percent": pca_explained_variance_percent,
             "latent_dim": config.latent_dim,
             "hidden_dim": config.hidden_dim,
+            "seed": config.seed,
+            "latent_score_ensemble_size": len(_effective_ensemble_seeds(config)),
+            "latent_score_ensemble_seeds": _format_seed_sequence(_effective_ensemble_seeds(config)),
             "reconstruction_weight": config.reconstruction_weight,
             "subject_adversary_weight": config.subject_adversary_weight,
             "prediction_balance_weight": config.prediction_balance_weight,
@@ -1047,6 +1084,10 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "latent_dim": config.latent_dim,
         "hidden_dim": config.hidden_dim,
         "dropout": config.dropout,
+        "seed": config.seed,
+        "latent_score_ensemble_size": int(fit_metadata.get("latent_score_ensemble_size", len(_effective_ensemble_seeds(config)))),
+        "latent_score_ensemble_seeds": fit_metadata.get("latent_score_ensemble_seeds", _format_seed_sequence(_effective_ensemble_seeds(config))),
+        "latent_score_ensemble_final_epochs": fit_metadata.get("latent_score_ensemble_final_epochs", ""),
         "reconstruction_weight": config.reconstruction_weight,
         "subject_adversary_weight": config.subject_adversary_weight,
         "prediction_balance_weight": config.prediction_balance_weight,
@@ -1154,6 +1195,9 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "components_pca": config.components_pca,
             "latent_dim": config.latent_dim,
             "hidden_dim": config.hidden_dim,
+            "seed": config.seed,
+            "latent_score_ensemble_size": len(_effective_ensemble_seeds(config)),
+            "latent_score_ensemble_seeds": _format_seed_sequence(_effective_ensemble_seeds(config)),
             "reconstruction_weight": config.reconstruction_weight,
             "subject_adversary_weight": config.subject_adversary_weight,
             "prediction_balance_weight": config.prediction_balance_weight,
@@ -1449,21 +1493,38 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
             components_pca=config.components_pca,
             seed=config.seed,
         )
-        final_epochs = _final_refit_epochs(selected_epoch, config)
-        final_model, final_fit_metadata = _train_model(
-            final_train_features_pca,
-            final_train_labels,
-            final_train_subjects,
-            classes=classes,
-            subject_ids=source_participants,
-            config=config,
-            validation=None,
-            max_epochs=final_epochs if config.refit_all_sources else config.epochs,
-        )
-        fit_metadata = {**fit_metadata, "best_epoch": selected_epoch, "final_epochs": final_fit_metadata.get("best_epoch", final_epochs)}
         device = _resolve_device(config.device)
-        scores = _predict_scores(final_model, test_features_pca, device=device, batch_size=config.batch_size)
+        final_epochs = _final_refit_epochs(selected_epoch, config)
+        final_training_epochs = final_epochs if config.refit_all_sources else config.epochs
+        final_seeds = _effective_ensemble_seeds(config)
+        final_score_matrices = []
+        final_epoch_values = []
+        for final_seed in final_seeds:
+            final_config = replace(config, seed=int(final_seed))
+            final_model, final_fit_metadata = _train_model(
+                final_train_features_pca,
+                final_train_labels,
+                final_train_subjects,
+                classes=classes,
+                subject_ids=source_participants,
+                config=final_config,
+                validation=None,
+                max_epochs=final_training_epochs,
+            )
+            final_epoch_values.append(int(final_fit_metadata.get("best_epoch", final_training_epochs)))
+            final_score_matrices.append(
+                _predict_scores(final_model, test_features_pca, device=device, batch_size=config.batch_size)
+            )
+        scores = np.mean(np.stack(final_score_matrices, axis=0), axis=0)
         scores = _apply_score_calibration(scores, score_calibration_bias)
+        fit_metadata = {
+            **fit_metadata,
+            "best_epoch": selected_epoch,
+            "final_epochs": int(final_training_epochs),
+            "latent_score_ensemble_size": len(final_seeds),
+            "latent_score_ensemble_seeds": _format_seed_sequence(final_seeds),
+            "latent_score_ensemble_final_epochs": _format_seed_sequence(final_epoch_values),
+        }
         predicted_labels, postprocessing_metadata = _postprocess_predictions(
             scores, classes, final_train_labels, config
         )
@@ -1633,6 +1694,15 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     )
     parser.add_argument("--final-min-epochs", type=int, default=0, help="Minimum epochs for the final all-source refit.")
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--ensemble-seeds",
+        type=_parse_int_sequence,
+        default=(),
+        help=(
+            "Optional comma-separated final-refit seeds. When provided, the command trains one final latent model "
+            "per seed and averages their class scores. Validation/epoch selection still uses --seed."
+        ),
+    )
     parser.add_argument("--chance-classes", type=int, default=16)
     parser.add_argument("--label-shuffle-control", action="store_true")
     parser.add_argument("--label-shuffle-seed", type=int, default=0)
@@ -1644,6 +1714,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
             "validation_class_bias_guarded",
             "validation_prediction_bias",
             "validation_argmax_class_bias",
+            "validation_argmax_class_bias_guarded",
             "validation_confusion_blend",
         ),
         default="none",
@@ -1737,6 +1808,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         final_epoch_multiplier=args.final_epoch_multiplier,
         final_min_epochs=args.final_min_epochs,
         seed=args.seed,
+        ensemble_seeds=args.ensemble_seeds,
         chance_classes=args.chance_classes,
         label_shuffle_control=bool(args.label_shuffle_control),
         label_shuffle_seed=args.label_shuffle_seed,
@@ -1746,6 +1818,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         score_calibration_confusion_smoothing=args.score_calibration_confusion_smoothing,
         score_calibration_selection_metric=args.score_calibration_selection_metric,
         score_calibration_guard_tolerance=args.score_calibration_guard_tolerance,
+        prediction_postprocessing=args.prediction_postprocessing,
         device=args.device,
         num_threads=args.num_threads,
     )

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -191,7 +191,7 @@ def _gradient_reverse(tensor, strength: float):
 
     torch, _nn, _F = _lazy_torch()
 
-    class _GradientReverse(torch.autograd.Function):  # type: ignore[misc]
+    class _GradientReverse(torch.autograd.Function):  # type: ignore[misc, name-defined]
         @staticmethod
         def forward(ctx, value, scale):
             ctx.scale = float(max(0.0, scale))
@@ -761,10 +761,6 @@ def _fit_validation_score_calibration(
     zero_bias = np.zeros(int(classes.shape[0]), dtype=float)
     if config.score_calibration == "none":
         return zero_bias, _empty_score_calibration_metadata(config, "not_requested")
-    guarded_calibrations = {
-        "validation_class_bias_guarded",
-        "validation_argmax_class_bias_guarded",
-    }
     supported_calibrations = {
         "validation_class_bias",
         "validation_class_bias_guarded",
@@ -1445,7 +1441,7 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
         validation_tuple = None
         selected_epoch = config.epochs
         fit_metadata: dict = {"best_epoch": config.epochs, "best_validation_balanced_accuracy": np.nan}
-        score_calibration_bias = np.zeros(0, dtype=float)
+        score_calibration_bias: np.ndarray | dict = np.zeros(0, dtype=float)
         initial_calibration_status = "not_requested" if config.score_calibration == "none" else "no_validation"
         score_calibration_metadata = _empty_score_calibration_metadata(config, initial_calibration_status)
         if validation_participants:

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -315,6 +315,30 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         )
         np.testing.assert_array_equal(mask, expected)
 
+    def test_topk_balanced_quota_falls_back_when_dense_topk_is_infeasible(self):
+        mode = "rank_top2_score_softmax_balanced_quota"
+        probabilities = np.asarray(
+            [
+                [0.90, 0.09, 0.01],
+                [0.85, 0.10, 0.05],
+                [0.80, 0.15, 0.05],
+                [0.20, 0.75, 0.05],
+                [0.25, 0.70, 0.05],
+                [0.30, 0.65, 0.05],
+            ],
+            dtype=float,
+        )
+
+        metadata = cross_subject._balanced_quota_metadata(  # pylint: disable=protected-access
+            probabilities,
+            np.arange(3, dtype=int),
+            mode,
+        )
+
+        self.assertTrue(metadata["top_k_fallback"])
+        self.assertTrue(metadata["status"].startswith("fallback_top2_infeasible_"))
+        np.testing.assert_array_equal(metadata["quota_counts"], np.asarray([2, 2, 2]))
+
     def test_topk_score_softmax_inner_confusion_guarded_mode_is_exported(self):
         mode = "rank_top3_score_softmax_inner_confusion_soft_guarded"
 

--- a/tests/test_stimulus_latent_autoencoder_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_calibration.py
@@ -38,3 +38,42 @@ def test_validation_prediction_bias_penalizes_argmax_collapse():
     uncalibrated = classes[np.argmax(scores, axis=1)]
     calibrated = classes[np.argmax(scores + bias, axis=1)]
     assert balanced_accuracy_score(labels, calibrated) >= balanced_accuracy_score(labels, uncalibrated)
+
+
+def test_validation_argmax_class_bias_guarded_uses_hard_prior_with_guard():
+    classes = np.asarray([1, 2, 3], dtype=int)
+    labels = np.asarray([1, 2, 2, 3, 3, 3], dtype=int)
+    # Every validation row initially argmaxes to class 1.  The new guarded hard
+    # argmax calibration should use the same collapse-sensitive prior source as
+    # validation_prediction_bias, while optimizing the guarded selection metric.
+    scores = np.asarray(
+        [
+            [4.0, 3.0, 2.0],
+            [4.0, 3.8, 1.0],
+            [4.0, 3.7, 1.2],
+            [4.0, 1.0, 3.8],
+            [4.0, 1.0, 3.7],
+            [4.0, 1.5, 3.6],
+        ],
+        dtype=float,
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_argmax_class_bias_guarded",
+        score_calibration_alphas=(0.0, 0.5, 1.0, 2.0),
+        score_calibration_smoothing=0.01,
+        score_calibration_selection_metric="balanced_top2_top3_rank_balance",
+        score_calibration_guard_tolerance=0.0,
+    )
+
+    bias, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+
+    assert metadata["score_calibration_status"] == "ok"
+    assert metadata["score_calibration_prior_source"] == "argmax_predictions"
+    assert metadata["score_calibration_predicted_prior_source"] == "argmax"
+    assert metadata["score_calibration_alpha"] > 0.0
+    assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata[
+        "score_calibration_uncalibrated_validation_balanced_accuracy"
+    ]
+    assert bias[0] < 0.0
+    assert bias[1] > 0.0
+    assert bias[2] > 0.0

--- a/tests/test_stimulus_latent_autoencoder_controls.py
+++ b/tests/test_stimulus_latent_autoencoder_controls.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import math
 import unittest
 

--- a/tests/test_stimulus_latent_autoencoder_controls.py
+++ b/tests/test_stimulus_latent_autoencoder_controls.py
@@ -8,10 +8,12 @@ import pytest
 from pymegdec.stimulus_latent_autoencoder import (
     LatentAutoencoderConfig,
     _balanced_epoch_indices,
+    _effective_ensemble_seeds,
     _final_refit_epochs,
     _gradient_reverse,
     _make_model_class,
     _prediction_balance_score,
+    _postprocess_predictions,
     _split_source_participants,
     _supervised_contrastive_loss,
     _validation_selection_metrics,
@@ -44,6 +46,15 @@ def test_final_refit_epochs_can_apply_floor_and_multiplier():
     assert _final_refit_epochs(20, config) == 30
 
 
+def test_effective_ensemble_seeds_defaults_to_seed_and_dedupes():
+    assert _effective_ensemble_seeds(LatentAutoencoderConfig(seed=7)) == (7,)
+    assert _effective_ensemble_seeds(LatentAutoencoderConfig(seed=7, ensemble_seeds=(1, 2, 1, 3))) == (
+        1,
+        2,
+        3,
+    )
+
+
 def test_prediction_balance_score_detects_collapse():
     classes = np.asarray([1, 2, 3, 4])
 
@@ -51,6 +62,28 @@ def test_prediction_balance_score_detects_collapse():
     balanced = _prediction_balance_score(np.asarray([1, 2, 3, 4]), classes)
 
     assert 0.0 <= collapsed < balanced <= 1.0
+
+
+def test_source_prior_balanced_assignment_postprocessing_uses_source_quotas():
+    classes = np.asarray([1, 2, 3])
+    source_labels = np.asarray([1, 1, 2, 2, 3, 3])
+    scores = np.asarray(
+        [
+            [4.0, 3.0, 0.0],
+            [4.0, 2.9, 0.0],
+            [4.0, 2.8, 0.0],
+            [4.0, 0.0, 3.0],
+            [4.0, 0.0, 2.9],
+            [4.0, 0.0, 2.8],
+        ]
+    )
+    config = LatentAutoencoderConfig(prediction_postprocessing="source_prior_balanced_assignment")
+
+    predictions, metadata = _postprocess_predictions(scores, classes, source_labels, config)
+
+    assert metadata["prediction_postprocessing_status"] == "ok"
+    assert metadata["prediction_postprocessing_quota_source"] == "source_label_prior"
+    assert Counter(predictions.tolist()) == Counter({1: 2, 2: 2, 3: 2})
 
 
 def test_validation_selection_metrics_rank_balance_variant_rewards_balanced_predictions():

--- a/tests/test_stimulus_latent_autoencoder_score_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_score_calibration.py
@@ -119,6 +119,38 @@ def test_validation_argmax_class_bias_calibration_targets_argmax_collapse():
     assert metadata["score_calibration_validation_balanced_accuracy"] > metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
 
 
+def test_guarded_validation_argmax_class_bias_uses_argmax_prior_without_balanced_regression():
+    classes = np.asarray([1, 2, 3])
+    labels = np.asarray([1, 1, 2, 2, 3, 3])
+    scores = np.asarray(
+        [
+            [2.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [2.0, 1.9, 0.0],
+            [2.0, 1.8, 0.0],
+            [2.0, 0.0, 1.9],
+            [2.0, 0.0, 1.8],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_argmax_class_bias_guarded",
+        score_calibration_alphas=(0.0, 0.5, 1.0, 2.0),
+        score_calibration_smoothing=0.1,
+        score_calibration_selection_metric="balanced_top2_top3_rank_balance",
+        score_calibration_guard_tolerance=0.0,
+    )
+
+    bias, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, bias), axis=1)]
+    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
+
+    assert metadata["score_calibration_status"] == "ok"
+    assert metadata["score_calibration_predicted_prior_source"] == "argmax"
+    assert metadata["score_calibration_alpha"] > 0.0
+    assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
+    assert len(set(calibrated_predictions.tolist())) > len(set(uncalibrated_predictions.tolist()))
+
+
 def test_validation_confusion_blend_reassigns_systematic_confusions():
     classes = np.asarray([1, 2, 3])
     labels = np.asarray([1, 1, 2, 2, 3, 3])


### PR DESCRIPTION
## Summary
- add guarded argmax score calibration controls
- add latent seed ensemble averaging and metadata
- tighten top-k quota fallback coverage

## Verification
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_cross_subject_next.py tests\test_stimulus_latent_autoencoder_controls.py tests\test_stimulus_latent_autoencoder_calibration.py tests\test_stimulus_latent_autoencoder_score_calibration.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-latent-autoencoder.yml').read_text(encoding='utf-8'))"`
- `git diff --check`

Tests were not run per request.