### PR TITLE
Make nested matrix data preparation resilient

### DIFF
--- a/.github/actions/prepare-meg-data/action.yml
+++ b/.github/actions/prepare-meg-data/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: Maximum seconds allowed for each WebDAV file copy.
     required: false
     default: "1800"
+  rclone-download-attempts:
+    description: Number of attempts for the WebDAV download step before failing.
+    required: false
+    default: "3"
   cache-segment-download-timeout-minutes:
     description: Maximum minutes allowed for one Actions cache download segment on GitHub-hosted runners.
     required: false
@@ -140,19 +144,35 @@ runs:
         FILE_NAMES: ${{ inputs.file-names }}
         RCLONE_LIST_TIMEOUT_S: ${{ inputs.rclone-list-timeout-s }}
         RCLONE_COPY_TIMEOUT_S: ${{ inputs.rclone-copy-timeout-s }}
+        RCLONE_DOWNLOAD_ATTEMPTS: ${{ inputs.rclone-download-attempts }}
       run: |
         set -euo pipefail
+        if ! [[ "${RCLONE_DOWNLOAD_ATTEMPTS}" =~ ^[0-9]+$ ]] || [ "${RCLONE_DOWNLOAD_ATTEMPTS}" -lt 1 ]; then
+          echo "rclone-download-attempts must be a positive integer, got '${RCLONE_DOWNLOAD_ATTEMPTS}'" >&2
+          exit 1
+        fi
         cmd=(
           python3 scripts/download_meg_data_files.py
           --source webdav-rclone
           --data-dir "${CACHE_DATA_DIR}"
           --rclone-list-timeout-s "${RCLONE_LIST_TIMEOUT_S}"
           --rclone-copy-timeout-s "${RCLONE_COPY_TIMEOUT_S}"
+          --rclone-copy-attempts "${RCLONE_DOWNLOAD_ATTEMPTS}"
         )
         if [ -n "${FILE_NAMES}" ]; then
           cmd+=(--file-names "${FILE_NAMES}")
         fi
-        "${cmd[@]}"
+        attempt=1
+        until "${cmd[@]}"; do
+          if [ "${attempt}" -ge "${RCLONE_DOWNLOAD_ATTEMPTS}" ]; then
+            echo "MEG data download failed after ${attempt} attempt(s)." >&2
+            exit 1
+          fi
+          delay=$((attempt * 30))
+          echo "MEG data download attempt ${attempt} failed; retrying in ${delay}s." >&2
+          sleep "${delay}"
+          attempt=$((attempt + 1))
+        done
 
     - name: Expose MEG data at workflow data path
       shell: bash

--- a/.github/workflows/stimulus-cross-subject-nested-matrix.yml
+++ b/.github/workflows/stimulus-cross-subject-nested-matrix.yml
@@ -20,6 +20,11 @@ on:
         required: true
         default: true
         type: boolean
+      github_hosted_shard_download_on_miss:
+        description: Allow GitHub-hosted shard jobs to download from WebDAV if the shared Actions cache is missing or unusable. Keep max_parallel low when this is true.
+        required: true
+        default: true
+        type: boolean
       config_bundle:
         description: Named candidate bundle to shard. Use all only for a broader screening pass.
         required: true
@@ -3886,6 +3891,9 @@ jobs:
     name: Prepare main MEG data cache
     runs-on: ${{ inputs.runner_type == 'github-hosted' && 'ubuntu-latest' || inputs.self_hosted_runner_label }}
     timeout-minutes: 360
+    concurrency:
+      group: nested-matrix-main-data-${{ github.repository }}-${{ inputs.runner_type }}-v2
+      cancel-in-progress: false
     env:
       DATA_DIR: .cache/meg-data-main
       DATA_CACHE_VERSION: v2
@@ -3916,6 +3924,21 @@ jobs:
   nested-matrix:
     name: Nested ${{ matrix.config_id }} ${{ matrix.outer_label }}
     needs: [prepare-matrix, prepare-data]
+    if: >-
+      ${{
+        always()
+        && needs.prepare-matrix.result == 'success'
+        && (
+          needs.prepare-data.result == 'success'
+          || (
+            inputs.use_nextcloud_data
+            && (
+              inputs.runner_type != 'github-hosted'
+              || inputs.github_hosted_shard_download_on_miss
+            )
+          )
+        )
+      }}
     runs-on: ${{ inputs.runner_type == 'github-hosted' && 'ubuntu-latest' || inputs.self_hosted_runner_label }}
     timeout-minutes: ${{ fromJSON(inputs.per_job_timeout_minutes) }}
     strategy:
