### PR TITLE
Add latent score calibration and reciprocal ranking options

### DIFF
--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -169,6 +169,7 @@ on:
           - windowed_logreg_175_w150_top2_borda_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_top3_borda_soft_guarded_inner_confusion
           - windowed_logreg_175_w150_top2_margin_blend
+          - windowed_logreg_175_w150_top3_reciprocal
           - windowed_logreg_175_w150_top2_margin_recall_bias
           - windowed_logreg_175_w150_pca160_top3_score_softmax
           - windowed_logreg_175_w150_top2_gated_recall_bias
@@ -267,6 +268,8 @@ on:
           - rank_z_blend
           - rank_top2_borda
           - rank_top3_borda
+          - rank_top2_reciprocal
+          - rank_top3_reciprocal
           - rank_top2_margin_blend
           - rank_top2_score_softmax
           - rank_top3_score_softmax
@@ -3408,6 +3411,26 @@ jobs:
                   "selection_ensemble_size": "3",
                   "selection_ensemble_diversity": "none",
                   "selection_ensemble_score_normalization": "rank_top3_margin_blend",
+                  "selection_ensemble_weighting": "inner_lcb_softmax",
+                  "selection_ensemble_temperature": "0.02",
+              },
+              "windowed_logreg_175_w150_top3_reciprocal": {
+                  # Rank-only, leakage-safe top-k pooling for the current BUSH
+                  # w150 source-only branch.  It is sharper than top-3 Borda but
+                  # less score-scale-sensitive than top-3 score-softmax, aiming
+                  # at the observed top-3/top-1 gap without cue data or target
+                  # labels.
+                  "window_centers": "0.175",
+                  "window_size": "0.150",
+                  "feature_modes": "sensor_flat",
+                  "normalizations": "subject_baseline_whiten",
+                  "alignments": "none",
+                  "classifiers": "multinomial-logistic,multinomial-logistic-weighted",
+                  "classifier_params": "0.3,1",
+                  "components_pca_values": "128",
+                  "selection_ensemble_size": "3",
+                  "selection_ensemble_diversity": "none",
+                  "selection_ensemble_score_normalization": "rank_top3_reciprocal",
                   "selection_ensemble_weighting": "inner_lcb_softmax",
                   "selection_ensemble_temperature": "0.02",
               },

--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -167,6 +167,12 @@ on:
           - none
           - source_prior_balanced_assignment
           - validation_guarded_source_prior_balanced_assignment
+          - validation_guarded_shrunk_source_prior_balanced_assignment
+      prediction_postprocessing_shrinkage_alphas:
+        description: Candidate shrinkage strengths for guarded shrunk source-prior assignment.
+        required: true
+        default: "0,0.25,0.5,0.75,1"
+        type: string
       prediction_postprocessing_guard_tolerance:
         description: Allowed validation balanced-accuracy drop for guarded prediction postprocessing.
         required: true
@@ -239,6 +245,7 @@ jobs:
             --score-calibration-selection-metric "${{ inputs.score_calibration_selection_metric }}"
             --score-calibration-guard-tolerance "${{ inputs.score_calibration_guard_tolerance }}"
             --prediction-postprocessing "${{ inputs.prediction_postprocessing }}"
+            --prediction-postprocessing-shrinkage-alphas "${{ inputs.prediction_postprocessing_shrinkage_alphas }}"
             --prediction-postprocessing-guard-tolerance "${{ inputs.prediction_postprocessing_guard_tolerance }}"
             --seed 0
             --outer-output "outputs/${{ inputs.output_stem }}_outer.csv"

--- a/src/pymegdec/_stimulus_cross_subject_next.py
+++ b/src/pymegdec/_stimulus_cross_subject_next.py
@@ -258,6 +258,15 @@ TOPK_BORDA_SCORE_NORMALIZATIONS = {
     "rank_top2_borda": 2,
     "rank_top3_borda": 3,
 }
