### PR TITLE
Extend latent AE calibration and postprocessing options

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -104,6 +104,8 @@ on:
           - windowed_logreg_175_w150_trial_margin
           - windowed_logreg_175_w150_trial_entropy
           - windowed_logreg_175_w150_adaptive_ranksoft
+          - windowed_logreg_175_w150_adaptive_topk
+          - windowed_logreg_175_w150_adaptive_topk_confusion
           - windowed_logreg_175_w150_source_anova_sqrt
           - windowed_logreg_175_w150_pca160
           - windowed_logreg_175_w150_pca160_median_consensus
@@ -157,6 +159,7 @@ on:
           - windowed_logreg_175_w150_rank_consensus
           - windowed_logreg_175_w150_adaptive_ranksoft_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_gaussian_taper_mix
+          - windowed_logreg_175_w150_gaussian_taper_delta2
           - windowed_logreg_175_w150_gaussian_taper_pyramid
           - windowed_logreg_175_w150_ranksoft_t0_5
           - windowed_logreg_175_w150_ranksoft_t0_75
@@ -275,6 +278,8 @@ on:
           - rank_top3_score_softmax
           - rank_top2_adaptive_score_softmax
           - rank_top3_adaptive_score_softmax
+          - rank_adaptive_topk_score_softmax
+          - rank_adaptive_topk_score_softmax_inner_confusion_soft_guarded
           - rank_top2_score_borda_blend
           - rank_top3_score_borda_blend
           - rank_top3_adaptive_score_softmax_inner_recall_bias
