### PR TITLE
Add guarded postprocessing and window LCB controls

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -195,6 +195,7 @@ on:
           - windowed_logreg_175_w150_top3_margin_blend
           - windowed_logreg_175_w150_top3_margin_blend_soft_guarded_inner_confusion
           - windowed_logreg_175_w125_w150
+          - windowed_logreg_175_w125_w150_window_classifier_lcb_pruned
           - windowed_logreg_w150_size_center_grid
           - windowed_logreg_175_w125_w150_top3_agreement_log_pool
           - windowed_logreg_w150_size_center_grid_top3_agreement_log_pool
@@ -238,6 +239,9 @@ on:
           - lcb_pruned_t0_5
           - lcb_pruned_t1_5
           - lcb_pruned_t2
+          - window_lcb_pruned
+          - window_classifier_lcb_pruned
+          - full_config_lcb_pruned
           - window_feature_classifier_score_calibration
           - full_config
       selection_ensemble_score_normalization_override:
@@ -3436,6 +3440,29 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w125_w150_window_classifier_lcb_pruned": {
+                  # Source-only follow-up for the current BUSH w150 winner.  The
+                  # 125 ms and 150 ms windows were both strong, but forcing a
+                  # diverse top-3 can include a weak tail candidate.  This first
+                  # picks distinct window/classifier candidates, then prunes any
+                  # member whose source-inner lower confidence bound is not close
+                  # to the leading candidate.  No cue data, alignment, M-CCA,
+                  # Procrustes, or held-out labels are used.
+                  "window_centers": "0.175",
+                  "window_sizes": "0.125,0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_classifier_lcb_pruned",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_w150_size_center_grid": {

--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -154,6 +154,12 @@ on:
         options:
           - none
           - source_prior_balanced_assignment
+          - validation_guarded_source_prior_balanced_assignment
+      prediction_postprocessing_guard_tolerance:
+        description: Allowed validation balanced-accuracy drop for guarded prediction postprocessing.
+        required: true
+        default: "0.0"
+        type: string
 
 permissions:
   contents: read
@@ -220,6 +226,7 @@ jobs:
             --score-calibration-selection-metric "${{ inputs.score_calibration_selection_metric }}"
             --score-calibration-guard-tolerance "${{ inputs.score_calibration_guard_tolerance }}"
             --prediction-postprocessing "${{ inputs.prediction_postprocessing }}"
+            --prediction-postprocessing-guard-tolerance "${{ inputs.prediction_postprocessing_guard_tolerance }}"
             --seed 0
             --outer-output "outputs/${{ inputs.output_stem }}_outer.csv"
             --summary-output "outputs/${{ inputs.output_stem }}_group_summary.csv"

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -289,6 +289,12 @@ LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIERS = {
     "lcb_pruned_t2": 2.0,
 }
 LCB_PRUNED_ENSEMBLE_DIVERSITY_MODES = tuple(LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIERS)
+LCB_PRUNED_AFTER_DIVERSITY_BASES = {
+    "window_lcb_pruned": "window",
+    "window_classifier_lcb_pruned": "window_classifier",
+    "full_config_lcb_pruned": "full_config",
+}
+LCB_PRUNED_AFTER_DIVERSITY_MODES = tuple(LCB_PRUNED_AFTER_DIVERSITY_BASES)
 LOG_POOL_SUFFIX = "_log_pool"
 ENSEMBLE_LOG_POOL_EPSILON = 1e-12
 BALANCED_QUOTA_SUFFIX = "_balanced_quota"
@@ -343,6 +349,7 @@ SELECTION_ENSEMBLE_DIVERSITY_MODES = (
     "window_feature_classifier_param_sample_weighting_score_calibration_pca",
     "inner_confusion_complement",
     *LCB_PRUNED_ENSEMBLE_DIVERSITY_MODES,
+    *LCB_PRUNED_AFTER_DIVERSITY_MODES,
     "full_config",
 )
 NESTED_SCORE_ENSEMBLE_CLASSIFIER = "nested_topk_score_ensemble"
@@ -1619,6 +1626,19 @@ def _select_diverse_nested_rows(ranked_rows, *, requested_size, candidate_config
             requested_size=requested_size,
             sem_multiplier=_lcb_pruned_ensemble_sem_multiplier(diversity),
         )