+TOPK_RECIPROCAL_SCORE_NORMALIZATIONS = {
+    # Sparse reciprocal-rank pooling is a compromise between truncated Borda
+    # and score-softmax: it ignores between-class score scale, but gives the
+    # top class a sharper advantage than Borda.  This is intended for BUSH-MEG
+    # w150 runs where top-2/top-3 accuracy is strong and top-1 re-ranking is the
+    # main bottleneck.
+    "rank_top2_reciprocal": 2,
+    "rank_top3_reciprocal": 3,
+}
 TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS = {
     "rank_top2_score_softmax": 2,
     "rank_top3_score_softmax": 3,
@@ -773,6 +782,7 @@ def install(impl) -> None:
     _install_guarded_quota_score_normalizations(impl)
     _install_guarded_test_prior_balance_score_normalizations(impl)
     _install_topk_borda_score_normalizations(impl)
+    _install_topk_reciprocal_score_normalizations(impl)
     _install_topk_score_softmax_score_normalizations(impl)
     _install_topk_score_softmax_balanced_quota_score_normalizations(impl)
     _install_topk_margin_blend_score_normalizations(impl)
@@ -931,6 +941,19 @@ def _install_topk_borda_score_normalizations(impl) -> None:
             (
                 *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
                 *TOPK_BORDA_SCORE_NORMALIZATIONS,
+            )
+        )
+    )
+
+
+def _install_topk_reciprocal_score_normalizations(impl) -> None:
+    """Expose sparse reciprocal-rank pooling for source-only score ensembles."""
+
+    impl.ENSEMBLE_SCORE_NORMALIZATION_MODES = tuple(
+        dict.fromkeys(
+            (
+                *impl.ENSEMBLE_SCORE_NORMALIZATION_MODES,
+                *TOPK_RECIPROCAL_SCORE_NORMALIZATIONS,
             )
         )
     )
@@ -1921,6 +1944,9 @@ def _class_score_probabilities(scores, *, score_normalization=None):
     top_k = TOPK_BORDA_SCORE_NORMALIZATIONS.get(base_mode)
     if top_k is not None:
         return _rank_topk_borda_probabilities(scores, top_k=top_k)
+    top_k = TOPK_RECIPROCAL_SCORE_NORMALIZATIONS.get(base_mode)
+    if top_k is not None:
+        return _rank_topk_reciprocal_probabilities(scores, top_k=top_k)
     top_k = TOPK_SCORE_SOFTMAX_SCORE_NORMALIZATIONS.get(base_mode)
     if top_k is not None:
         return _rank_topk_score_softmax_probabilities(scores, top_k=top_k)
@@ -2176,6 +2202,45 @@ def _rank_topk_borda_probabilities(scores, *, top_k):
         )[:k]
         weights = np.zeros(row.shape[0], dtype=float)
         weights[ordered_columns] = np.arange(k, 0, -1, dtype=float)
+        probabilities[row_index] = weights / np.sum(weights)
+    return probabilities
+
+
+def _rank_topk_reciprocal_probabilities(scores, *, top_k):
+    """Convert class scores to a sparse reciprocal-rank distribution.
+
+    Only the top-k classes receive nonzero probability.  Within that set, the
+    weights are 1 / rank, so the top class receives twice the mass of the second
+    class and three times the mass of the third.  This is more top-heavy than
+    truncated Borda but remains rank-only and therefore robust to classifier
+    score scale differences across selected source-only models.
+    """
+
+    scores = np.asarray(scores, dtype=float)
+    if scores.ndim != 2 or scores.shape[1] == 0:
+        raise ValueError(
+            "Nested score ensembling requires a non-empty two-dimensional "
+            "class-score matrix."
+        )
+    top_k = int(top_k)
+    if top_k < 1:
+        raise ValueError("top_k must be at least one.")
+
+    probabilities = np.empty_like(scores, dtype=float)
+    for row_index, row in enumerate(scores):
+        finite = np.isfinite(row)
+        n_finite = int(np.sum(finite))
+        if n_finite == 0:
+            probabilities[row_index] = np.full(
+                row.shape[0],
+                1.0 / row.shape[0],
+                dtype=float,
+            )
+            continue
+        k = min(top_k, n_finite)
+        ordered_columns = np.argsort(-np.where(finite, row, -np.inf), kind="mergesort")[:k]
+        weights = np.zeros(row.shape[0], dtype=float)
+        weights[ordered_columns] = 1.0 / (np.arange(k, dtype=float) + 1.0)
         probabilities[row_index] = weights / np.sum(weights)
     return probabilities
 

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -93,6 +93,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     score_calibration_guard_tolerance: float = 0.0
     prediction_postprocessing: str = "none"
     prediction_postprocessing_guard_tolerance: float = 0.0
+    prediction_postprocessing_shrinkage_alphas: tuple[float, ...] = (0.0, 0.25, 0.5, 0.75, 1.0)
     device: str = "auto"
     num_threads: int = 1
 
@@ -740,6 +741,8 @@ def _empty_score_calibration_metadata(config: LatentAutoencoderConfig, status: s
         "score_calibration_bias_mean_abs": 0.0,
         "score_calibration_confusion_smoothing": float(config.score_calibration_confusion_smoothing),
         "score_calibration_confusion_map_trace": np.nan,
+        "score_calibration_scale_min": np.nan,
+        "score_calibration_scale_max": np.nan,
     }
 
 
