### PR TITLE
Default latent validation source selection to rotating

### DIFF
--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -74,6 +74,18 @@ on:
         required: true
         default: "0.0"
         type: string
+      validation_source_strategy:
+        description: Source-validation participant selection for early stopping/calibration.
+        required: true
+        default: rotating
+        type: choice
+        options:
+          # Rotate by held-out participant so full LOSO runs do not always early-stop
+          # on the same two source subjects.
+          - rotating
+          - spread
+          - tail
+          - head
       balanced_batch_sampling:
         description: Interleave classes within training epochs so minibatches are class-diverse.
         required: true
@@ -216,6 +228,7 @@ jobs:
             --epochs "${{ inputs.epochs }}"
             --batch-size 256
             --validation-source-count 2
+            --validation-source-strategy "${{ inputs.validation_source_strategy }}"
             --patience 12
             --device cpu
             --num-threads 1

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -44,6 +44,7 @@ DEFAULT_LATENT_COMPONENTS_PCA = 160
 DEFAULT_LATENT_DIM = 64
 DEFAULT_LATENT_HIDDEN_DIM = 128
 DEFAULT_LATENT_RECONSTRUCTION_WEIGHT = 0.03
+DEFAULT_LATENT_VALIDATION_SOURCE_STRATEGY = "rotating"
 
 
 @dataclass(frozen=True)
@@ -73,7 +74,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     learning_rate: float = 1e-3
     weight_decay: float = 1e-4
     validation_source_count: int = 2
-    validation_source_strategy: str = "tail"
+    validation_source_strategy: str = DEFAULT_LATENT_VALIDATION_SOURCE_STRATEGY
     validation_selection_metric: str = "balanced_accuracy"
     patience: int = 12
     refit_all_sources: bool = True
@@ -1751,8 +1752,12 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument(
         "--validation-source-strategy",
         choices=("tail", "head", "spread", "rotating"),
-        default="tail",
-        help="How to choose source participants for early stopping/calibration validation.",
+        default=DEFAULT_LATENT_VALIDATION_SOURCE_STRATEGY,
+        help=(
+            "How to choose source participants for early stopping/calibration validation. "
+            "The default rotates with the held-out participant so a full LOSO run "
+            "does not always early-stop on the same source subjects."
+        ),
     )
     parser.add_argument(
         "--validation-selection-metric",

--- a/tests/test_stimulus_latent_autoencoder_controls.py
+++ b/tests/test_stimulus_latent_autoencoder_controls.py
@@ -28,6 +28,10 @@ def _import_torch_or_skip():
     return torch
 
 
+def test_latent_config_defaults_to_rotating_validation_sources():
+    assert LatentAutoencoderConfig().validation_source_strategy == "rotating"
+
+
 def test_split_source_participants_spread_does_not_always_take_tail():
     train, validation = _split_source_participants(tuple(range(1, 11)), 2, strategy="spread")
 


### PR DESCRIPTION
## Summary
- default latent AE validation source selection to rotating
- expose the validation source strategy workflow input
- add focused coverage for the new default

## Verification
- Did not run tests per request.
- `python -m py_compile src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_latent_autoencoder_controls.py`
- YAML parse for `.github/workflows/stimulus-latent-autoencoder.yml`
- `git diff --check`