@@ -1966,6 +1971,40 @@ jobs:
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
+              "windowed_logreg_175_w150_adaptive_topk": {
+                  # Same clean source-only w150 family as the current best run,
+                  # but make the top-k support row-adaptive: top-2 for decisive
+                  # held-out score rows and top-3 for ambiguous rows.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_adaptive_topk_score_softmax",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_adaptive_topk_confusion": {
+                  # Row-adaptive top-k support plus the existing guarded source-inner confusion reranker.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_adaptive_topk_score_softmax_inner_confusion_soft_guarded",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
               "windowed_logreg_175_w150_source_anova_sqrt": {
                   "window_centers": "0.175",
                   "window_size": "0.150",
@@ -3021,6 +3060,29 @@ jobs:
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_softmax",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_gaussian_taper_delta2": {
+                  # Source-only follow-up for the 14.10% w150 branch.  It keeps
+                  # the clean no-alignment protocol but adds a candidate feature
+                  # that center-weights the broad 150 ms visual window and exposes
+                  # first/second temporal-difference blocks.  The feature width is
+                  # still a channel-block multiple, so subject_baseline_whiten can
+                  # use the same blockwise whitening path.  No cue data, target
+                  # labels, hyperalignment, M-CCA, or Procrustes are used.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat,sensor_flat_gaussian_taper_delta2",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128,160",
+                  "selection_metric": "balanced_top2_top3_rank_lcb",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "window_feature_classifier_param_sample_weighting_score_calibration_pca",
+                  "selection_ensemble_score_normalization": "rank_softmax",
+                  "selection_ensemble_weighting": "inner_selection_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },
               "windowed_logreg_175_w150_gaussian_taper_pyramid": {

--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -54,6 +54,11 @@ on:
         required: true
         default: "0.05"
         type: string
+      focal_loss_gamma:
+        description: Focal-loss gamma for latent AE classification; 0 disables focal modulation.
+        required: true
+        default: "0.0"
+        type: string
       supervised_contrastive_weight:
         description: Source-only supervised contrastive latent loss weight; 0 disables it.
         required: true
@@ -128,9 +133,15 @@ on:
           - validation_prediction_bias
           - validation_argmax_class_bias
           - validation_argmax_class_bias_guarded
+          - validation_temperature_class_bias_guarded
+          - validation_temperature_argmax_class_bias_guarded
           - validation_confusion_blend
           - validation_logistic_stack
           - validation_logistic_stack_guarded
+          - validation_class_zscore
+          - validation_class_zscore_guarded
+          - validation_score_standardize
+          - validation_score_standardize_guarded
       score_calibration_alphas:
         description: Candidate alpha strengths for source-validation class-bias calibration.
         required: true
@@ -140,6 +151,11 @@ on:
         description: Candidate C values for validation_logistic_stack calibration.
         required: true
         default: "0.03,0.1,0.3,1"
+        type: string
+      score_calibration_temperatures:
+        description: Candidate logit temperatures for validation_temperature_* calibration.
+        required: true
+        default: "0.5,0.75,1,1.5,2,3"
         type: string
       score_calibration_smoothing:
         description: Additive smoothing for score-calibration priors.
@@ -173,7 +189,9 @@ on:
         options:
           - none
           - source_prior_balanced_assignment
+          - source_prior_soft_balanced_assignment
           - validation_guarded_source_prior_balanced_assignment
+          - validation_guarded_source_prior_soft_balanced_assignment
           - validation_guarded_shrunk_source_prior_balanced_assignment
       prediction_postprocessing_shrinkage_alphas:
         description: Candidate shrinkage strengths for guarded shrunk source-prior assignment.
@@ -184,6 +202,11 @@ on:
         description: Allowed validation balanced-accuracy drop for guarded prediction postprocessing.
         required: true
         default: "0.0"
+        type: string
+      prediction_postprocessing_quota_strength:
+        description: Blend strength for soft source-prior postprocessing.
+        required: true
+        default: "1.0"
         type: string
 
 permissions:
@@ -235,6 +258,7 @@ jobs:
             --prediction-balance-weight "${{ inputs.prediction_balance_weight }}"
             --prediction-balance-target-smoothing "${{ inputs.prediction_balance_target_smoothing }}"
             --label-smoothing "${{ inputs.label_smoothing }}"
+            --focal-loss-gamma "${{ inputs.focal_loss_gamma }}"
             --supervised-contrastive-weight "${{ inputs.supervised_contrastive_weight }}"
             --supervised-contrastive-temperature "${{ inputs.supervised_contrastive_temperature }}"
             --validation-prediction-balance-weight "${{ inputs.validation_prediction_balance_weight }}"
@@ -248,6 +272,7 @@ jobs:
             --score-calibration "${{ inputs.score_calibration }}"
             --score-calibration-alphas "${{ inputs.score_calibration_alphas }}"
             --score-calibration-logistic-c-values "${{ inputs.score_calibration_logistic_c_values }}"
+            --score-calibration-temperatures "${{ inputs.score_calibration_temperatures }}"
             --score-calibration-smoothing "${{ inputs.score_calibration_smoothing }}"
             --score-calibration-confusion-smoothing "${{ inputs.score_calibration_confusion_smoothing }}"
             --score-calibration-selection-metric "${{ inputs.score_calibration_selection_metric }}"
@@ -255,6 +280,7 @@ jobs:
             --prediction-postprocessing "${{ inputs.prediction_postprocessing }}"
             --prediction-postprocessing-shrinkage-alphas "${{ inputs.prediction_postprocessing_shrinkage_alphas }}"
             --prediction-postprocessing-guard-tolerance "${{ inputs.prediction_postprocessing_guard_tolerance }}"
+            --prediction-postprocessing-quota-strength "${{ inputs.prediction_postprocessing_quota_strength }}"
             --seed 0
             --outer-output "outputs/${{ inputs.output_stem }}_outer.csv"
             --summary-output "outputs/${{ inputs.output_stem }}_group_summary.csv"

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -27,7 +27,8 @@
     "tests/test_stimulus_cross_subject.py",
     "tests/test_stimulus_cross_subject_next.py",
     "tests/test_stimulus_decoding.py",
-    "tests/test_stimulus_full_epoch_lowrank.py"
+    "tests/test_stimulus_full_epoch_lowrank.py",
+    "tests/test_time_axis_handling.py"
   ],
   "threshold": 2.0
 }

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -28,6 +28,7 @@
     "tests/test_stimulus_cross_subject_next.py",
     "tests/test_stimulus_decoding.py",
     "tests/test_stimulus_full_epoch_lowrank.py",
+    "tests/test_stimulus_latent_autoencoder_score_calibration.py",
     "tests/test_time_axis_handling.py"
   ],
   "threshold": 2.0

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -100,6 +100,7 @@ BASELINE_WHITENED_EXTENDED_FEATURE_MODES = (
     "sensor_flat_taper",
     "sensor_flat_gaussian_taper",
     "sensor_flat_gaussian_taper_time_pyramid",
+    "sensor_flat_gaussian_taper_delta2",
     "sensor_flat_centered",
     "sensor_flat_delta",
     "sensor_flat_delta2",
@@ -122,6 +123,7 @@ EXTENDED_FEATURE_MODES = (
     "sensor_flat_taper",
     "sensor_flat_gaussian_taper",
     "sensor_flat_gaussian_taper_time_pyramid",
+    "sensor_flat_gaussian_taper_delta2",
     "sensor_flat_centered",
     "sensor_flat_delta",
     "sensor_flat_delta2",
@@ -281,6 +283,22 @@ TOPK_ADAPTIVE_SCORE_SOFTMAX_SCORE_NORMALIZATIONS = {
 }
 TOPK_ADAPTIVE_SCORE_SOFTMAX_LOW_TEMPERATURE = 0.50
 TOPK_ADAPTIVE_SCORE_SOFTMAX_HIGH_TEMPERATURE = 2.00
+ADAPTIVE_TOPK_SCORE_SOFTMAX_MODE = "rank_adaptive_topk_score_softmax"
+ADAPTIVE_TOPK_SCORE_SOFTMAX_MIN_K = 2
+ADAPTIVE_TOPK_SCORE_SOFTMAX_MAX_K = 3
+ADAPTIVE_TOPK_SCORE_SOFTMAX_MARGIN_LOW = 0.25
+ADAPTIVE_TOPK_SCORE_SOFTMAX_MARGIN_HIGH = 1.25
+ADAPTIVE_TOPK_SCORE_SOFTMAX_TEMPERATURE = 1.0
+ADAPTIVE_TOPK_SCORE_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES = {
+    # Source-only near-miss reranker for the current BUSH-MEG w150 regime.  The
+    # normalizer uses a sparse top-2 posterior when a held-out score row has a
+    # strong top-1/top-2 margin, and a sparse top-3 posterior when the row is
+    # ambiguous.  The guarded inner-confusion variant keeps the same unlabeled
+    # row-local base probabilities, then applies the existing source-inner
+    # confusion correction.  No cue data, target labels, or cross-subject
+    # alignment are used.
+    f"{ADAPTIVE_TOPK_SCORE_SOFTMAX_MODE}_inner_confusion_soft_guarded": ADAPTIVE_TOPK_SCORE_SOFTMAX_MODE,
+}
 TOPK_SCORE_BORDA_BLEND_SCORE_NORMALIZATIONS = {
     # Confidence-gated blend between score-sensitive sparse top-k softmax and
     # robust truncated Borda pooling.  The current BUSH-MEG w150 source-only run
@@ -876,6 +894,9 @@ def _install_soft_inner_confusion_score_normalizations(impl) -> None:
         TOPK_ADAPTIVE_SCORE_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES
     )
     impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
+        ADAPTIVE_TOPK_SCORE_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES
+    )
+    impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
         INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_BASES
     )
     impl.INNER_CONFUSION_ENSEMBLE_SCORE_NORMALIZATION_BASES.update(
@@ -895,6 +916,7 @@ def _install_soft_inner_confusion_score_normalizations(impl) -> None:
         *tuple(TOPK_BORDA_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
         *tuple(SOFT_GUARDED_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
         *tuple(TOPK_SCORE_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
+        *tuple(ADAPTIVE_TOPK_SCORE_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
         *tuple(TOPK_ADAPTIVE_SCORE_SOFTMAX_INNER_CONFUSION_SCORE_NORMALIZATION_BASES),
         *tuple(INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_BASES),
         *tuple(INTERMEDIATE_RANK_SOFTMAX_INNER_CONFUSION_MARGIN_BASES),
@@ -968,6 +990,7 @@ def _install_topk_score_softmax_score_normalizations(impl) -> None:
                 *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
                 *TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS,
                 *TOPK_ADAPTIVE_SCORE_SOFTMAX_SCORE_NORMALIZATIONS,
+                ADAPTIVE_TOPK_SCORE_SOFTMAX_MODE,
                 *TOPK_SCORE_SOFTMAX_LOG_POOL_SCORE_NORMALIZATIONS,
                 *TOPK_SCORE_BORDA_BLEND_SCORE_NORMALIZATIONS,
             )
@@ -1953,6 +1976,8 @@ def _class_score_probabilities(scores, *, score_normalization=None):
     top_k = TOPK_ADAPTIVE_SCORE_SOFTMAX_SCORE_NORMALIZATIONS.get(base_mode)
     if top_k is not None:
         return _rank_topk_adaptive_score_softmax_probabilities(scores, top_k=top_k)
+    if base_mode == ADAPTIVE_TOPK_SCORE_SOFTMAX_MODE:
+        return _rank_adaptive_topk_score_softmax_probabilities(scores)
     top_k = TOPK_SCORE_BORDA_BLEND_SCORE_NORMALIZATIONS.get(base_mode)
     if top_k is not None:
         return _rank_topk_score_borda_blend_probabilities(scores, top_k=top_k)
@@ -2352,6 +2377,84 @@ def _rank_topk_adaptive_score_softmax_probabilities(scores, *, top_k):
     return probabilities
 
 
+def _rank_adaptive_topk_score_softmax_probabilities(scores):
+    """Return a sparse score softmax with per-trial adaptive top-k support.
+
+    The fixed ``rank_top2_score_softmax`` and ``rank_top3_score_softmax`` modes
+    encode a trade-off: top-2 is conservative on decisive rows, while top-3
+    preserves more near-miss information on ambiguous rows.  The current BUSH-MEG
+    w150 source-only runs have high top-2/top-3 but lower top-1, so this mode
+    makes that trade-off per trial using only the unlabeled score row.  Rows with
+    a strong top-1/top-2 margin use top-2; low-margin rows use top-3.
+    """
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError(
+            "Nested score ensembling requires a non-empty two-dimensional "
+            "class-score matrix."
+        )
+
+    min_k = int(ADAPTIVE_TOPK_SCORE_SOFTMAX_MIN_K)
+    max_k = int(ADAPTIVE_TOPK_SCORE_SOFTMAX_MAX_K)
+    if min_k < 1 or max_k < min_k:
+        raise ValueError("Adaptive top-k score-softmax requires 1 <= min_k <= max_k.")
+    temperature = float(ADAPTIVE_TOPK_SCORE_SOFTMAX_TEMPERATURE)
+    if temperature <= 0.0:
+        raise ValueError("Adaptive top-k score-softmax temperature must be positive.")
+
+    probabilities = np.zeros_like(scores, dtype=float)
+    n_classes = int(scores.shape[1])
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        n_finite = int(np.sum(finite))
+        if n_finite == 0:
+            probabilities[row_index] = np.full(n_classes, 1.0 / n_classes, dtype=float)
+            continue
+
+        k = min(_adaptive_topk_support_size(row, min_k=min_k, max_k=max_k), n_finite)
+        ordered_columns = np.argsort(
+            -np.where(finite, row, -np.inf),
+            kind="mergesort",
+        )[:k]
+        logits = np.asarray(row[ordered_columns], dtype=float)
+        logits = logits - float(np.mean(logits))
+        scale = float(np.std(logits))
+        if isfinite(scale) and scale > 1e-12:
+            logits = logits / scale
+        logits = logits / temperature
+        logits = logits - float(np.max(logits))
+        exp_logits = np.exp(logits)
+        total = float(np.sum(exp_logits))
+        if not isfinite(total) or total <= 0.0:
+            probabilities[row_index, ordered_columns] = 1.0 / k
+        else:
+            probabilities[row_index, ordered_columns] = exp_logits / total
+    return probabilities
+
+
+def _adaptive_topk_support_size(row, *, min_k, max_k):
+    """Choose top-k support from z-scored top-1/top-2 score separation."""
+
+    row = np.asarray(row, dtype=float)
+    finite = np.isfinite(row)
+    n_finite = int(np.sum(finite))
+    if n_finite <= int(min_k):
+        return max(1, n_finite)
+    finite_scores = row[finite]
+    centered = finite_scores - np.mean(finite_scores)
+    scale = float(np.std(centered))
+    if scale > 1e-12:
+        centered = centered / scale
+    ordered = np.sort(centered)[::-1]
+    margin = float(ordered[0] - ordered[1]) if ordered.shape[0] >= 2 else np.inf
+    threshold = 0.5 * (
+        float(ADAPTIVE_TOPK_SCORE_SOFTMAX_MARGIN_LOW)
+        + float(ADAPTIVE_TOPK_SCORE_SOFTMAX_MARGIN_HIGH)
+    )
+    return int(max_k) if margin <= threshold else int(min_k)
+
+
 def _rank_topk_score_borda_blend_probabilities(scores, *, top_k):
     """Blend sparse top-k score softmax with truncated Borda by score margin.
 
@@ -2615,6 +2718,8 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
             feature = _sensor_flat_gaussian_taper_feature(signal)
         elif feature_mode == "sensor_flat_gaussian_taper_time_pyramid":
             feature = _sensor_flat_gaussian_taper_time_pyramid_feature(signal)
+        elif feature_mode == "sensor_flat_gaussian_taper_delta2":
+            feature = _sensor_flat_gaussian_taper_delta2_feature(signal)
         elif feature_mode == "sensor_flat_centered":
             feature = _sensor_flat_centered_feature(signal)
         elif feature_mode == "sensor_flat_delta":
@@ -2761,6 +2866,33 @@ def _sensor_flat_gaussian_taper_time_pyramid_feature(window_signal):
             _sensor_time_pyramid_feature(signal),
         )
     )
+
+
+def _sensor_flat_gaussian_taper_delta2_feature(window_signal):
+    """Return center-weighted broad-window samples plus temporal shape blocks.
+
+    The best current clean BUSH-MEG source-only branch uses a 150 ms window
+    centered at 175 ms.  That broad window likely contains both a useful central
+    visual response and subject-specific latency/shape variation.  This feature
+    keeps the same channel-block layout as ``sensor_flat`` and remains compatible
+    with ``subject_baseline_whiten``: the first block is Gaussian-tapered raw
+    samples, followed by first and second temporal differences from the untapered
+    signal.  The downstream PCA/logistic model can then choose between absolute
+    evoked amplitude and local temporal shape without using cue data, alignment,
+    or held-out labels.
+    """
+
+    signal = np.asarray(window_signal, dtype=float)
+    if signal.ndim != 2:
+        raise ValueError("window_signal must be a channel x time matrix.")
+
+    weights = _sensor_flat_gaussian_taper_weights(signal.shape[1])
+    pieces = [(signal * weights[None, :]).reshape(-1, order="F")]
+    if signal.shape[1] >= 2:
+        pieces.append(np.diff(signal, axis=1).reshape(-1, order="F"))
+    if signal.shape[1] >= 3:
+        pieces.append(np.diff(signal, n=2, axis=1).reshape(-1, order="F"))
+    return np.concatenate(pieces)
 
 
 def _sensor_flat_centered_feature(window_signal):

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -66,6 +66,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     prediction_balance_weight: float = 0.0
     prediction_balance_target_smoothing: float = 1.0
     label_smoothing: float = 0.0
+    focal_loss_gamma: float = 0.0
     supervised_contrastive_weight: float = 0.0
     supervised_contrastive_temperature: float = 0.20
     balanced_batch_sampling: bool = False
@@ -88,6 +89,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     label_shuffle_seed: int = 0
     score_calibration: str = "none"
     score_calibration_alphas: tuple[float, ...] = (0.0, 0.25, 0.5, 0.75, 1.0)
+    score_calibration_temperatures: tuple[float, ...] = (0.5, 0.75, 1.0, 1.5, 2.0, 3.0)
     score_calibration_logistic_c_values: tuple[float, ...] = (0.03, 0.1, 0.3, 1.0)
     score_calibration_smoothing: float = 1.0
     score_calibration_confusion_smoothing: float = 4.0
@@ -98,6 +100,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     score_calibration_vector_l2: float = 0.0
     prediction_postprocessing: str = "none"
     prediction_postprocessing_guard_tolerance: float = 0.0
+    prediction_postprocessing_quota_strength: float = 1.0
     prediction_postprocessing_shrinkage_alphas: tuple[float, ...] = (0.0, 0.25, 0.5, 0.75, 1.0)
     device: str = "auto"
     num_threads: int = 1
@@ -319,6 +322,39 @@ def _bounded_label_smoothing(value: float) -> float:
     return min(max(float(value), 0.0), 0.999)
 
 
+def _class_balanced_focal_cross_entropy(
+    logits,
+    targets,
+    *,
+    weight,
+    label_smoothing: float,
+    focal_gamma: float,
+):
+    """Return class-weighted CE with optional focal modulation."""
+
+    torch, _nn, F = _lazy_torch()
+    gamma = max(0.0, float(focal_gamma))
+    smoothing = _bounded_label_smoothing(label_smoothing)
+    if gamma <= 0.0:
+        return F.cross_entropy(
+            logits,
+            targets,
+            weight=weight,
+            label_smoothing=smoothing,
+        )
+    per_example_loss = F.cross_entropy(
+        logits,
+        targets,
+        weight=weight,
+        label_smoothing=smoothing,
+        reduction="none",
+    )
+    probabilities = F.softmax(logits, dim=1)
+    true_probabilities = probabilities.gather(1, targets.reshape(-1, 1)).reshape(-1)
+    focal_weight = torch.pow(1.0 - torch.clamp(true_probabilities, min=1e-6, max=1.0), gamma)
+    return (focal_weight * per_example_loss).mean()
+
+
 def _prediction_balance_loss(logits, label_indices, *, target_smoothing: float):
     """Penalize minibatch-level predicted-class collapse."""
 
@@ -527,11 +563,12 @@ def _train_model(  # pylint: disable=too-many-arguments,too-many-locals
             yb = y_tensor[batch_index]
             pb = p_tensor[batch_index]
             logits, latent = model(xb)
-            class_loss = F.cross_entropy(
+            class_loss = _class_balanced_focal_cross_entropy(
                 logits,
                 yb,
                 weight=weights,
-                label_smoothing=_bounded_label_smoothing(config.label_smoothing),
+                label_smoothing=config.label_smoothing,
+                focal_gamma=config.focal_loss_gamma,
             )
             reconstruction_losses = []
             for subject_id in torch.unique(pb).detach().cpu().numpy().tolist():
@@ -735,6 +772,7 @@ def _empty_score_calibration_metadata(config: LatentAutoencoderConfig, status: s
         "score_calibration_prior_source": "",
         "score_calibration_predicted_prior_source": "none",
         "score_calibration_alpha": 0.0,
+        "score_calibration_temperature": 1.0,
         "score_calibration_logistic_c": np.nan,
         "score_calibration_logistic_c_values": ";".join(str(float(value)) for value in config.score_calibration_logistic_c_values),
         "score_calibration_validation_balanced_accuracy": np.nan,
@@ -746,14 +784,15 @@ def _empty_score_calibration_metadata(config: LatentAutoencoderConfig, status: s
         "score_calibration_bias_min": 0.0,
         "score_calibration_bias_max": 0.0,
         "score_calibration_bias_mean_abs": 0.0,
+        "score_calibration_scale_min": 1.0,
+        "score_calibration_scale_max": 1.0,
+        "score_calibration_scale_mean": 1.0,
         "score_calibration_confusion_smoothing": float(config.score_calibration_confusion_smoothing),
         "score_calibration_confusion_map_trace": np.nan,
         "score_calibration_vector_steps": ";".join(str(float(step)) for step in config.score_calibration_vector_steps),
         "score_calibration_vector_rounds": int(config.score_calibration_vector_rounds),
         "score_calibration_vector_l2": float(config.score_calibration_vector_l2),
         "score_calibration_vector_updates": 0,
-        "score_calibration_scale_min": np.nan,
-        "score_calibration_scale_max": np.nan,
     }
 
 
@@ -788,6 +827,10 @@ def _fit_validation_score_calibration(
         "validation_logistic_stack_guarded",
         "validation_vector_bias",
         "validation_vector_bias_guarded",
+        "validation_class_zscore",
+        "validation_class_zscore_guarded",
+        "validation_temperature_class_bias_guarded",
+        "validation_temperature_argmax_class_bias_guarded",
         "validation_score_standardize",
         "validation_score_standardize_guarded",
     }
@@ -806,6 +849,13 @@ def _fit_validation_score_calibration(
         return _fit_validation_confusion_blend_calibration(validation_scores, validation_labels, classes, config)
     if config.score_calibration in {"validation_vector_bias", "validation_vector_bias_guarded"}:
         return _fit_validation_vector_bias_calibration(validation_scores, validation_labels, classes, config)
+    if config.score_calibration in {"validation_class_zscore", "validation_class_zscore_guarded"}:
+        return _fit_validation_class_zscore_calibration(validation_scores, validation_labels, classes, config)
+    if config.score_calibration in {
+        "validation_temperature_class_bias_guarded",
+        "validation_temperature_argmax_class_bias_guarded",
+    }:
+        return _fit_validation_temperature_bias_calibration(validation_scores, validation_labels, classes, config)
     if config.score_calibration in {
         "validation_score_standardize",
         "validation_score_standardize_guarded",
@@ -890,6 +940,7 @@ def _fit_validation_score_calibration(
             "softmax_mean" if prior_source == "mean_softmax" else "argmax"
         ),
         "score_calibration_alpha": best_alpha,
+        "score_calibration_temperature": 1.0,
         "score_calibration_logistic_c": np.nan,
         "score_calibration_logistic_c_values": ";".join(str(float(value)) for value in config.score_calibration_logistic_c_values),
         "score_calibration_validation_balanced_accuracy": best_balanced,
@@ -903,6 +954,108 @@ def _fit_validation_score_calibration(
         "score_calibration_bias_mean_abs": float(np.mean(np.abs(bias))),
     }
     return bias, metadata
+
+
+def _fit_validation_temperature_bias_calibration(
+    validation_scores: np.ndarray,
+    validation_labels: np.ndarray,
+    classes: np.ndarray,
+    config: LatentAutoencoderConfig,
+) -> tuple[dict, dict]:
+    """Fit source-validation temperature plus class-prior logit bias."""
+
+    validation_scores = np.asarray(validation_scores, dtype=float)
+    validation_labels = np.asarray(validation_labels, dtype=int)
+    label_indices = _class_index(validation_labels, classes)
+    n_classes = int(classes.shape[0])
+    smoothing = max(0.0, float(config.score_calibration_smoothing))
+
+    true_counts = np.bincount(label_indices, minlength=n_classes).astype(float)
+    true_prior = (true_counts + smoothing) / (float(np.sum(true_counts)) + smoothing * n_classes)
+
+    if config.score_calibration == "validation_temperature_class_bias_guarded":
+        prior_source = "mean_softmax"
+        predicted_counts = np.sum(_softmax_scores(validation_scores), axis=0)
+    else:
+        prior_source = "argmax_predictions"
+        predicted_counts = np.bincount(np.argmax(validation_scores, axis=1), minlength=n_classes).astype(float)
+    predicted_prior = (predicted_counts + smoothing) / (float(np.sum(predicted_counts)) + smoothing * n_classes)
+    base_bias = np.log(true_prior) - np.log(predicted_prior)
+    base_bias = base_bias - float(np.mean(base_bias))
+
+    uncalibrated_metrics = _validation_selection_metrics(
+        validation_labels,
+        validation_scores,
+        classes,
+        config.score_calibration_selection_metric,
+    )
+    uncalibrated_balanced = float(uncalibrated_metrics["balanced_accuracy"])
+    uncalibrated_selection = float(uncalibrated_metrics["selection_score"])
+    guard_floor = uncalibrated_balanced - max(0.0, float(config.score_calibration_guard_tolerance))
+
+    alphas = tuple(float(alpha) for alpha in config.score_calibration_alphas) or (1.0,)
+    temperatures = tuple(float(value) for value in config.score_calibration_temperatures if float(value) > 0.0) or (1.0,)
+
+    best_alpha = 0.0
+    best_temperature = 1.0
+    best_balanced = uncalibrated_balanced
+    best_selection = uncalibrated_selection
+    best_objective = uncalibrated_selection
+    for temperature in temperatures:
+        scaled_scores = validation_scores / max(float(temperature), 1e-6)
+        for alpha in alphas:
+            calibrated_scores = scaled_scores + float(alpha) * base_bias
+            calibrated_metrics = _validation_selection_metrics(
+                validation_labels,
+                calibrated_scores,
+                classes,
+                config.score_calibration_selection_metric,
+            )
+            balanced = float(calibrated_metrics["balanced_accuracy"])
+            if balanced + 1e-12 < guard_floor:
+                continue
+            selection_score = float(calibrated_metrics["selection_score"])
+            objective = selection_score
+            if (
+                objective > best_objective + 1e-12
+                or (abs(objective - best_objective) <= 1e-12 and balanced > best_balanced + 1e-12)
+                or (
+                    abs(objective - best_objective) <= 1e-12
+                    and abs(balanced - best_balanced) <= 1e-12
+                    and abs(float(alpha)) + abs(float(temperature) - 1.0)
+                    < abs(best_alpha) + abs(best_temperature - 1.0)
+                )
+            ):
+                best_objective = objective
+                best_balanced = balanced
+                best_selection = selection_score
+                best_alpha = float(alpha)
+                best_temperature = float(temperature)
+
+    bias = best_alpha * base_bias
+    calibrator = {"kind": "temperature_bias", "temperature": best_temperature, "bias": bias}
+    metadata = {
+        "score_calibration": config.score_calibration,
+        "score_calibration_status": "ok",
+        "score_calibration_prior_source": prior_source,
+        "score_calibration_predicted_prior_source": (
+            "softmax_mean" if prior_source == "mean_softmax" else "argmax"
+        ),
+        "score_calibration_alpha": best_alpha,
+        "score_calibration_temperature": best_temperature,
+        "score_calibration_logistic_c": np.nan,
+        "score_calibration_logistic_c_values": ";".join(str(float(value)) for value in config.score_calibration_logistic_c_values),
+        "score_calibration_validation_balanced_accuracy": best_balanced,
+        "score_calibration_uncalibrated_validation_balanced_accuracy": uncalibrated_balanced,
+        "score_calibration_selection_metric": config.score_calibration_selection_metric,
+        "score_calibration_validation_selection_score": best_selection,
+        "score_calibration_uncalibrated_validation_selection_score": uncalibrated_selection,
+        "score_calibration_guard_tolerance": config.score_calibration_guard_tolerance,
+        "score_calibration_bias_min": float(np.min(bias)),
+        "score_calibration_bias_max": float(np.max(bias)),
+        "score_calibration_bias_mean_abs": float(np.mean(np.abs(bias))),
+    }
+    return calibrator, metadata
 
 
 def _fit_validation_vector_bias_calibration(
@@ -1298,6 +1451,9 @@ def _fit_validation_score_standardization_calibration(
         "score_calibration_prior_source": "validation_score_moments",
         "score_calibration_predicted_prior_source": "score_standardization",
         "score_calibration_alpha": float(best_alpha),
+        "score_calibration_temperature": 1.0,
+        "score_calibration_logistic_c": np.nan,
+        "score_calibration_logistic_c_values": ";".join(str(float(value)) for value in config.score_calibration_logistic_c_values),
         "score_calibration_validation_balanced_accuracy": float(best_balanced),
         "score_calibration_uncalibrated_validation_balanced_accuracy": uncalibrated_balanced,
         "score_calibration_selection_metric": config.score_calibration_selection_metric,
@@ -1311,7 +1467,28 @@ def _fit_validation_score_standardization_calibration(
         "score_calibration_confusion_map_trace": np.nan,
         "score_calibration_scale_min": float(np.min(scales[:n_classes])),
         "score_calibration_scale_max": float(np.max(scales[:n_classes])),
+        "score_calibration_scale_mean": float(np.mean(scales[:n_classes])),
     }
+    return calibrator, metadata
+
+
+def _fit_validation_class_zscore_calibration(
+    validation_scores: np.ndarray,
+    validation_labels: np.ndarray,
+    classes: np.ndarray,
+    config: LatentAutoencoderConfig,
+) -> tuple[dict, dict]:
+    calibrator, metadata = _fit_validation_score_standardization_calibration(
+        validation_scores,
+        validation_labels,
+        classes,
+        config,
+    )
+    calibrator = dict(calibrator)
+    calibrator["kind"] = "class_zscore"
+    metadata = dict(metadata)
+    metadata["score_calibration_prior_source"] = "validation_score_distribution"
+    metadata["score_calibration_predicted_prior_source"] = "class_zscore"
     return calibrator, metadata
 
 
@@ -1320,17 +1497,22 @@ def _apply_score_calibration(scores: np.ndarray, calibration: np.ndarray | dict 
         return np.asarray(scores, dtype=float)
     scores = np.asarray(scores, dtype=float)
     if isinstance(calibration, dict):
-        if calibration.get("kind") == "logistic_stack":
+        kind = calibration.get("kind")
+        if kind == "logistic_stack":
             return _logistic_stack_score_matrix(calibration["model"], scores, np.asarray(calibration["classes"], dtype=int))
-        if calibration.get("kind") == "score_standardize":
+        if kind in {"score_standardize", "class_zscore"}:
             alpha = min(max(float(calibration.get("alpha", 0.0)), 0.0), 1.0)
             means = np.asarray(calibration["mean"], dtype=float).reshape(1, -1)
             scales = np.asarray(calibration["scale"], dtype=float).reshape(1, -1)
             scales = np.maximum(scales, 1e-6)
             standardized = (scores - means) / scales
             return (1.0 - alpha) * scores + alpha * standardized
-        if calibration.get("kind") != "confusion_blend":
-            raise ValueError(f"Unknown score calibration kind: {calibration.get('kind')!r}")
+        if kind == "temperature_bias":
+            temperature = max(float(calibration.get("temperature", 1.0)), 1e-6)
+            bias = np.asarray(calibration["bias"], dtype=float).reshape(1, -1)
+            return scores / temperature + bias
+        if kind != "confusion_blend":
+            raise ValueError(f"Unknown score calibration kind: {kind!r}")
         alpha = min(max(float(calibration.get("alpha", 0.0)), 0.0), 1.0)
         probabilities = _softmax_scores(scores)
         confusion_map = np.asarray(calibration["confusion_map"], dtype=float)
@@ -1396,6 +1578,7 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
             "prediction_balance_weight": config.prediction_balance_weight,
             "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "label_smoothing": config.label_smoothing,
+            "focal_loss_gamma": config.focal_loss_gamma,
             "supervised_contrastive_weight": config.supervised_contrastive_weight,
             "supervised_contrastive_temperature": config.supervised_contrastive_temperature,
             "balanced_batch_sampling": config.balanced_batch_sampling,
@@ -1484,6 +1667,7 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "prediction_balance_weight": config.prediction_balance_weight,
         "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
         "label_smoothing": config.label_smoothing,
+        "focal_loss_gamma": config.focal_loss_gamma,
         "supervised_contrastive_weight": config.supervised_contrastive_weight,
         "supervised_contrastive_temperature": config.supervised_contrastive_temperature,
         "balanced_batch_sampling": config.balanced_batch_sampling,
@@ -1493,6 +1677,8 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "score_calibration_prior_source": fit_metadata.get("score_calibration_prior_source", ""),
         "score_calibration_predicted_prior_source": fit_metadata.get("score_calibration_predicted_prior_source", "none"),
         "score_calibration_alpha": fit_metadata.get("score_calibration_alpha", np.nan),
+        "score_calibration_temperature": fit_metadata.get("score_calibration_temperature", np.nan),
+        "score_calibration_temperatures": ";".join(str(float(value)) for value in config.score_calibration_temperatures),
         "score_calibration_validation_balanced_accuracy": fit_metadata.get("score_calibration_validation_balanced_accuracy", np.nan),
         "score_calibration_uncalibrated_validation_balanced_accuracy": fit_metadata.get(
             "score_calibration_uncalibrated_validation_balanced_accuracy", np.nan
@@ -1519,6 +1705,8 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "prediction_postprocessing_status": fit_metadata.get("prediction_postprocessing_status", "not_requested"),
         "prediction_postprocessing_quota_source": fit_metadata.get("prediction_postprocessing_quota_source", "none"),
         "prediction_postprocessing_class_quota_counts": fit_metadata.get("prediction_postprocessing_class_quota_counts", ""),
+        "prediction_postprocessing_quota_strength": fit_metadata.get("prediction_postprocessing_quota_strength", np.nan),
+        "prediction_postprocessing_apply": fit_metadata.get("prediction_postprocessing_apply", False),
         "prediction_postprocessing_objective_delta": fit_metadata.get("prediction_postprocessing_objective_delta", np.nan),
         "prediction_postprocessing_validation_balanced_accuracy": fit_metadata.get(
             "prediction_postprocessing_validation_balanced_accuracy", np.nan
@@ -1541,6 +1729,7 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "score_calibration_confusion_map_trace": fit_metadata.get("score_calibration_confusion_map_trace", np.nan),
         "score_calibration_scale_min": fit_metadata.get("score_calibration_scale_min", np.nan),
         "score_calibration_scale_max": fit_metadata.get("score_calibration_scale_max", np.nan),
+        "score_calibration_scale_mean": fit_metadata.get("score_calibration_scale_mean", np.nan),
         "epochs_requested": config.epochs,
         "best_epoch": fit_metadata.get("best_epoch", np.nan),
         "final_epochs": fit_metadata.get("final_epochs", np.nan),
@@ -1787,6 +1976,23 @@ def _shrunk_source_prior_class_quotas(
     return _round_expected_class_quotas(expected, n_test_trials)
 
 
+def _blended_source_prior_class_quotas(
+    predicted_labels: np.ndarray,
+    source_labels: np.ndarray,
+    classes: np.ndarray,
+    n_test_trials: int,
+    *,
+    quota_strength: float,
+) -> np.ndarray:
+    return _shrunk_source_prior_class_quotas(
+        source_labels,
+        predicted_labels,
+        classes,
+        n_test_trials,
+        shrinkage_alpha=quota_strength,
+    )
+
+
 def _uniform_class_quotas(n_classes: int, n_test_trials: int) -> np.ndarray:
     n_classes = int(n_classes)
     n_test_trials = int(n_test_trials)
@@ -1846,6 +2052,9 @@ def _postprocess_predictions(
     validation_labels: np.ndarray | None = None,
 ) -> tuple[np.ndarray, dict]:
     method = str(config.prediction_postprocessing or "none")
+    scores = np.asarray(scores, dtype=float)
+    classes = np.asarray(classes, dtype=int)
+    source_labels = np.asarray(source_labels, dtype=int)
     argmax_labels = classes[np.argmax(scores, axis=1)]
     base_metadata = {
         "prediction_postprocessing_quota_source": "none",
@@ -1855,6 +2064,8 @@ def _postprocess_predictions(
         "prediction_postprocessing_uncalibrated_validation_balanced_accuracy": np.nan,
         "prediction_postprocessing_validation_objective_delta": np.nan,
         "prediction_postprocessing_guard_tolerance": float(config.prediction_postprocessing_guard_tolerance),
+        "prediction_postprocessing_quota_strength": float(config.prediction_postprocessing_quota_strength),
+        "prediction_postprocessing_apply": False,
         "prediction_postprocessing_shrinkage_alpha": np.nan,
         "prediction_postprocessing_shrinkage_alphas": ";".join(str(float(alpha)) for alpha in config.prediction_postprocessing_shrinkage_alphas),
     }
@@ -1865,19 +2076,31 @@ def _postprocess_predictions(
         }
     supported = {
         "source_prior_balanced_assignment",
+        "source_prior_soft_balanced_assignment",
         "validation_guarded_source_prior_balanced_assignment",
+        "validation_guarded_source_prior_soft_balanced_assignment",
         "validation_guarded_shrunk_source_prior_balanced_assignment",
     }
     if method not in supported:
         raise ValueError(
             "prediction_postprocessing must be one of: none, source_prior_balanced_assignment, "
-            "validation_guarded_source_prior_balanced_assignment, "
+            "source_prior_soft_balanced_assignment, validation_guarded_source_prior_balanced_assignment, "
+            "validation_guarded_source_prior_soft_balanced_assignment, "
             "validation_guarded_shrunk_source_prior_balanced_assignment"
         )
 
+    soft_quota_methods = {
+        "source_prior_soft_balanced_assignment",
+        "validation_guarded_source_prior_soft_balanced_assignment",
+    }
+    guarded_methods = {
+        "validation_guarded_source_prior_balanced_assignment",
+        "validation_guarded_source_prior_soft_balanced_assignment",
+        "validation_guarded_shrunk_source_prior_balanced_assignment",
+    }
     validation_metadata = dict(base_metadata)
     selected_shrinkage_alpha = 1.0
-    if method in {"validation_guarded_source_prior_balanced_assignment", "validation_guarded_shrunk_source_prior_balanced_assignment"}:
+    if method in guarded_methods:
         if validation_scores is None or validation_labels is None or len(validation_labels) == 0:
             return argmax_labels, {
                 **validation_metadata,
@@ -1918,7 +2141,16 @@ def _postprocess_predictions(
             validation_balanced, validation_objective_delta, selected_shrinkage_alpha, validation_assigned, validation_quotas = candidate_rows[0]
             validation_metadata["prediction_postprocessing_shrinkage_alpha"] = float(selected_shrinkage_alpha)
         else:
-            validation_quotas = _source_prior_class_quotas(source_labels, classes, int(validation_scores.shape[0]))
+            if method in soft_quota_methods:
+                validation_quotas = _blended_source_prior_class_quotas(
+                    validation_argmax,
+                    source_labels,
+                    classes,
+                    int(validation_scores.shape[0]),
+                    quota_strength=config.prediction_postprocessing_quota_strength,
+                )
+            else:
+                validation_quotas = _source_prior_class_quotas(source_labels, classes, int(validation_scores.shape[0]))
             validation_assigned, validation_objective_delta = _balanced_assignment_predictions(
                 validation_scores,
                 classes,
@@ -1940,7 +2172,16 @@ def _postprocess_predictions(
                 "prediction_postprocessing_status": "guard_rejected",
             }
 
-    if method == "validation_guarded_shrunk_source_prior_balanced_assignment":
+    if method in soft_quota_methods:
+        quotas = _blended_source_prior_class_quotas(
+            argmax_labels,
+            source_labels,
+            classes,
+            int(scores.shape[0]),
+            quota_strength=config.prediction_postprocessing_quota_strength,
+        )
+        quota_source = "argmax_source_prior_blend"
+    elif method == "validation_guarded_shrunk_source_prior_balanced_assignment":
         quotas = _shrunk_source_prior_class_quotas(
             source_labels,
             argmax_labels,
@@ -1960,6 +2201,7 @@ def _postprocess_predictions(
         "prediction_postprocessing_quota_source": quota_source,
         "prediction_postprocessing_class_quota_counts": _format_counter(quota_counts),
         "prediction_postprocessing_objective_delta": float(objective_delta),
+        "prediction_postprocessing_apply": True,
     }
 
 
@@ -2221,6 +2463,15 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         help="Cross-entropy label smoothing for latent AE training; useful for reducing overconfident class collapse.",
     )
     parser.add_argument(
+        "--focal-loss-gamma",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional focal-loss gamma for latent AE classification. 0 preserves the existing "
+            "class-balanced cross-entropy; try 1.0 or 2.0 to emphasize hard source trials/classes."
+        ),
+    )
+    parser.add_argument(
         "--supervised-contrastive-weight",
         type=float,
         default=0.0,
@@ -2302,11 +2553,15 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
             "validation_prediction_bias",
             "validation_argmax_class_bias",
             "validation_argmax_class_bias_guarded",
+            "validation_temperature_class_bias_guarded",
+            "validation_temperature_argmax_class_bias_guarded",
             "validation_confusion_blend",
             "validation_logistic_stack",
             "validation_logistic_stack_guarded",
             "validation_vector_bias",
             "validation_vector_bias_guarded",
+            "validation_class_zscore",
+            "validation_class_zscore_guarded",
             "validation_score_standardize",
             "validation_score_standardize_guarded",
         ),
@@ -2324,6 +2579,12 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         type=_parse_float_sequence,
         default=(0.03, 0.1, 0.3, 1.0),
         help="Candidate inverse-regularization strengths for validation_logistic_stack calibration.",
+    )
+    parser.add_argument(
+        "--score-calibration-temperatures",
+        type=_parse_float_sequence,
+        default=(0.5, 0.75, 1.0, 1.5, 2.0, 3.0),
+        help="Candidate logit temperatures for validation_temperature_* score calibration.",
     )
     parser.add_argument("--score-calibration-smoothing", type=float, default=1.0)
     parser.add_argument(
@@ -2382,13 +2643,16 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         choices=(
             "none",
             "source_prior_balanced_assignment",
+            "source_prior_soft_balanced_assignment",
             "validation_guarded_source_prior_balanced_assignment",
+            "validation_guarded_source_prior_soft_balanced_assignment",
             "validation_guarded_shrunk_source_prior_balanced_assignment",
         ),
         default="none",
         help=(
-            "Optional source-prior balanced assignment over the held-out batch. "
-            "The validation_guarded variant applies it only when source validation does not regress."
+            "Optional source-prior quota assignment over the held-out batch. "
+            "Soft variants blend argmax counts with the source prior; validation_guarded variants "
+            "apply the assignment only when source validation does not regress."
         ),
     )
     parser.add_argument(
@@ -2405,6 +2669,16 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         type=float,
         default=0.0,
         help="Allowed validation balanced-accuracy drop for validation_guarded_source_prior_balanced_assignment.",
+    )
+    parser.add_argument(
+        "--prediction-postprocessing-quota-strength",
+        type=float,
+        default=1.0,
+        help=(
+            "Blend strength for source_prior_soft_balanced_assignment. 0 keeps the model's argmax "
+            "prediction counts, 1 uses exact source-prior quotas, and intermediate values partially "
+            "correct class-collapse while avoiding a fully forced balanced assignment."
+        ),
     )
     parser.add_argument("--device", default="auto", help="auto, cpu, cuda, or another torch device string.")
     parser.add_argument("--num-threads", type=int, default=1)
@@ -2435,6 +2709,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         prediction_balance_weight=args.prediction_balance_weight,
         prediction_balance_target_smoothing=args.prediction_balance_target_smoothing,
         label_smoothing=args.label_smoothing,
+        focal_loss_gamma=args.focal_loss_gamma,
         supervised_contrastive_weight=args.supervised_contrastive_weight,
         supervised_contrastive_temperature=args.supervised_contrastive_temperature,
         balanced_batch_sampling=bool(args.balanced_batch_sampling),
@@ -2457,6 +2732,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         label_shuffle_seed=args.label_shuffle_seed,
         score_calibration=args.score_calibration,
         score_calibration_alphas=args.score_calibration_alphas,
+        score_calibration_temperatures=args.score_calibration_temperatures,
         score_calibration_logistic_c_values=args.score_calibration_logistic_c_values,
         score_calibration_smoothing=args.score_calibration_smoothing,
         score_calibration_confusion_smoothing=args.score_calibration_confusion_smoothing,
@@ -2467,6 +2743,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         score_calibration_vector_l2=args.score_calibration_vector_l2,
         prediction_postprocessing=args.prediction_postprocessing,
         prediction_postprocessing_guard_tolerance=args.prediction_postprocessing_guard_tolerance,
+        prediction_postprocessing_quota_strength=args.prediction_postprocessing_quota_strength,
         prediction_postprocessing_shrinkage_alphas=args.prediction_postprocessing_shrinkage_alphas,
         device=args.device,
         num_threads=args.num_threads,

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -24,6 +24,21 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         np.testing.assert_allclose(feature, np.concatenate((tapered, pyramid)))
         self.assertTrue(np.all(np.isfinite(feature)))
 
+    def test_sensor_flat_gaussian_taper_delta2_feature_is_exported(self):
+        mode = "sensor_flat_gaussian_taper_delta2"
+
+        self.assertEqual(cross_subject._normalize_feature_mode(mode), mode)  # pylint: disable=protected-access
+
+        signal = np.arange(18, dtype=float).reshape(3, 6)
+        feature = next_hooks._sensor_flat_gaussian_taper_delta2_feature(signal)  # pylint: disable=protected-access
+        tapered = next_hooks._sensor_flat_gaussian_taper_feature(signal)  # pylint: disable=protected-access
+        delta = np.diff(signal, axis=1).reshape(-1, order="F")
+        delta2 = np.diff(signal, n=2, axis=1).reshape(-1, order="F")
+
+        self.assertEqual(feature.shape, (3 * (6 + 5 + 4),))
+        np.testing.assert_allclose(feature, np.concatenate((tapered, delta, delta2)))
+        self.assertTrue(np.all(np.isfinite(feature)))
+
     def test_soft_guarded_inner_confusion_score_normalizations_are_exported(self):
         mode = "rank_softmax_t2_inner_confusion_soft_guarded"
 
@@ -202,6 +217,48 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertEqual(confident[0, 3], 0.0)
         self.assertEqual(ambiguous[0, 3], 0.0)
         self.assertGreater(confident[0, 0], ambiguous[0, 0])
+
+    def test_adaptive_topk_score_softmax_switches_support_by_margin(self):
+        mode = "rank_adaptive_topk_score_softmax"
+        guarded_mode = f"{mode}_inner_confusion_soft_guarded"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertIn(guarded_mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            mode,
+        )
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(guarded_mode),  # pylint: disable=protected-access
+            mode,
+        )
+
+        confident_scores = np.asarray([[6.0, 1.0, 0.0, -1.0]], dtype=float)
+        ambiguous_scores = np.asarray([[3.0, 2.9, 2.8, 0.0]], dtype=float)
+        confident = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            confident_scores,
+            score_normalization=mode,
+        )
+        ambiguous = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            ambiguous_scores,
+            score_normalization=mode,
+        )
+
+        np.testing.assert_allclose(np.sum(confident, axis=1), np.ones(1))
+        np.testing.assert_allclose(np.sum(ambiguous, axis=1), np.ones(1))
+        self.assertEqual(np.count_nonzero(confident[0]), 2)
+        self.assertEqual(np.count_nonzero(ambiguous[0]), 3)
+        self.assertEqual(confident[0, 2], 0.0)
+        self.assertEqual(ambiguous[0, 3], 0.0)
+
+        metadata = cross_subject._inner_confusion_correction_metadata(  # pylint: disable=protected-access
+            [{"selected_inner_true_predicted_label_pair_counts": "1001:4;1002:2;2002:5"}],
+            np.arange(2, dtype=int),
+            np.ones(1, dtype=float),
+            guarded_mode,
+        )
+        self.assertEqual(metadata["inner_mode"], guarded_mode)
+        self.assertTrue(metadata["guarded"])
 
     def test_topk_score_borda_blend_modes_are_exported_and_margin_gated(self):
         mode = "rank_top3_score_borda_blend"

--- a/tests/test_stimulus_latent_autoencoder_controls.py
+++ b/tests/test_stimulus_latent_autoencoder_controls.py
@@ -8,6 +8,7 @@ import numpy as np
 from pymegdec.stimulus_latent_autoencoder import (
     LatentAutoencoderConfig,
     _balanced_epoch_indices,
+    _class_balanced_focal_cross_entropy,
     _effective_ensemble_seeds,
     _final_refit_epochs,
     _gradient_reverse,
@@ -137,6 +138,60 @@ def test_balanced_epoch_indices_interleaves_classes_and_preserves_rows():
     assert np.bincount(labels[order], minlength=3).tolist() == [5, 3, 4]
 
 
+def test_guarded_source_prior_assignment_policy_uses_source_validation_gain():
+    classes = np.asarray([1, 2, 3, 4])
+    source_labels = np.asarray([1, 1, 2, 2, 3, 3, 4, 4])
+    validation_labels = np.asarray([1, 2, 3, 4])
+    # Argmax collapses onto classes 1 and 3, but a one-per-class assignment
+    # recovers the full validation label set from the second-best scores.
+    validation_scores = np.asarray(
+        [
+            [4.0, 3.0, 0.0, 0.0],
+            [4.0, 3.5, 0.0, 0.0],
+            [0.0, 0.0, 4.0, 3.0],
+            [0.0, 0.0, 4.0, 3.5],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        prediction_postprocessing="validation_guarded_source_prior_balanced_assignment"
+    )
+
+    _predicted, metadata = _postprocess_predictions(
+        validation_scores,
+        classes,
+        source_labels,
+        config,
+        validation_scores=validation_scores,
+        validation_labels=validation_labels,
+    )
+
+    assert metadata["prediction_postprocessing_status"] == "ok"
+    assert metadata["prediction_postprocessing_apply"] is True
+    assert metadata["prediction_postprocessing_validation_balanced_accuracy"] > metadata[
+        "prediction_postprocessing_uncalibrated_validation_balanced_accuracy"
+    ]
+
+
+def test_guarded_source_prior_assignment_falls_back_without_validation_support():
+    classes = np.asarray([1, 2, 3, 4])
+    scores = np.asarray([[4.0, 3.0, 0.0, 0.0], [4.0, 3.5, 0.0, 0.0]])
+    source_labels = np.asarray([1, 1, 2, 2, 3, 3, 4, 4])
+    config = LatentAutoencoderConfig(
+        prediction_postprocessing="validation_guarded_source_prior_balanced_assignment"
+    )
+
+    predictions, metadata = _postprocess_predictions(
+        scores,
+        classes,
+        source_labels,
+        config,
+    )
+
+    assert predictions.tolist() == [1, 1]
+    assert metadata["prediction_postprocessing_status"] == "no_validation"
+    assert metadata["prediction_postprocessing_apply"] is False
+
+
 def test_gradient_reverse_flips_and_scales_gradient_when_torch_is_available():
     torch = _import_torch_or_skip()
     value = torch.tensor([1.0, -2.0], requires_grad=True)
@@ -145,6 +200,44 @@ def test_gradient_reverse_flips_and_scales_gradient_when_torch_is_available():
     reversed_value.sum().backward()
 
     assert torch.allclose(value.grad, torch.tensor([-0.25, -0.25]))
+
+
+def test_focal_loss_gamma_zero_matches_weighted_cross_entropy_when_torch_is_available():
+    torch = _import_torch_or_skip()
+    logits = torch.tensor(
+        [
+            [3.0, 0.0, -1.0],
+            [0.0, 2.0, -1.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=torch.float32,
+    )
+    targets = torch.tensor([0, 1, 2], dtype=torch.long)
+    weight = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32)
+
+    focal = _class_balanced_focal_cross_entropy(
+        logits,
+        targets,
+        weight=weight,
+        label_smoothing=0.0,
+        focal_gamma=0.0,
+    )
+    expected = torch.nn.functional.cross_entropy(logits, targets, weight=weight)
+
+    assert torch.allclose(focal, expected)
+
+
+def test_positive_focal_loss_gamma_downweights_easy_examples_when_torch_is_available():
+    torch = _import_torch_or_skip()
+    logits = torch.tensor([[8.0, -4.0], [0.2, 0.0]], dtype=torch.float32)
+    targets = torch.tensor([0, 0], dtype=torch.long)
+    weight = torch.ones(2, dtype=torch.float32)
+
+    ce = _class_balanced_focal_cross_entropy(logits, targets, weight=weight, label_smoothing=0.0, focal_gamma=0.0)
+    focal = _class_balanced_focal_cross_entropy(logits, targets, weight=weight, label_smoothing=0.0, focal_gamma=2.0)
+
+    assert torch.isfinite(focal)
+    assert focal < ce
 
 
 def test_latent_model_maps_sparse_participant_ids_for_subject_adversary_when_torch_is_available():

--- a/tests/test_stimulus_latent_autoencoder_postprocessing.py
+++ b/tests/test_stimulus_latent_autoencoder_postprocessing.py
@@ -3,6 +3,7 @@ import numpy as np
 from pymegdec.stimulus_latent_autoencoder import (
     LatentAutoencoderConfig,
     _balanced_assignment_predictions,
+    _blended_source_prior_class_quotas,
     _display_label_map,
     _postprocess_predictions,
     _shrunk_source_prior_class_quotas,
@@ -86,6 +87,54 @@ def test_shrunk_source_prior_class_quotas_interpolate_argmax_and_source_prior():
 
     assert argmax_quotas.tolist() == [4, 2, 1, 1]
     assert source_quotas.tolist() == [2, 2, 2, 2]
+
+
+def test_blended_source_prior_class_quotas_match_shrunk_prior_helper():
+    classes = np.asarray([1, 2, 3, 4])
+    source_labels = np.repeat(classes, 10)
+    predicted_labels = np.asarray([1, 1, 1, 1, 2, 2, 3, 4])
+
+    blended = _blended_source_prior_class_quotas(
+        predicted_labels,
+        source_labels,
+        classes,
+        n_test_trials=8,
+        quota_strength=0.5,
+    )
+    shrunk = _shrunk_source_prior_class_quotas(
+        source_labels,
+        predicted_labels,
+        classes,
+        n_test_trials=8,
+        shrinkage_alpha=0.5,
+    )
+
+    assert blended.tolist() == shrunk.tolist()
+
+
+def test_postprocess_predictions_soft_balanced_assignment_uses_blended_quotas():
+    classes = np.asarray([1, 2, 3, 4])
+    source_labels = np.repeat(classes, 12)
+    scores = np.asarray(
+        [
+            [5.0, 4.0, 0.0, 0.0],
+            [4.9, 4.8, 0.0, 0.0],
+            [4.7, 0.0, 5.0, 0.0],
+            [4.6, 0.0, 0.0, 5.0],
+        ]
+    )
+    predictions, metadata = _postprocess_predictions(
+        scores,
+        classes,
+        source_labels,
+        LatentAutoencoderConfig(
+            prediction_postprocessing="source_prior_soft_balanced_assignment",
+            prediction_postprocessing_quota_strength=0.75,
+        ),
+    )
+    assert sorted(predictions.tolist()) == [1, 2, 3, 4]
+    assert metadata["prediction_postprocessing_status"] == "ok"
+    assert metadata["prediction_postprocessing_quota_source"] == "argmax_source_prior_blend"
 
 
 def test_postprocess_predictions_validation_guarded_shrunk_assignment_selects_partial_alpha():

--- a/tests/test_stimulus_latent_autoencoder_score_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_score_calibration.py
@@ -151,6 +151,72 @@ def test_guarded_validation_argmax_class_bias_uses_argmax_prior_without_balanced
     assert len(set(calibrated_predictions.tolist())) > len(set(uncalibrated_predictions.tolist()))
 
 
+def test_temperature_argmax_class_bias_jointly_tunes_logit_scale_and_bias():
+    classes = np.asarray([1, 2, 3])
+    labels = np.asarray([1, 1, 2, 2, 3, 3])
+    scores = np.asarray(
+        [
+            [3.0, 0.0, 0.0],
+            [2.8, 0.0, 0.0],
+            [1.6, 1.5, 0.0],
+            [1.6, 1.4, 0.0],
+            [1.6, 0.0, 1.5],
+            [1.6, 0.0, 1.4],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_temperature_argmax_class_bias_guarded",
+        score_calibration_alphas=(0.0, 0.5, 1.0, 2.0),
+        score_calibration_temperatures=(0.5, 1.0, 2.0, 4.0),
+        score_calibration_smoothing=0.1,
+        score_calibration_selection_metric="balanced_top2_top3_rank_balance",
+        score_calibration_guard_tolerance=0.0,
+    )
+
+    calibration, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
+    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, calibration), axis=1)]
+
+    assert metadata["score_calibration_status"] == "ok"
+    assert metadata["score_calibration_predicted_prior_source"] == "argmax"
+    assert metadata["score_calibration_temperature"] in config.score_calibration_temperatures
+    assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
+    assert len(set(calibrated_predictions.tolist())) > len(set(uncalibrated_predictions.tolist()))
+
+
+def test_validation_class_zscore_calibration_removes_logit_scale_collapse():
+    classes = np.asarray([1, 2, 3])
+    labels = np.asarray([1, 1, 2, 2, 3, 3])
+    scores = np.asarray(
+        [
+            [1.0, 0.0, 5.0],
+            [1.1, 0.0, 5.1],
+            [0.0, 1.0, 5.2],
+            [0.0, 1.1, 5.3],
+            [0.0, 0.0, 5.5],
+            [0.0, 0.0, 5.6],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_class_zscore",
+        score_calibration_alphas=(0.0, 1.0),
+        score_calibration_selection_metric="balanced_accuracy",
+    )
+
+    calibration, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
+    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, calibration), axis=1)]
+
+    assert metadata["score_calibration_status"] == "ok"
+    assert metadata["score_calibration_prior_source"] == "validation_score_distribution"
+    assert metadata["score_calibration_predicted_prior_source"] == "class_zscore"
+    assert metadata["score_calibration_alpha"] == 1.0
+    assert np.unique(uncalibrated_predictions).tolist() == [3]
+    assert calibrated_predictions.tolist() == labels.tolist()
+    assert metadata["score_calibration_validation_balanced_accuracy"] > metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
+    assert metadata["score_calibration_scale_min"] > 0.0
+
+
 def test_guarded_validation_vector_bias_can_fix_multiple_collapsed_classes():
     classes = np.asarray([1, 2, 3])
     labels = np.asarray([1, 1, 2, 2, 3, 3])


### PR DESCRIPTION
## Summary
- add BUSH w150 adaptive top-k score-softmax and Gaussian taper workflow options
- extend latent AE scoring with z-score, temperature-bias, focal loss, and soft/guarded quota postprocessing controls
- add focused coverage for the new control paths

## Verification
- Did not run tests per request.
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_cross_subject_next.py tests\test_stimulus_latent_autoencoder_controls.py tests\test_stimulus_latent_autoencoder_postprocessing.py tests\test_stimulus_latent_autoencoder_score_calibration.py`
- YAML parse for `.github/workflows/stimulus-cross-subject-nested-matrix.yml` and `.github/workflows/stimulus-latent-autoencoder.yml`
- `git diff --check`