+    if diversity in LCB_PRUNED_AFTER_DIVERSITY_MODES:
+        base_diversity = LCB_PRUNED_AFTER_DIVERSITY_BASES[diversity]
+        diverse_rows = _select_diverse_nested_rows(
+            ranked_rows,
+            requested_size=requested_size,
+            candidate_configs=candidate_configs,
+            diversity=base_diversity,
+        )
+        return _select_lcb_pruned_nested_rows(
+            diverse_rows,
+            requested_size=requested_size,
+            sem_multiplier=LCB_PRUNED_ENSEMBLE_SEM_MULTIPLIER,
+        )
 
     selected = []
     selected_indices = set()
@@ -1850,6 +1870,12 @@ def _ensemble_diversity_key(config, diversity):
         return "inner_confusion_complement"
     if diversity in LCB_PRUNED_ENSEMBLE_DIVERSITY_MODES:
         return diversity
+    if diversity in LCB_PRUNED_AFTER_DIVERSITY_BASES:
+        base_diversity = LCB_PRUNED_AFTER_DIVERSITY_BASES[diversity]
+        return (
+            f"{diversity}:"
+            f"{_ensemble_diversity_key(config, base_diversity)}"
+        )
     return (
         f"window={float(config.window_center):.6g}/{float(config.window_size):.6g},"
         f"feature={config.feature_mode},norm={config.normalization},alignment={config.alignment},"

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -91,6 +91,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     score_calibration_selection_metric: str = "balanced_accuracy"
     score_calibration_guard_tolerance: float = 0.0
     prediction_postprocessing: str = "none"
+    prediction_postprocessing_guard_tolerance: float = 0.0
     device: str = "auto"
     num_threads: int = 1
 
@@ -1117,6 +1118,16 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "prediction_postprocessing_quota_source": fit_metadata.get("prediction_postprocessing_quota_source", "none"),
         "prediction_postprocessing_class_quota_counts": fit_metadata.get("prediction_postprocessing_class_quota_counts", ""),
         "prediction_postprocessing_objective_delta": fit_metadata.get("prediction_postprocessing_objective_delta", np.nan),
+        "prediction_postprocessing_validation_balanced_accuracy": fit_metadata.get(
+            "prediction_postprocessing_validation_balanced_accuracy", np.nan
+        ),
+        "prediction_postprocessing_uncalibrated_validation_balanced_accuracy": fit_metadata.get(
+            "prediction_postprocessing_uncalibrated_validation_balanced_accuracy", np.nan
+        ),
+        "prediction_postprocessing_validation_objective_delta": fit_metadata.get(
+            "prediction_postprocessing_validation_objective_delta", np.nan
+        ),
+        "prediction_postprocessing_guard_tolerance": fit_metadata.get("prediction_postprocessing_guard_tolerance", np.nan),
         "score_calibration_bias_min": fit_metadata.get("score_calibration_bias_min", np.nan),
         "score_calibration_bias_max": fit_metadata.get("score_calibration_bias_max", np.nan),
         "score_calibration_bias_mean_abs": fit_metadata.get("score_calibration_bias_mean_abs", np.nan),
@@ -1219,6 +1230,7 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "prediction_postprocessing_status_counts": _format_counter(
                 Counter(row.get("prediction_postprocessing_status", "not_requested") for row in outer_rows)
             ),
+            "prediction_postprocessing_guard_tolerance": config.prediction_postprocessing_guard_tolerance,
             "epochs_requested": config.epochs,
             "validation_selection_metric": config.validation_selection_metric,
             "validation_source_count": config.validation_source_count,
@@ -1269,6 +1281,15 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "score_calibration_bias_mean_abs_mean": float(np.nanmean([float(row.get("score_calibration_bias_mean_abs", np.nan)) for row in outer_rows])),
             "score_calibration_confusion_map_trace_mean": float(
                 np.nanmean([float(row.get("score_calibration_confusion_map_trace", np.nan)) for row in outer_rows])
+            ),
+            "prediction_postprocessing_validation_balanced_accuracy_mean": float(
+                np.nanmean([float(row.get("prediction_postprocessing_validation_balanced_accuracy", np.nan)) for row in outer_rows])
+            ),
+            "prediction_postprocessing_uncalibrated_validation_balanced_accuracy_mean": float(
+                np.nanmean([float(row.get("prediction_postprocessing_uncalibrated_validation_balanced_accuracy", np.nan)) for row in outer_rows])
+            ),
+            "prediction_postprocessing_validation_objective_delta_mean": float(
+                np.nanmean([float(row.get("prediction_postprocessing_validation_objective_delta", np.nan)) for row in outer_rows])
             ),
             "best_validation_selection_score_mean": float(
                 np.nanmean([float(row.get("best_validation_selection_score", np.nan)) for row in outer_rows])
@@ -1361,23 +1382,73 @@ def _postprocess_predictions(
     classes: np.ndarray,
     source_labels: np.ndarray,
     config: LatentAutoencoderConfig,
+    *,
+    validation_scores: np.ndarray | None = None,
+    validation_labels: np.ndarray | None = None,
 ) -> tuple[np.ndarray, dict]:
     method = str(config.prediction_postprocessing or "none")
+    argmax_labels = classes[np.argmax(scores, axis=1)]
+    base_metadata = {
+        "prediction_postprocessing_quota_source": "none",
+        "prediction_postprocessing_class_quota_counts": "",
+        "prediction_postprocessing_objective_delta": 0.0,
+        "prediction_postprocessing_validation_balanced_accuracy": np.nan,
+        "prediction_postprocessing_uncalibrated_validation_balanced_accuracy": np.nan,
+        "prediction_postprocessing_validation_objective_delta": np.nan,
+        "prediction_postprocessing_guard_tolerance": float(config.prediction_postprocessing_guard_tolerance),
+    }
     if method == "none":
-        return classes[np.argmax(scores, axis=1)], {
+        return argmax_labels, {
+            **base_metadata,
             "prediction_postprocessing_status": "not_requested",
-            "prediction_postprocessing_quota_source": "none",
-            "prediction_postprocessing_class_quota_counts": "",
-            "prediction_postprocessing_objective_delta": 0.0,
         }
-    if method != "source_prior_balanced_assignment":
+    supported = {
+        "source_prior_balanced_assignment",
+        "validation_guarded_source_prior_balanced_assignment",
+    }
+    if method not in supported:
         raise ValueError(
-            "prediction_postprocessing must be one of: none, source_prior_balanced_assignment"
+            "prediction_postprocessing must be one of: none, source_prior_balanced_assignment, "
+            "validation_guarded_source_prior_balanced_assignment"
         )
+
+    validation_metadata = dict(base_metadata)
+    if method == "validation_guarded_source_prior_balanced_assignment":
+        if validation_scores is None or validation_labels is None or len(validation_labels) == 0:
+            return argmax_labels, {
+                **validation_metadata,
+                "prediction_postprocessing_status": "no_validation",
+            }
+        validation_scores = np.asarray(validation_scores, dtype=float)
+        validation_labels = np.asarray(validation_labels, dtype=int)
+        validation_argmax = classes[np.argmax(validation_scores, axis=1)]
+        validation_quotas = _source_prior_class_quotas(source_labels, classes, int(validation_scores.shape[0]))
+        validation_assigned, validation_objective_delta = _balanced_assignment_predictions(
+            validation_scores,
+            classes,
+            validation_quotas,
+        )
+        uncalibrated_validation_balanced = float(balanced_accuracy_score(validation_labels, validation_argmax))
+        validation_balanced = float(balanced_accuracy_score(validation_labels, validation_assigned))
+        validation_metadata.update(
+            {
+                "prediction_postprocessing_validation_balanced_accuracy": validation_balanced,
+                "prediction_postprocessing_uncalibrated_validation_balanced_accuracy": uncalibrated_validation_balanced,
+                "prediction_postprocessing_validation_objective_delta": float(validation_objective_delta),
+            }
+        )
+        guard_tolerance = max(0.0, float(config.prediction_postprocessing_guard_tolerance))
+        if validation_balanced + guard_tolerance + 1e-12 < uncalibrated_validation_balanced:
+            return argmax_labels, {
+                **validation_metadata,
+                "prediction_postprocessing_status": "guard_rejected",
+            }
+
     quotas = _source_prior_class_quotas(source_labels, classes, int(scores.shape[0]))
     predicted_labels, objective_delta = _balanced_assignment_predictions(scores, classes, quotas)
     quota_counts = Counter({int(class_label): int(quota) for class_label, quota in zip(classes, quotas, strict=True)})
     return predicted_labels, {
+        **validation_metadata,
         "prediction_postprocessing_status": "ok",
         "prediction_postprocessing_quota_source": "source_label_prior",
         "prediction_postprocessing_class_quota_counts": _format_counter(quota_counts),
@@ -1444,6 +1515,8 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
         score_calibration_bias: np.ndarray | dict = np.zeros(0, dtype=float)
         initial_calibration_status = "not_requested" if config.score_calibration == "none" else "no_validation"
         score_calibration_metadata = _empty_score_calibration_metadata(config, initial_calibration_status)
+        validation_scores_for_postprocessing = None
+        validation_labels_for_postprocessing = None
         if validation_participants:
             validation_features_raw, validation_labels_raw, _validation_subjects = _concat_features(feature_sets, validation_participants)
             train_labels_epoch = train_labels_raw
@@ -1475,6 +1548,8 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
             score_calibration_bias, score_calibration_metadata = _fit_validation_score_calibration(
                 validation_scores, validation_labels_epoch, classes_epoch, config
             )
+            validation_scores_for_postprocessing = _apply_score_calibration(validation_scores, score_calibration_bias)
+            validation_labels_for_postprocessing = validation_labels_epoch
             selected_epoch = int(fit_metadata.get("best_epoch", config.epochs))
             fit_metadata = {**fit_metadata, **score_calibration_metadata}
 
@@ -1522,7 +1597,12 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
             "latent_score_ensemble_final_epochs": _format_seed_sequence(final_epoch_values),
         }
         predicted_labels, postprocessing_metadata = _postprocess_predictions(
-            scores, classes, final_train_labels, config
+            scores,
+            classes,
+            final_train_labels,
+            config,
+            validation_scores=validation_scores_for_postprocessing,
+            validation_labels=validation_labels_for_postprocessing,
         )
         fit_metadata = {**fit_metadata, **postprocessing_metadata}
         outer_row = _outer_row(
@@ -1752,12 +1832,22 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--prediction-postprocessing",
-        choices=("none", "source_prior_balanced_assignment"),
+        choices=(
+            "none",
+            "source_prior_balanced_assignment",
+            "validation_guarded_source_prior_balanced_assignment",
+        ),
         default="none",
         help=(
             "Optional source-prior balanced assignment over the held-out batch. "
-            "This uses source-label class frequencies and test scores only; report separately as transductive postprocessing."
+            "The validation_guarded variant applies it only when source validation does not regress."
         ),
+    )
+    parser.add_argument(
+        "--prediction-postprocessing-guard-tolerance",
+        type=float,
+        default=0.0,
+        help="Allowed validation balanced-accuracy drop for validation_guarded_source_prior_balanced_assignment.",
     )
     parser.add_argument("--device", default="auto", help="auto, cpu, cuda, or another torch device string.")
     parser.add_argument("--num-threads", type=int, default=1)
@@ -1815,6 +1905,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         score_calibration_selection_metric=args.score_calibration_selection_metric,
         score_calibration_guard_tolerance=args.score_calibration_guard_tolerance,
         prediction_postprocessing=args.prediction_postprocessing,
+        prediction_postprocessing_guard_tolerance=args.prediction_postprocessing_guard_tolerance,
         device=args.device,
         num_threads=args.num_threads,
     )

--- a/tests/test_stimulus_cross_subject.py
+++ b/tests/test_stimulus_cross_subject.py
@@ -521,6 +521,64 @@ class TestStimulusCrossSubject(unittest.TestCase):
             [1, 3],
         )
 
+    def test_window_classifier_lcb_pruned_keeps_close_diverse_rows(self):
+        configs = (
+            CrossSubjectStimulusConfig(
+                window_center=0.175,
+                window_size=0.150,
+                classifier="multinomial-logistic",
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.175,
+                window_size=0.150,
+                classifier="multinomial-logistic-weighted",
+            ),
+            CrossSubjectStimulusConfig(
+                window_center=0.175,
+                window_size=0.125,
+                classifier="multinomial-logistic",
+            ),
+        )
+        ranked_rows = [
+            {
+                "selected_candidate_index": 1,
+                "selected_inner_selection_ranking_score": 0.120,
+                "selected_inner_selection_score_mean": 0.120,
+                "selected_inner_selection_score_sem": 0.010,
+                "selected_inner_balanced_accuracy_mean": 0.120,
+                "selected_inner_balanced_accuracy_sem": 0.010,
+            },
+            {
+                "selected_candidate_index": 2,
+                "selected_inner_selection_ranking_score": 0.119,
+                "selected_inner_selection_score_mean": 0.119,
+                "selected_inner_selection_score_sem": 0.004,
+                "selected_inner_balanced_accuracy_mean": 0.119,
+                "selected_inner_balanced_accuracy_sem": 0.004,
+            },
+            {
+                "selected_candidate_index": 3,
+                "selected_inner_selection_ranking_score": 0.104,
+                "selected_inner_selection_score_mean": 0.104,
+                "selected_inner_selection_score_sem": 0.003,
+                "selected_inner_balanced_accuracy_mean": 0.104,
+                "selected_inner_balanced_accuracy_sem": 0.003,
+            },
+        ]
+
+        self.assertIn(
+            "window_classifier_lcb_pruned",
+            cross_subject.SELECTION_ENSEMBLE_DIVERSITY_MODES,
+        )
+        selected = cross_subject._select_diverse_nested_rows(  # pylint: disable=protected-access
+            ranked_rows,
+            requested_size=3,
+            candidate_configs=configs,
+            diversity="window_classifier_lcb_pruned",
+        )
+
+        self.assertEqual([row["selected_candidate_index"] for row in selected], [1, 2])
+
     def test_sensor_dct_keeps_low_order_temporal_coefficients(self):
         time = np.asarray([-0.5, 0.0, 0.1, 0.2, 0.3, 0.4], dtype=float)
         trials = [

--- a/tests/test_stimulus_latent_autoencoder_controls.py
+++ b/tests/test_stimulus_latent_autoencoder_controls.py
@@ -188,3 +188,59 @@ def test_supervised_contrastive_loss_rewards_same_class_latent_neighbors():
 
     assert torch.isfinite(clustered_loss)
     assert clustered_loss < mixed_loss
+
+
+def test_guarded_source_prior_assignment_applies_when_validation_improves():
+    classes = np.asarray([1, 2, 3], dtype=int)
+    source_labels = np.asarray([1, 1, 2, 2, 3, 3], dtype=int)
+    labels = np.asarray([1, 1, 2, 2, 3, 3], dtype=int)
+    scores = np.asarray(
+        [
+            [4.0, 0.0, 0.0],
+            [3.9, 0.0, 0.0],
+            [4.0, 3.99, 0.0],
+            [4.0, 3.98, 0.0],
+            [4.0, 0.0, 3.99],
+            [4.0, 0.0, 3.98],
+        ],
+        dtype=float,
+    )
+    config = LatentAutoencoderConfig(
+        prediction_postprocessing="validation_guarded_source_prior_balanced_assignment"
+    )
+
+    predicted, metadata = _postprocess_predictions(
+        scores,
+        classes,
+        source_labels,
+        config,
+        validation_scores=scores,
+        validation_labels=labels,
+    )
+
+    assert predicted.tolist() == labels.tolist()
+    assert metadata["prediction_postprocessing_status"] == "ok"
+    assert metadata["prediction_postprocessing_quota_source"] == "source_label_prior"
+    assert metadata["prediction_postprocessing_validation_balanced_accuracy"] == 1.0
+
+
+def test_guarded_source_prior_assignment_rejects_validation_regression():
+    classes = np.asarray([1, 2, 3], dtype=int)
+    source_labels = np.asarray([1, 1, 2, 2, 3, 3], dtype=int)
+    scores = np.asarray([[4.0, 0.0, 0.0]] * 6, dtype=float)
+    labels = np.asarray([1, 1, 1, 1, 1, 1], dtype=int)
+    config = LatentAutoencoderConfig(
+        prediction_postprocessing="validation_guarded_source_prior_balanced_assignment"
+    )
+
+    predicted, metadata = _postprocess_predictions(
+        scores,
+        classes,
+        source_labels,
+        config,
+        validation_scores=scores,
+        validation_labels=labels,
+    )
+
+    assert predicted.tolist() == labels.tolist()
+    assert metadata["prediction_postprocessing_status"] == "guard_rejected"

--- a/tests/test_stimulus_latent_autoencoder_postprocessing.py
+++ b/tests/test_stimulus_latent_autoencoder_postprocessing.py
@@ -1,0 +1,68 @@
+import numpy as np
+
+from pymegdec.stimulus_latent_autoencoder import (
+    LatentAutoencoderConfig,
+    _balanced_assignment_predictions,
+    _display_label_map,
+    _postprocess_predictions,
+    _source_prior_class_quotas,
+)
+
+
+def test_latent_config_carries_prediction_postprocessing_option():
+    config = LatentAutoencoderConfig(prediction_postprocessing="source_prior_balanced_assignment")
+    assert config.prediction_postprocessing == "source_prior_balanced_assignment"
+
+
+def test_source_prior_class_quotas_follow_balanced_bush_fold_counts():
+    labels = np.repeat(np.asarray([1, 2, 3, 4]), 10)
+    quotas = _source_prior_class_quotas(labels, np.asarray([1, 2, 3, 4]), n_test_trials=20)
+    assert quotas.tolist() == [5, 5, 5, 5]
+
+
+def test_balanced_assignment_predictions_respect_quotas():
+    classes = np.asarray([1, 2, 3])
+    # Argmax alone would over-predict class 1 for the first two rows.  The
+    # quota-constrained assignment should still choose the best feasible one-row
+    # allocation for each class.
+    scores = np.asarray(
+        [
+            [3.0, 2.0, 0.0],
+            [2.9, 2.8, 0.0],
+            [2.0, 0.0, 4.0],
+        ]
+    )
+    predictions, objective_delta = _balanced_assignment_predictions(
+        scores,
+        classes,
+        np.asarray([1, 1, 1]),
+    )
+    assert sorted(predictions.tolist()) == [1, 2, 3]
+    assert objective_delta <= 0.0
+
+
+def test_postprocess_predictions_source_prior_balanced_assignment():
+    classes = np.asarray([1, 2, 3, 4])
+    source_labels = np.repeat(classes, 12)
+    scores = np.asarray(
+        [
+            [5.0, 4.0, 0.0, 0.0],
+            [4.9, 4.8, 0.0, 0.0],
+            [4.7, 0.0, 5.0, 0.0],
+            [4.6, 0.0, 0.0, 5.0],
+        ]
+    )
+    predictions, metadata = _postprocess_predictions(
+        scores,
+        classes,
+        source_labels,
+        LatentAutoencoderConfig(prediction_postprocessing="source_prior_balanced_assignment"),
+    )
+    assert sorted(predictions.tolist()) == [1, 2, 3, 4]
+    assert metadata["prediction_postprocessing_status"] == "ok"
+    assert metadata["prediction_postprocessing_quota_source"] == "source_label_prior"
+
+
+def test_display_label_map_does_not_shift_one_based_labels():
+    assert _display_label_map(np.asarray([1, 2, 3])) == {1: 1, 2: 2, 3: 3}
+    assert _display_label_map(np.asarray([0, 1, 2])) == {0: 1, 1: 2, 2: 3}


### PR DESCRIPTION
## Summary
- add BUSH window LCB-pruned workflow variants
- enable guarded latent prediction postprocessing
- add focused coverage for window LCB and guarded postprocessing behavior

## Verification
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_legacy.py src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_cross_subject.py tests\test_stimulus_latent_autoencoder_controls.py tests\test_stimulus_latent_autoencoder_postprocessing.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/stimulus-cross-subject-nested-matrix.yml').read_text(encoding='utf-8')); yaml.safe_load(pathlib.Path('.github/workflows/stimulus-latent-autoencoder.yml').read_text(encoding='utf-8'))"`
- `git diff --check`

Tests were not run per request.