@@ -770,6 +773,8 @@ def _fit_validation_score_calibration(
         "validation_argmax_class_bias",
         "validation_argmax_class_bias_guarded",
         "validation_confusion_blend",
+        "validation_score_standardize",
+        "validation_score_standardize_guarded",
     }
     if config.score_calibration not in supported_calibrations:
         raise ValueError(f"Unsupported latent AE score calibration: {config.score_calibration!r}")
@@ -777,6 +782,11 @@ def _fit_validation_score_calibration(
         return zero_bias, _empty_score_calibration_metadata(config, "no_validation")
     if config.score_calibration == "validation_confusion_blend":
         return _fit_validation_confusion_blend_calibration(validation_scores, validation_labels, classes, config)
+    if config.score_calibration in {
+        "validation_score_standardize",
+        "validation_score_standardize_guarded",
+    }:
+        return _fit_validation_score_standardization_calibration(validation_scores, validation_labels, classes, config)
 
     validation_scores = np.asarray(validation_scores, dtype=float)
     validation_labels = np.asarray(validation_labels, dtype=int)
@@ -931,11 +941,121 @@ def _fit_validation_confusion_blend_calibration(
     return calibrator, metadata
 
 
+def _fit_validation_score_standardization_calibration(
+    validation_scores: np.ndarray,
+    validation_labels: np.ndarray,
+    classes: np.ndarray,
+    config: LatentAutoencoderConfig,
+) -> tuple[dict, dict]:
+    """Fit source-validation-only classwise score standardization.
+
+    The latent AE smoke fold showed a hard argmax collapse onto a small subset
+    of classes.  Additive prior/bias calibration can fix offset problems, but it
+    cannot fix class-specific logit scale problems.  This calibrator estimates
+    per-class validation score mean and standard deviation and tunes a blend
+    between raw logits and classwise standardized logits on source-validation
+    subjects only.  Held-out-subject labels are never used.
+    """
+
+    validation_scores = np.asarray(validation_scores, dtype=float)
+    validation_labels = np.asarray(validation_labels, dtype=int)
+    guarded_calibration = str(config.score_calibration).endswith("_guarded")
+    n_classes = int(classes.shape[0])
+    means = np.mean(validation_scores, axis=0)
+    scales = np.std(validation_scores, axis=0)
+    positive_scales = scales[scales > 1e-6]
+    fallback_scale = float(np.median(positive_scales)) if positive_scales.size else 1.0
+    scales = np.where(scales > 1e-6, scales, fallback_scale)
+    scales = np.maximum(scales, 1e-6)
+
+    def _calibrated_scores(scores: np.ndarray, alpha: float) -> np.ndarray:
+        standardized = (np.asarray(scores, dtype=float) - means.reshape(1, -1)) / scales.reshape(1, -1)
+        return (1.0 - float(alpha)) * np.asarray(scores, dtype=float) + float(alpha) * standardized
+
+    uncalibrated_metrics = _validation_selection_metrics(
+        validation_labels,
+        validation_scores,
+        classes,
+        config.score_calibration_selection_metric,
+    )
+    uncalibrated_balanced = float(uncalibrated_metrics["balanced_accuracy"])
+    uncalibrated_selection = float(uncalibrated_metrics["selection_score"])
+    alphas = tuple(min(max(float(alpha), 0.0), 1.0) for alpha in config.score_calibration_alphas)
+    if not alphas:
+        alphas = (1.0,)
+    best_alpha = 0.0
+    best_balanced = uncalibrated_balanced if guarded_calibration else -math.inf
+    best_selection = uncalibrated_selection if guarded_calibration else -math.inf
+    best_objective = uncalibrated_selection if guarded_calibration else -math.inf
+    guard_floor = uncalibrated_balanced - max(0.0, float(config.score_calibration_guard_tolerance))
+    for alpha in alphas:
+        calibrated_scores = _calibrated_scores(validation_scores, alpha)
+        calibrated_metrics = _validation_selection_metrics(
+            validation_labels,
+            calibrated_scores,
+            classes,
+            config.score_calibration_selection_metric,
+        )
+        balanced = float(calibrated_metrics["balanced_accuracy"])
+        selection_score = float(calibrated_metrics["selection_score"])
+        if guarded_calibration and balanced + 1e-12 < guard_floor:
+            continue
+        objective = selection_score if guarded_calibration else balanced
+        if (
+            objective > best_objective + 1e-12
+            or (abs(objective - best_objective) <= 1e-12 and balanced > best_balanced + 1e-12)
+            or (
+                abs(objective - best_objective) <= 1e-12
+                and abs(balanced - best_balanced) <= 1e-12
+                and abs(float(alpha)) < abs(best_alpha)
+            )
+        ):
+            best_objective = objective
+            best_balanced = balanced
+            best_selection = selection_score
+            best_alpha = float(alpha)
+
+    calibrator = {
+        "kind": "score_standardize",
+        "alpha": float(best_alpha),
+        "mean": means,
+        "scale": scales,
+    }
+    metadata = {
+        "score_calibration": config.score_calibration,
+        "score_calibration_status": "ok",
+        "score_calibration_prior_source": "validation_score_moments",
+        "score_calibration_predicted_prior_source": "score_standardization",
+        "score_calibration_alpha": float(best_alpha),
+        "score_calibration_validation_balanced_accuracy": float(best_balanced),
+        "score_calibration_uncalibrated_validation_balanced_accuracy": uncalibrated_balanced,
+        "score_calibration_selection_metric": config.score_calibration_selection_metric,
+        "score_calibration_validation_selection_score": float(best_selection),
+        "score_calibration_uncalibrated_validation_selection_score": uncalibrated_selection,
+        "score_calibration_guard_tolerance": config.score_calibration_guard_tolerance,
+        "score_calibration_bias_min": float(np.min(-means)),
+        "score_calibration_bias_max": float(np.max(-means)),
+        "score_calibration_bias_mean_abs": float(np.mean(np.abs(means))),
+        "score_calibration_confusion_smoothing": float(config.score_calibration_confusion_smoothing),
+        "score_calibration_confusion_map_trace": np.nan,
+        "score_calibration_scale_min": float(np.min(scales[:n_classes])),
+        "score_calibration_scale_max": float(np.max(scales[:n_classes])),
+    }
+    return calibrator, metadata
+
+
 def _apply_score_calibration(scores: np.ndarray, calibration: np.ndarray | dict | None) -> np.ndarray:
     if calibration is None or len(calibration) == 0:
         return np.asarray(scores, dtype=float)
     scores = np.asarray(scores, dtype=float)
     if isinstance(calibration, dict):
+        if calibration.get("kind") == "score_standardize":
+            alpha = min(max(float(calibration.get("alpha", 0.0)), 0.0), 1.0)
+            means = np.asarray(calibration["mean"], dtype=float).reshape(1, -1)
+            scales = np.asarray(calibration["scale"], dtype=float).reshape(1, -1)
+            scales = np.maximum(scales, 1e-6)
+            standardized = (scores - means) / scales
+            return (1.0 - alpha) * scores + alpha * standardized
         if calibration.get("kind") != "confusion_blend":
             raise ValueError(f"Unknown score calibration kind: {calibration.get('kind')!r}")
         alpha = min(max(float(calibration.get("alpha", 0.0)), 0.0), 1.0)
@@ -1129,11 +1249,17 @@ def _outer_row(  # pylint: disable=too-many-arguments
             "prediction_postprocessing_validation_objective_delta", np.nan
         ),
         "prediction_postprocessing_guard_tolerance": fit_metadata.get("prediction_postprocessing_guard_tolerance", np.nan),
+        "prediction_postprocessing_shrinkage_alpha": fit_metadata.get("prediction_postprocessing_shrinkage_alpha", np.nan),
+        "prediction_postprocessing_shrinkage_alphas": fit_metadata.get(
+            "prediction_postprocessing_shrinkage_alphas", ";".join(str(float(alpha)) for alpha in config.prediction_postprocessing_shrinkage_alphas)
+        ),
         "score_calibration_bias_min": fit_metadata.get("score_calibration_bias_min", np.nan),
         "score_calibration_bias_max": fit_metadata.get("score_calibration_bias_max", np.nan),
         "score_calibration_bias_mean_abs": fit_metadata.get("score_calibration_bias_mean_abs", np.nan),
         "score_calibration_confusion_smoothing": fit_metadata.get("score_calibration_confusion_smoothing", np.nan),
         "score_calibration_confusion_map_trace": fit_metadata.get("score_calibration_confusion_map_trace", np.nan),
+        "score_calibration_scale_min": fit_metadata.get("score_calibration_scale_min", np.nan),
+        "score_calibration_scale_max": fit_metadata.get("score_calibration_scale_max", np.nan),
         "epochs_requested": config.epochs,
         "best_epoch": fit_metadata.get("best_epoch", np.nan),
         "final_epochs": fit_metadata.get("final_epochs", np.nan),
@@ -1292,6 +1418,9 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "prediction_postprocessing_validation_objective_delta_mean": float(
                 np.nanmean([float(row.get("prediction_postprocessing_validation_objective_delta", np.nan)) for row in outer_rows])
             ),
+            "prediction_postprocessing_shrinkage_alpha_mean": float(
+                np.nanmean([float(row.get("prediction_postprocessing_shrinkage_alpha", np.nan)) for row in outer_rows])
+            ),
             "best_validation_selection_score_mean": float(
                 np.nanmean([float(row.get("best_validation_selection_score", np.nan)) for row in outer_rows])
             ),
@@ -1326,6 +1455,49 @@ def _source_prior_class_quotas(source_labels: np.ndarray, classes: np.ndarray, n
     if float(np.sum(source_counts)) <= 0.0:
         return _uniform_class_quotas(n_classes, n_test_trials)
     expected = source_counts / float(np.sum(source_counts)) * float(n_test_trials)
+    return _round_expected_class_quotas(expected, n_test_trials)
+
+
+def _source_prior_expected_class_counts(source_labels: np.ndarray, classes: np.ndarray, n_test_trials: int) -> np.ndarray:
+    """Return fractional expected counts from the source-label class prior."""
+
+    n_test_trials = int(n_test_trials)
+    n_classes = int(classes.shape[0])
+    if n_test_trials < 0:
+        raise ValueError("n_test_trials must be non-negative.")
+    if n_classes == 0:
+        return np.asarray([], dtype=float)
+    source_indices = _class_index(np.asarray(source_labels, dtype=int), classes)
+    source_counts = np.bincount(source_indices, minlength=n_classes).astype(float)
+    if float(np.sum(source_counts)) <= 0.0:
+        return np.full(n_classes, float(n_test_trials) / float(n_classes), dtype=float)
+    return source_counts / float(np.sum(source_counts)) * float(n_test_trials)
+
+
+def _shrunk_source_prior_class_quotas(
+    source_labels: np.ndarray,
+    predicted_labels: np.ndarray,
+    classes: np.ndarray,
+    n_test_trials: int,
+    *,
+    shrinkage_alpha: float,
+) -> np.ndarray:
+    """Blend observed argmax counts with the source prior before assignment."""
+
+    n_test_trials = int(n_test_trials)
+    classes = np.asarray(classes, dtype=int)
+    n_classes = int(classes.shape[0])
+    if n_classes == 0:
+        return np.asarray([], dtype=int)
+    source_expected = _source_prior_expected_class_counts(source_labels, classes, n_test_trials)
+    predicted_indices = _class_index(np.asarray(predicted_labels, dtype=int), classes)
+    predicted_counts = np.bincount(predicted_indices, minlength=n_classes).astype(float)
+    if float(np.sum(predicted_counts)) <= 0.0:
+        predicted_counts = source_expected.copy()
+    else:
+        predicted_counts *= float(n_test_trials) / float(np.sum(predicted_counts))
+    alpha = min(max(float(shrinkage_alpha), 0.0), 1.0)
+    expected = (1.0 - alpha) * predicted_counts + alpha * source_expected
     return _round_expected_class_quotas(expected, n_test_trials)
 
 
@@ -1397,6 +1569,8 @@ def _postprocess_predictions(
         "prediction_postprocessing_uncalibrated_validation_balanced_accuracy": np.nan,
         "prediction_postprocessing_validation_objective_delta": np.nan,
         "prediction_postprocessing_guard_tolerance": float(config.prediction_postprocessing_guard_tolerance),
+        "prediction_postprocessing_shrinkage_alpha": np.nan,
+        "prediction_postprocessing_shrinkage_alphas": ";".join(str(float(alpha)) for alpha in config.prediction_postprocessing_shrinkage_alphas),
     }
     if method == "none":
         return argmax_labels, {
@@ -1406,15 +1580,18 @@ def _postprocess_predictions(
     supported = {
         "source_prior_balanced_assignment",
         "validation_guarded_source_prior_balanced_assignment",
+        "validation_guarded_shrunk_source_prior_balanced_assignment",
     }
     if method not in supported:
         raise ValueError(
             "prediction_postprocessing must be one of: none, source_prior_balanced_assignment, "
-            "validation_guarded_source_prior_balanced_assignment"
+            "validation_guarded_source_prior_balanced_assignment, "
+            "validation_guarded_shrunk_source_prior_balanced_assignment"
         )
 
     validation_metadata = dict(base_metadata)
-    if method == "validation_guarded_source_prior_balanced_assignment":
+    selected_shrinkage_alpha = 1.0
+    if method in {"validation_guarded_source_prior_balanced_assignment", "validation_guarded_shrunk_source_prior_balanced_assignment"}:
         if validation_scores is None or validation_labels is None or len(validation_labels) == 0:
             return argmax_labels, {
                 **validation_metadata,
@@ -1423,14 +1600,46 @@ def _postprocess_predictions(
         validation_scores = np.asarray(validation_scores, dtype=float)
         validation_labels = np.asarray(validation_labels, dtype=int)
         validation_argmax = classes[np.argmax(validation_scores, axis=1)]
-        validation_quotas = _source_prior_class_quotas(source_labels, classes, int(validation_scores.shape[0]))
-        validation_assigned, validation_objective_delta = _balanced_assignment_predictions(
-            validation_scores,
-            classes,
-            validation_quotas,
-        )
+        if method == "validation_guarded_shrunk_source_prior_balanced_assignment":
+            candidate_alphas = tuple(float(alpha) for alpha in config.prediction_postprocessing_shrinkage_alphas)
+            if not candidate_alphas:
+                candidate_alphas = (1.0,)
+            candidate_rows = []
+            for candidate_alpha in candidate_alphas:
+                validation_quotas = _shrunk_source_prior_class_quotas(
+                    source_labels,
+                    validation_argmax,
+                    classes,
+                    int(validation_scores.shape[0]),
+                    shrinkage_alpha=candidate_alpha,
+                )
+                validation_assigned, validation_objective_delta = _balanced_assignment_predictions(
+                    validation_scores,
+                    classes,
+                    validation_quotas,
+                )
+                validation_balanced = float(balanced_accuracy_score(validation_labels, validation_assigned))
+                candidate_rows.append(
+                    (
+                        validation_balanced,
+                        float(validation_objective_delta),
+                        float(candidate_alpha),
+                        validation_assigned,
+                        validation_quotas,
+                    )
+                )
+            candidate_rows.sort(key=lambda row: (row[0], row[1], -abs(row[2])), reverse=True)
+            validation_balanced, validation_objective_delta, selected_shrinkage_alpha, validation_assigned, validation_quotas = candidate_rows[0]
+            validation_metadata["prediction_postprocessing_shrinkage_alpha"] = float(selected_shrinkage_alpha)
+        else:
+            validation_quotas = _source_prior_class_quotas(source_labels, classes, int(validation_scores.shape[0]))
+            validation_assigned, validation_objective_delta = _balanced_assignment_predictions(
+                validation_scores,
+                classes,
+                validation_quotas,
+            )
+            validation_balanced = float(balanced_accuracy_score(validation_labels, validation_assigned))
         uncalibrated_validation_balanced = float(balanced_accuracy_score(validation_labels, validation_argmax))
-        validation_balanced = float(balanced_accuracy_score(validation_labels, validation_assigned))
         validation_metadata.update(
             {
                 "prediction_postprocessing_validation_balanced_accuracy": validation_balanced,
@@ -1445,13 +1654,24 @@ def _postprocess_predictions(
                 "prediction_postprocessing_status": "guard_rejected",
             }
 
-    quotas = _source_prior_class_quotas(source_labels, classes, int(scores.shape[0]))
+    if method == "validation_guarded_shrunk_source_prior_balanced_assignment":
+        quotas = _shrunk_source_prior_class_quotas(
+            source_labels,
+            argmax_labels,
+            classes,
+            int(scores.shape[0]),
+            shrinkage_alpha=selected_shrinkage_alpha,
+        )
+        quota_source = "shrunk_source_label_prior"
+    else:
+        quotas = _source_prior_class_quotas(source_labels, classes, int(scores.shape[0]))
+        quota_source = "source_label_prior"
     predicted_labels, objective_delta = _balanced_assignment_predictions(scores, classes, quotas)
     quota_counts = Counter({int(class_label): int(quota) for class_label, quota in zip(classes, quotas, strict=True)})
     return predicted_labels, {
         **validation_metadata,
         "prediction_postprocessing_status": "ok",
-        "prediction_postprocessing_quota_source": "source_label_prior",
+        "prediction_postprocessing_quota_source": quota_source,
         "prediction_postprocessing_class_quota_counts": _format_counter(quota_counts),
         "prediction_postprocessing_objective_delta": float(objective_delta),
     }
@@ -1797,6 +2017,8 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
             "validation_argmax_class_bias",
             "validation_argmax_class_bias_guarded",
             "validation_confusion_blend",
+            "validation_score_standardize",
+            "validation_score_standardize_guarded",
         ),
         default="none",
         help="Optional source-validation-only logit calibration for latent AE predictions.",
@@ -1841,11 +2063,21 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
             "none",
             "source_prior_balanced_assignment",
             "validation_guarded_source_prior_balanced_assignment",
+            "validation_guarded_shrunk_source_prior_balanced_assignment",
         ),
         default="none",
         help=(
             "Optional source-prior balanced assignment over the held-out batch. "
             "The validation_guarded variant applies it only when source validation does not regress."
+        ),
+    )
+    parser.add_argument(
+        "--prediction-postprocessing-shrinkage-alphas",
+        type=_parse_float_sequence,
+        default=(0.0, 0.25, 0.5, 0.75, 1.0),
+        help=(
+            "Candidate shrinkage strengths for validation_guarded_shrunk_source_prior_balanced_assignment. "
+            "0 preserves the argmax prediction histogram; 1 uses the full source-label prior."
         ),
     )
     parser.add_argument(
@@ -1911,6 +2143,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         score_calibration_guard_tolerance=args.score_calibration_guard_tolerance,
         prediction_postprocessing=args.prediction_postprocessing,
         prediction_postprocessing_guard_tolerance=args.prediction_postprocessing_guard_tolerance,
+        prediction_postprocessing_shrinkage_alphas=args.prediction_postprocessing_shrinkage_alphas,
         device=args.device,
         num_threads=args.num_threads,
     )

--- a/tests/test_stimulus_cross_subject_next.py
+++ b/tests/test_stimulus_cross_subject_next.py
@@ -129,6 +129,28 @@ class TestStimulusCrossSubjectNext(unittest.TestCase):
         self.assertGreater(probabilities[0, 1], probabilities[0, 2])
         self.assertEqual(probabilities[0, 3], 0.0)
 
+    def test_topk_reciprocal_modes_are_exported(self):
+        mode = "rank_top3_reciprocal"
+
+        self.assertIn(mode, cross_subject.ENSEMBLE_SCORE_NORMALIZATION_MODES)
+        self.assertEqual(
+            cross_subject._base_ensemble_score_normalization(mode),  # pylint: disable=protected-access
+            mode,
+        )
+
+        scores = np.asarray([[4.0, 3.0, 2.0, 1.0]], dtype=float)
+        probabilities = cross_subject._class_score_probabilities(  # pylint: disable=protected-access
+            scores,
+            score_normalization=mode,
+        )
+
+        self.assertEqual(np.count_nonzero(probabilities[0]), 3)
+        np.testing.assert_allclose(np.sum(probabilities, axis=1), np.ones(1))
+        self.assertEqual(probabilities[0, 3], 0.0)
+        self.assertGreater(probabilities[0, 0], probabilities[0, 1])
+        self.assertGreater(probabilities[0, 1], probabilities[0, 2])
+        self.assertAlmostEqual(probabilities[0, 0] / probabilities[0, 1], 2.0)
+
     def test_topk_score_softmax_log_pool_modes_are_exported(self):
         modes = (
             "rank_top2_score_softmax_log_pool",

--- a/tests/test_stimulus_latent_autoencoder_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_calibration.py
@@ -1,7 +1,13 @@
 import numpy as np
+import pytest
 from sklearn.metrics import balanced_accuracy_score
 
-from pymegdec.stimulus_latent_autoencoder import LatentAutoencoderConfig, _fit_validation_score_calibration
+from pymegdec.stimulus_latent_autoencoder import (
+    LatentAutoencoderConfig,
+    _apply_score_calibration,
+    _fit_validation_score_calibration,
+    _validation_selection_metrics,
+)
 
 
 def test_validation_prediction_bias_penalizes_argmax_collapse():
@@ -77,3 +83,57 @@ def test_validation_argmax_class_bias_guarded_uses_hard_prior_with_guard():
     assert bias[0] < 0.0
     assert bias[1] > 0.0
     assert bias[2] > 0.0
+
+
+def test_validation_score_standardize_can_correct_classwise_score_scale_bias():
+    classes = np.asarray([1, 2, 3])
+    labels = np.asarray([1, 1, 2, 2, 3, 3])
+    scores = np.asarray(
+        [
+            [3.0, 2.0, 1.0],
+            [2.8, 1.5, 1.0],
+            [3.0, 4.0, 1.0],
+            [2.9, 4.1, 1.0],
+            [3.0, 1.0, 2.2],
+            [2.8, 1.0, 2.1],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_score_standardize",
+        score_calibration_alphas=(0.0, 0.25, 0.5, 0.75, 1.0),
+    )
+
+    calibration, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    calibrated = _apply_score_calibration(scores, calibration)
+
+    raw_balanced = _validation_selection_metrics(labels, scores, classes, "balanced_accuracy")["balanced_accuracy"]
+    calibrated_balanced = _validation_selection_metrics(labels, calibrated, classes, "balanced_accuracy")[
+        "balanced_accuracy"
+    ]
+    assert metadata["score_calibration_status"] == "ok"
+    assert metadata["score_calibration_predicted_prior_source"] == "score_standardization"
+    assert metadata["score_calibration_alpha"] > 0.0
+    assert calibrated_balanced > raw_balanced
+
+
+def test_validation_score_standardize_guard_rejects_balanced_accuracy_drop():
+    classes = np.asarray([1, 2, 3])
+    labels = np.asarray([1, 2, 3])
+    scores = np.asarray(
+        [
+            [3.0, 2.0, 1.0],
+            [1.0, 3.0, 2.0],
+            [1.0, 2.0, 3.0],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_score_standardize_guarded",
+        score_calibration_alphas=(0.0, 1.0),
+        score_calibration_guard_tolerance=0.0,
+    )
+
+    calibration, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    calibrated = _apply_score_calibration(scores, calibration)
+
+    assert metadata["score_calibration_alpha"] == pytest.approx(0.0)
+    np.testing.assert_allclose(calibrated, scores)

--- a/tests/test_stimulus_latent_autoencoder_postprocessing.py
+++ b/tests/test_stimulus_latent_autoencoder_postprocessing.py
@@ -5,6 +5,7 @@ from pymegdec.stimulus_latent_autoencoder import (
     _balanced_assignment_predictions,
     _display_label_map,
     _postprocess_predictions,
+    _shrunk_source_prior_class_quotas,
     _source_prior_class_quotas,
 )
 
@@ -61,6 +62,58 @@ def test_postprocess_predictions_source_prior_balanced_assignment():
     assert sorted(predictions.tolist()) == [1, 2, 3, 4]
     assert metadata["prediction_postprocessing_status"] == "ok"
     assert metadata["prediction_postprocessing_quota_source"] == "source_label_prior"
+
+
+def test_shrunk_source_prior_class_quotas_interpolate_argmax_and_source_prior():
+    classes = np.asarray([1, 2, 3, 4])
+    source_labels = np.repeat(classes, 10)
+    predicted_labels = np.asarray([1, 1, 1, 1, 2, 2, 3, 4])
+
+    argmax_quotas = _shrunk_source_prior_class_quotas(
+        source_labels,
+        predicted_labels,
+        classes,
+        n_test_trials=8,
+        shrinkage_alpha=0.0,
+    )
+    source_quotas = _shrunk_source_prior_class_quotas(
+        source_labels,
+        predicted_labels,
+        classes,
+        n_test_trials=8,
+        shrinkage_alpha=1.0,
+    )
+
+    assert argmax_quotas.tolist() == [4, 2, 1, 1]
+    assert source_quotas.tolist() == [2, 2, 2, 2]
+
+
+def test_postprocess_predictions_validation_guarded_shrunk_assignment_selects_partial_alpha():
+    classes = np.asarray([1, 2, 3, 4])
+    source_labels = np.repeat(classes, 12)
+    scores = np.asarray(
+        [
+            [5.0, 4.0, 0.0, 0.0],
+            [4.9, 4.8, 0.0, 0.0],
+            [4.7, 0.0, 5.0, 0.0],
+            [4.6, 0.0, 0.0, 5.0],
+        ]
+    )
+    predictions, metadata = _postprocess_predictions(
+        scores,
+        classes,
+        source_labels,
+        LatentAutoencoderConfig(
+            prediction_postprocessing="validation_guarded_shrunk_source_prior_balanced_assignment",
+            prediction_postprocessing_shrinkage_alphas=(0.0, 1.0),
+        ),
+        validation_scores=scores,
+        validation_labels=np.asarray([1, 2, 3, 4]),
+    )
+    assert sorted(predictions.tolist()) == [1, 2, 3, 4]
+    assert metadata["prediction_postprocessing_status"] == "ok"
+    assert metadata["prediction_postprocessing_quota_source"] == "shrunk_source_label_prior"
+    assert metadata["prediction_postprocessing_shrinkage_alpha"] == 1.0
 
 
 def test_display_label_map_does_not_shift_one_based_labels():


### PR DESCRIPTION
## Summary
- add top-k reciprocal rank pooling options for BUSH cross-subject ensembles
- add latent AE validation score standardization calibration
- add guarded shrunk source-prior postprocessing and workflow controls

## Verification
- Did not run tests per request.
- `python -m py_compile src\pymegdec\_stimulus_cross_subject_next.py src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_cross_subject_next.py tests\test_stimulus_latent_autoencoder_calibration.py tests\test_stimulus_latent_autoencoder_postprocessing.py`
- YAML parse for `.github/workflows/stimulus-cross-subject-nested-matrix.yml` and `.github/workflows/stimulus-latent-autoencoder.yml`
- `git diff --check`