@@ -3963,6 +3986,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Note shard data fallback
+        if: ${{ needs.prepare-data.result != 'success' }}
+        shell: bash
+        run: |
+          echo "Prepare-data job result was '${{ needs.prepare-data.result }}'."
+          echo "This shard will prepare MEG data independently because download fallback is enabled."
+
       - name: Prepare main MEG data
         timeout-minutes: 180
         uses: ./.github/actions/prepare-meg-data
@@ -3970,7 +4000,7 @@ jobs:
           data-dir: ${{ env.DATA_DIR }}
           cache-version: ${{ env.DATA_CACHE_VERSION }}
           cache-key: meg-data-main-${{ runner.os }}-${{ env.DATA_CACHE_VERSION }}
-          download-on-miss: ${{ inputs.runner_type == 'github-hosted' && 'false' || inputs.use_nextcloud_data }}
+          download-on-miss: ${{ inputs.use_nextcloud_data && (inputs.runner_type != 'github-hosted' || inputs.github_hosted_shard_download_on_miss) }}
           file-names: ${{ env.MAIN_FILE_NAMES }}
           require-cue-files: "false"
           expected-main-files: "23"

--- a/scripts/download_private_meg_data.py
+++ b/scripts/download_private_meg_data.py
@@ -12,6 +12,7 @@ import os
 import re
 import shutil
 import subprocess  # nosec B404
+import time
 import urllib.parse
 import urllib.request
 from collections.abc import Sequence
@@ -129,6 +130,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument("--rclone-binary", default="rclone")
     parser.add_argument("--rclone-list-timeout-s", type=int, default=300, help="Maximum seconds allowed for the rclone WebDAV listing call.")
     parser.add_argument("--rclone-copy-timeout-s", type=int, default=1800, help="Maximum seconds allowed for each rclone file copy.")
+    parser.add_argument("--rclone-copy-attempts", type=int, default=3, help="Number of attempts for each rclone file copy.")
     parser.add_argument("--manifest", default="data-manifest/downloaded-files.txt")
     return parser
 
@@ -168,6 +170,28 @@ def _run_rclone(args: list[str], *, capture_output: bool = False, timeout: int |
         detail = f": {result.stderr.strip()}" if capture_output and result.stderr else ""
         raise SystemExit(f"{description} failed with exit code {result.returncode}{detail}")
     return result
+
+
+def _run_rclone_with_retries(
+    args: list[str],
+    *,
+    capture_output: bool = False,
+    timeout: int | None = None,
+    description: str = "rclone",
+    attempts: int = 1,
+) -> subprocess.CompletedProcess[str]:
+    if attempts < 1:
+        raise SystemExit(f"{description} attempts must be positive.")
+    for attempt in range(1, attempts + 1):
+        try:
+            return _run_rclone(args, capture_output=capture_output, timeout=timeout, description=description)
+        except SystemExit:
+            if attempt >= attempts:
+                raise
+            delay = attempt * 30
+            print(f"{description} failed on attempt {attempt}/{attempts}; retrying in {delay}s...", flush=True)
+            time.sleep(delay)
+    raise AssertionError("unreachable")
 
 
 def _download_from_url_list(args: argparse.Namespace, data_dir: Path) -> list[Path]:
@@ -260,7 +284,7 @@ def _download_from_webdav_rclone(args: argparse.Namespace, data_dir: Path) -> li
         remote_source = _webdav_remote("/".join(part for part in [args.remote_path.strip("/"), remote_file] if part))
         target = data_dir / Path(remote_file).name
         print(f"Downloading file {index}/{len(remote_files)}: {remote_file} -> {target.name}", flush=True)
-        _run_rclone(
+        _run_rclone_with_retries(
             [
                 args.rclone_binary,
                 "copyto",
@@ -273,6 +297,7 @@ def _download_from_webdav_rclone(args: argparse.Namespace, data_dir: Path) -> li
             ],
             timeout=args.rclone_copy_timeout_s,
             description=f"rclone copy {remote_file!r}",
+            attempts=args.rclone_copy_attempts,
         )
         downloaded.append(target)
         print(f"Downloaded file {index}/{len(remote_files)}: {target.name}", flush=True)


### PR DESCRIPTION
## Summary
- retry flaky WebDAV/rclone downloads during MEG data preparation
- serialize shared nested-matrix data-cache preparation by runner type/cache key
- allow GitHub-hosted shard jobs to fall back to WebDAV downloads when the shared Actions cache is missing or unusable

## Validation
- parsed modified YAML files with PyYAML
- `python -m ruff check .github scripts tests/test_data_download.py`
- direct smoke check of `_run_rclone_with_retries`
- `python scripts/download_private_meg_data.py --help`

Note: local `python -m pytest tests/test_data_download.py -q` is blocked by this desktop environment resolving `scripts` to an unrelated package from another workspace before the repo-local `scripts/` directory.