### PR TITLE
Use per-trial time axes for extended BUSH features

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -27,7 +27,8 @@
     "tests/test_stimulus_cross_subject.py",
     "tests/test_stimulus_cross_subject_next.py",
     "tests/test_stimulus_decoding.py",
-    "tests/test_stimulus_full_epoch_lowrank.py"
+    "tests/test_stimulus_full_epoch_lowrank.py",
+    "tests/test_time_axis_handling.py"
   ],
   "threshold": 2.0
 }

--- a/src/pymegdec/_stimulus_cross_subject_legacy.py
+++ b/src/pymegdec/_stimulus_cross_subject_legacy.py
@@ -48,6 +48,7 @@ DEFAULT_CROSS_SUBJECT_CLASSIFIER = "multiclass-svm"
 DEFAULT_CROSS_SUBJECT_COMPONENTS_PCA = 64
 DEFAULT_CROSS_SUBJECT_NESTED_WINDOW_CENTERS = (0.150, 0.175, 0.200)
 DEFAULT_CROSS_SUBJECT_SELECTION_METRIC = "balanced_accuracy"
+DEFAULT_SENSOR_FLAT_TAPER_FLOOR = 0.25
 CROSS_SUBJECT_SELECTION_METRIC_CHOICES = (
     "balanced_accuracy",
     "balanced_accuracy_lcb",
@@ -3915,6 +3916,21 @@ def _sensor_mean_slope_std_feature(window_signal, window_time):
     slopes = _sensor_window_slopes(window_signal, window_time, means)
     stds = np.std(window_signal, axis=1)
     return np.concatenate((means, slopes, stds))
+
+
+def _sensor_flat_taper_weights(n_samples, floor=DEFAULT_SENSOR_FLAT_TAPER_FLOOR):
+    """Return a smooth nonzero temporal taper for flattened evoked samples."""
+
+    n_samples = int(n_samples)
+    if n_samples <= 0:
+        raise ValueError("sensor_flat_taper requires at least one time sample.")
+    if n_samples == 1:
+        return np.ones(1, dtype=float)
+
+    floor = float(floor)
+    if not 0.0 <= floor <= 1.0:
+        raise ValueError("DEFAULT_SENSOR_FLAT_TAPER_FLOOR must be in [0, 1].")
+    return floor + (1.0 - floor) * np.hanning(n_samples)
 
 
 def _sensor_temporal_pyramid_feature(window_signal):

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -15,6 +15,7 @@ from itertools import product
 from math import isfinite
 
 import numpy as np
+from pymegdec import _stimulus_cross_subject_timefix as _timefix
 from pymegdec.classifiers import get_default_classifier_param, should_use_default_classifier_param, train_multiclass_classifier
 
 DEFAULT_CROSS_SUBJECT_SAMPLE_WEIGHTING = "none"
@@ -2532,12 +2533,11 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
     if feature_mode not in EXTENDED_FEATURE_MODES:
         return _previous_extract_window_features(data, time_window, feature_mode=feature_mode, trial_indices=trial_indices)
 
-    time_vector = _impl._time_vector(data, 0)
-    mask = _impl._time_mask(time_vector, time_window)
-    window_time = time_vector[mask]
     features = []
-    for trial_idx in _impl._iter_trial_indices(data, trial_indices):
-        signal = _impl._trial_signal(data, trial_idx)[:, mask]
+    n_window_samples = None
+    for _trial_idx, window_time, signal, n_window_samples in _iter_window_signal_blocks(
+        data, time_window, trial_indices, window_name="time_window"
+    ):
         if feature_mode == "sensor_logpower":
             feature = _sensor_logpower_feature(signal)
         elif feature_mode == "sensor_flat_logpower":
@@ -2588,7 +2588,32 @@ def _extract_window_features(data, time_window, *, feature_mode, trial_indices=N
         else:
             raise ValueError(f"Unsupported feature_mode: {feature_mode}")
         features.append(feature)
-    return np.vstack(features), int(np.sum(mask))
+    if n_window_samples is None:
+        raise ValueError("No trials were selected for window feature extraction.")
+    return np.vstack(features), int(n_window_samples)
+
+
+def _iter_window_signal_blocks(data, time_window, trial_indices, *, window_name):
+    """Yield per-trial channel x time blocks using each trial's own time axis.
+
+    The base extractor was fixed in ``_stimulus_cross_subject_timefix`` to avoid
+    applying trial 0's time mask to every trial.  Extended feature modes must use
+    the same per-trial masking; otherwise shifted or non-identical time vectors
+    can silently select the wrong samples for source-only BUSH-MEG features.
+    """
+
+    n_window_samples = None
+    for trial_idx in _impl._iter_trial_indices(data, trial_indices):
+        time_vector = _timefix._validated_trial_time_vector(data, trial_idx)
+        signal = _timefix._validated_trial_signal(data, trial_idx, time_vector)
+        mask = _timefix._time_mask_for_trial(time_vector, time_window, trial_idx)
+        n_window_samples = _timefix._require_consistent_sample_count(
+            int(np.sum(mask)),
+            n_window_samples,
+            trial_idx,
+            window_name,
+        )
+        yield int(trial_idx), time_vector[mask], signal[:, mask], int(n_window_samples)
 
 
 def _sensor_logpower_feature(window_signal):
@@ -3163,11 +3188,10 @@ def _sensor_flat_delta_baseline_statistics(data, config, n_window_samples, trial
         config.baseline_window,
         trial_indices,
     )
-    time_vector = _impl._time_vector(data, 0)
-    mask = _impl._time_mask(time_vector, config.baseline_window)
     delta_blocks = []
-    for trial_idx in _impl._iter_trial_indices(data, trial_indices):
-        signal = _impl._trial_signal(data, trial_idx)[:, mask]
+    for _trial_idx, _window_time, signal, _sample_count in _iter_window_signal_blocks(
+        data, config.baseline_window, trial_indices, window_name="baseline_window"
+    ):
         if signal.shape[1] >= 2:
             delta_blocks.append(np.diff(signal, axis=1))
 
@@ -3198,12 +3222,11 @@ def _sensor_flat_delta2_baseline_statistics(data, config, n_window_samples, tria
         config.baseline_window,
         trial_indices,
     )
-    time_vector = _impl._time_vector(data, 0)
-    mask = _impl._time_mask(time_vector, config.baseline_window)
     first_delta_blocks = []
     second_delta_blocks = []
-    for trial_idx in _impl._iter_trial_indices(data, trial_indices):
-        signal = _impl._trial_signal(data, trial_idx)[:, mask]
+    for _trial_idx, _window_time, signal, _sample_count in _iter_window_signal_blocks(
+        data, config.baseline_window, trial_indices, window_name="baseline_window"
+    ):
         if signal.shape[1] >= 2:
             first_delta_blocks.append(np.diff(signal, axis=1))
         if signal.shape[1] >= 3:

--- a/tests/test_time_axis_handling.py
+++ b/tests/test_time_axis_handling.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import numpy as np
 from pymegdec.preprocessing import downsample_data, extract_windows
+from pymegdec import stimulus_cross_subject as cross_subject
 from pymegdec.stimulus_cross_subject import CrossSubjectStimulusConfig, load_participant_stimulus_features
 from tests.matlab_fixtures import cell_array
 
@@ -85,6 +86,53 @@ class TestTimeAxisHandling(unittest.TestCase):
 
         np.testing.assert_allclose(feature_set.features.ravel(), [2.0, 13.0])
         self.assertEqual(feature_set.n_window_samples, 3)
+
+    def test_extended_cross_subject_features_use_each_trial_time_vector(self):
+        first_time = np.array([-0.2, -0.1, 0.0, 0.1, 0.2], dtype=float)
+        second_time = np.array([-0.3, -0.2, -0.1, 0.0, 0.1, 0.2], dtype=float)
+        first_trial = np.array([[0, 1, 2, 3, 4]], dtype=float)
+        second_trial = np.array([[10, 11, 12, 13, 14, 15]], dtype=float)
+        data_by_participant = {1: _mat_data([1, 2], [first_trial, second_trial], [first_time, second_time])}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.0,
+            window_size=0.2,
+            feature_mode="sensor_flat_taper",
+            normalization="none",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        taper = cross_subject._sensor_flat_taper_weights(3)  # pylint: disable=protected-access
+        np.testing.assert_allclose(feature_set.features[0], np.asarray([1.0, 2.0, 3.0]) * taper)
+        np.testing.assert_allclose(feature_set.features[1], np.asarray([12.0, 13.0, 14.0]) * taper)
+        self.assertEqual(feature_set.n_window_samples, 3)
+
+    def test_extended_delta_baseline_statistics_use_each_trial_time_vector(self):
+        first_time = np.array([-0.2, -0.1, 0.0, 0.1, 0.2], dtype=float)
+        second_time = np.array([-0.3, -0.2, -0.1, 0.0, 0.1, 0.2], dtype=float)
+        first_trial = np.array([[0, 1, 2, 3, 4]], dtype=float)
+        second_trial = np.array([[10, 11, 12, 13, 14, 15]], dtype=float)
+        data_by_participant = {1: _mat_data([1, 2], [first_trial, second_trial], [first_time, second_time])}
+        config = CrossSubjectStimulusConfig(
+            window_center=0.0,
+            window_size=0.2,
+            baseline_window=(-0.1, 0.1),
+            feature_mode="sensor_flat_delta",
+            normalization="subject_baseline_z",
+            components_pca=float("inf"),
+            chance_classes=2,
+        )
+
+        with patch("pymegdec.stimulus_cross_subject.sio.loadmat", side_effect=_loadmat_side_effect(data_by_participant)):
+            feature_set = load_participant_stimulus_features("unused", 1, config=config)
+
+        # The selected baseline samples are [1, 2, 3] and [12, 13, 14].  Applying
+        # trial 0's mask to trial 2 would silently select [11, 12, 13] instead.
+        np.testing.assert_allclose(feature_set.baseline_feature_mean.ravel(), [7.5, 7.5, 7.5, 1.0, 1.0])
+        self.assertEqual(feature_set.n_baseline_samples, 3)
 
     def test_legacy_cross_subject_extractors_use_each_trial_time_vector_without_public_shim(self):
         """Guard the implementation path, not only the public facade import."""


### PR DESCRIPTION
## Summary
- route extended BUSH feature extraction through per-trial time-axis validation
- use per-trial masking for extended baseline delta statistics
- add focused coverage for shifted trial time vectors

## Verification
- Did not run tests per request.
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py tests\test_time_axis_handling.py`
- `git diff --check`