### PR TITLE
Add artifact and latent selection controls

### DIFF
--- a/.github/workflows/stimulus-artifact-ensemble.yml
+++ b/.github/workflows/stimulus-artifact-ensemble.yml
@@ -33,6 +33,21 @@ on:
         required: true
         default: auto,hard_vote,mean_score,mean_rank,borda,score_tiebreak_first_source
         type: string
+      nested_selection_metrics:
+        description: Comma-separated leave-subject-out selector metrics to compare.
+        required: true
+        default: balanced_accuracy,balanced_top2_top3_rank_lcb
+        type: string
+      nested_weight_selector_ensemble:
+        description: Multi-source ensemble to optimize with leakage-safe leave-subject-out source-weight selection.
+        required: true
+        default: compact_small_finetune_w150_pca128
+        type: string
+      nested_weight_grid_step:
+        description: Simplex grid step for nested source-weight selection.
+        required: true
+        default: "0.25"
+        type: string
 
 permissions:
   contents: read
@@ -78,33 +93,53 @@ jobs:
       - name: Combine predictions
         env:
           AGGREGATION_MODES: ${{ inputs.aggregation_modes }}
+          NESTED_SELECTION_METRICS: ${{ inputs.nested_selection_metrics }}
+          NESTED_WEIGHT_SELECTOR_ENSEMBLE: ${{ inputs.nested_weight_selector_ensemble }}
+          NESTED_WEIGHT_GRID_STEP: ${{ inputs.nested_weight_grid_step }}
         shell: bash
         run: |
           set -euo pipefail
           IFS=',' read -r -a modes <<< "${AGGREGATION_MODES}"
+          IFS=',' read -r -a selection_metrics <<< "${NESTED_SELECTION_METRICS}"
           for raw_mode in "${modes[@]}"; do
             mode="$(echo "${raw_mode}" | xargs)"
             if [[ -z "${mode}" ]]; then
               continue
             fi
-            stem="artifact_ensemble_${mode//-/_}"
-            python -m pymegdec.stimulus_artifact_ensemble \
-              --source compact=artifacts/compact \
-              --source small_finetune=artifacts/small_finetune \
-              --source w150_pca128=artifacts/w150_pca128 \
-              --source w125=artifacts/w125 \
-              --ensemble compact=compact \
-              --ensemble compact_small_finetune=compact,small_finetune \
-              --ensemble compact_w150_pca128=compact,w150_pca128 \
-              --ensemble compact_w125=compact,w125 \
-              --ensemble compact_small_finetune_w150_pca128=compact,small_finetune,w150_pca128 \
-              --key-column test_participant \
-              --key-column test_trial_index \
-              --key-column true_label \
-              --nested-selector-name nested_subject_selector \
-              --aggregation-mode "${mode}" \
-              --output-dir outputs \
-              --output-stem "${stem}"
+            for raw_metric in "${selection_metrics[@]}"; do
+              metric="$(echo "${raw_metric}" | xargs)"
+              if [[ -z "${metric}" ]]; then
+                continue
+              fi
+              stem="artifact_ensemble_${mode//-/_}"
+              selector_name="nested_subject_selector"
+              if [[ "${metric}" != "balanced_accuracy" ]]; then
+                metric_slug="${metric//-/_}"
+                stem="${stem}_${metric_slug}"
+                selector_name="nested_subject_selector_${metric_slug}"
+              fi
+              python -m pymegdec.stimulus_artifact_ensemble \
+                --source compact=artifacts/compact \
+                --source small_finetune=artifacts/small_finetune \
+                --source w150_pca128=artifacts/w150_pca128 \
+                --source w125=artifacts/w125 \
+                --ensemble compact=compact \
+                --ensemble compact_small_finetune=compact,small_finetune \
+                --ensemble compact_w150_pca128=compact,w150_pca128 \
+                --ensemble compact_w125=compact,w125 \
+                --ensemble compact_small_finetune_w150_pca128=compact,small_finetune,w150_pca128 \
+                --key-column test_participant \
+                --key-column test_trial_index \
+                --key-column true_label \
+                --nested-selector-name "${selector_name}" \
+                --nested-selection-metric "${metric}" \
+                --nested-weight-selector-name nested_weight_selector \
+                --nested-weight-selector-ensemble "${NESTED_WEIGHT_SELECTOR_ENSEMBLE}" \
+                --nested-weight-grid-step "${NESTED_WEIGHT_GRID_STEP}" \
+                --aggregation-mode "${mode}" \
+                --output-dir outputs \
+                --output-stem "${stem}"
+            done
           done
 
       - name: Append comparison summary

--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -54,6 +54,16 @@ on:
         required: true
         default: "1"
         type: string
+      logit_mean_center_weight:
+        description: Penalize minibatch-level class-logit offsets; 0 disables it.
+        required: true
+        default: "0"
+        type: string
+      confidence_penalty_weight:
+        description: Entropy confidence penalty on training logits; 0 disables it.
+        required: true
+        default: "0"
+        type: string
       label_smoothing:
         description: Cross-entropy label smoothing for latent AE training; 0 disables it.
         required: true
@@ -63,6 +73,11 @@ on:
         description: Focal-loss gamma for latent AE classification; 0 disables focal modulation.
         required: true
         default: "0.0"
+        type: string
+      soft_macro_recall_weight:
+        description: Differentiable macro-recall / balanced-accuracy surrogate loss weight; 0 disables it.
+        required: true
+        default: "0"
         type: string
       supervised_contrastive_weight:
         description: Source-only supervised contrastive latent loss weight; 0 disables it.
@@ -147,6 +162,7 @@ on:
           - validation_class_zscore_guarded
           - validation_score_standardize
           - validation_score_standardize_guarded
+          - validation_selected_guarded
       score_calibration_alphas:
         description: Candidate alpha strengths for source-validation class-bias calibration.
         required: true
@@ -198,6 +214,7 @@ on:
           - validation_guarded_source_prior_balanced_assignment
           - validation_guarded_source_prior_soft_balanced_assignment
           - validation_guarded_shrunk_source_prior_balanced_assignment
+          - validation_selected_balanced_assignment
       prediction_postprocessing_shrinkage_alphas:
         description: Candidate shrinkage strengths for guarded shrunk source-prior assignment.
         required: true
@@ -263,8 +280,11 @@ jobs:
             --prediction-balance-weight "${{ inputs.prediction_balance_weight }}"
             --prediction-balance-target-smoothing "${{ inputs.prediction_balance_target_smoothing }}"
             --prediction-balance-temperature "${{ inputs.prediction_balance_temperature }}"
+            --logit-mean-center-weight "${{ inputs.logit_mean_center_weight }}"
+            --confidence-penalty-weight "${{ inputs.confidence_penalty_weight }}"
             --label-smoothing "${{ inputs.label_smoothing }}"
             --focal-loss-gamma "${{ inputs.focal_loss_gamma }}"
+            --soft-macro-recall-weight "${{ inputs.soft_macro_recall_weight }}"
             --supervised-contrastive-weight "${{ inputs.supervised_contrastive_weight }}"
             --supervised-contrastive-temperature "${{ inputs.supervised_contrastive_temperature }}"
             --validation-prediction-balance-weight "${{ inputs.validation_prediction_balance_weight }}"

--- a/src/pymegdec/stimulus_artifact_ensemble.py
+++ b/src/pymegdec/stimulus_artifact_ensemble.py
@@ -30,6 +30,12 @@ ARTIFACT_AGGREGATION_MODE_CHOICES = (
     "borda",
     "score_tiebreak_first_source",
 )
+ARTIFACT_NESTED_SELECTION_METRIC_CHOICES = (
+    "balanced_accuracy",
+    "balanced_accuracy_lcb",
+    "balanced_top2_top3_rank",
+    "balanced_top2_top3_rank_lcb",
+)
 
 
 @dataclass(frozen=True)
@@ -302,6 +308,24 @@ def _normalize_artifact_aggregation_mode(aggregation_mode: str) -> str:
         raise ValueError(
             "Artifact aggregation mode must be one of "
             f"{', '.join(ARTIFACT_AGGREGATION_MODE_CHOICES)}."
+        )
+    return normalized
+
+
+def _normalize_artifact_nested_selection_metric(selection_metric: str) -> str:
+    normalized = str(selection_metric).strip().lower().replace("-", "_")
+    aliases = {
+        "balanced": "balanced_accuracy",
+        "balanced_lcb": "balanced_accuracy_lcb",
+        "balanced_rank": "balanced_top2_top3_rank",
+        "balanced_rank_lcb": "balanced_top2_top3_rank_lcb",
+        "rank_lcb": "balanced_top2_top3_rank_lcb",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in ARTIFACT_NESTED_SELECTION_METRIC_CHOICES:
+        raise ValueError(
+            "Artifact nested selection metric must be one of "
+            f"{', '.join(ARTIFACT_NESTED_SELECTION_METRIC_CHOICES)}."
         )
     return normalized
 
@@ -587,9 +611,269 @@ def _metric_mean(rows: Sequence[dict[str, object]], metric: str) -> float:
     return _mean([_to_float(row[metric]) for row in rows])
 
 
+def _nested_selection_metric_label(selection_metric: str) -> str:
+    return f"other_subjects_{_normalize_artifact_nested_selection_metric(selection_metric)}"
+
+
+def _outer_metric_values(rows: Sequence[dict[str, object]], metric: str) -> list[float]:
+    return [_to_float(row[metric]) for row in rows]
+
+
+def _artifact_recipe_rank_score(row: dict[str, object], *, n_classes: int) -> float:
+    """Return a source-only recipe score that rewards top-k/rank signal.
+
+    The balanced-accuracy term remains dominant. Top-2/top-3 and mean-rank
+    terms are deliberately small, chance-centered nudges intended for artifact
+    recipe selection when several recipes tie on balanced accuracy across the
+    other subjects.
+    """
+
+    if n_classes <= 0:
+        raise ValueError("Nested artifact selection requires at least one class.")
+    balanced = _to_float(row["balanced_accuracy"])
+    top2 = _to_float(row["top2_accuracy"])
+    top3 = _to_float(row["top3_accuracy"])
+    mean_rank = _to_float(row["mean_true_label_rank"])
+    top2_chance = min(2.0 / n_classes, 1.0)
+    top3_chance = min(3.0 / n_classes, 1.0)
+    chance_mean_rank = 0.5 * (n_classes + 1.0)
+    rank_scale = max(chance_mean_rank - 1.0, 1.0)
+    rank_gain = (chance_mean_rank - mean_rank) / rank_scale
+    return balanced + 0.25 * (top2 - top2_chance) + 0.125 * (top3 - top3_chance) + 0.10 * rank_gain
+
+
+def _nested_selection_metric_value(rows: Sequence[dict[str, object]], *, selection_metric: str, n_classes: int) -> float:
+    normalized = _normalize_artifact_nested_selection_metric(selection_metric)
+    if normalized == "balanced_accuracy":
+        return _metric_mean(rows, "balanced_accuracy")
+    if normalized == "balanced_accuracy_lcb":
+        values = _outer_metric_values(rows, "balanced_accuracy")
+        return _mean(values) - _sem(values)
+
+    values = [_artifact_recipe_rank_score(row, n_classes=n_classes) for row in rows]
+    score = _mean(values)
+    if normalized.endswith("_lcb"):
+        score -= _sem(values)
+    return score
+
+
 def _counts_text(values: Iterable[str]) -> str:
     counts = Counter(values)
     return ";".join(f"{value}:{counts[value]}" for value in sorted(counts, key=_participant_sort_key))
+
+
+@dataclass(frozen=True)
+class WeightCandidate:
+    candidate_index: int
+    weights: tuple[float, ...]
+    weight_text: str
+    uniform_distance: float
+    predictions_by_participant: dict[str, list[dict]]
+    outer_by_participant: dict[str, dict]
+
+
+def _source_weight_text(source_names: Sequence[str], weights: Sequence[float]) -> str:
+    normalized = _normalized_source_weights(weights, len(source_names))
+    return ";".join(
+        f"{source_name}:{weight:.6g}"
+        for source_name, weight in zip(source_names, normalized, strict=True)
+    )
+
+
+def _simplex_weight_grid(n_sources: int, step: float) -> list[tuple[float, ...]]:
+    """Return non-negative source-weight vectors on a simplex grid.
+
+    The grid is intentionally small and deterministic; it is meant for
+    leakage-safe artifact-level selection, not for fitting another model to the
+    held-out subject.  ``step=0.25`` gives 15 candidates for three sources.
+    """
+
+    if n_sources <= 0:
+        raise ValueError("At least one source is required for a weight grid.")
+    if step <= 0.0 or step > 1.0 or not math.isfinite(step):
+        raise ValueError("Weight-grid step must be finite and in the interval (0, 1].")
+    denominator_float = 1.0 / step
+    denominator = int(round(denominator_float))
+    if denominator <= 0 or not math.isclose(denominator_float, denominator, rel_tol=0.0, abs_tol=1e-9):
+        raise ValueError("Weight-grid step must evenly divide 1.0, e.g. 1, 0.5, 0.25, or 0.1.")
+
+    weights: list[tuple[float, ...]] = []
+
+    def visit(prefix: list[int], remaining: int, slots: int) -> None:
+        if slots == 1:
+            weights.append(tuple(value / denominator for value in (*prefix, remaining)))
+            return
+        for value in range(remaining + 1):
+            visit([*prefix, value], remaining - value, slots - 1)
+
+    visit([], denominator, n_sources)
+    return weights
+
+
+def _weight_uniform_distance(weights: Sequence[float]) -> float:
+    if not weights:
+        return math.inf
+    uniform = 1.0 / len(weights)
+    return sum(abs(weight - uniform) for weight in weights)
+
+
+def _weighted_ensemble_predictions(
+    *,
+    ensemble_name: str,
+    source_names: Sequence[str],
+    source_weights: Sequence[float],
+    indexed_sources: dict[str, dict[tuple[str, ...], dict[str, str]]],
+    key_columns: Sequence[str],
+    class_labels: Sequence[int],
+    score_normalization: str,
+    aggregation_mode: str,
+) -> list[dict]:
+    reference_keys = set(indexed_sources[source_names[0]])
+    return [
+        _prediction_row(
+            ensemble_name=ensemble_name,
+            source_names=source_names,
+            source_weights=source_weights,
+            source_rows=[indexed_sources[source_name][key] for source_name in source_names],
+            key_columns=key_columns,
+            key=key,
+            class_labels=class_labels,
+            score_normalization=score_normalization,
+            aggregation_mode=aggregation_mode,
+        )
+        for key in sorted(reference_keys, key=_prediction_key_sort_key)
+    ]
+
+
+def _nested_source_weight_selector(
+    *,
+    selector_name: str,
+    selector_ensemble: str,
+    ensemble_sources: dict[str, Sequence[str]],
+    indexed_sources: dict[str, dict[tuple[str, ...], dict[str, str]]],
+    key_columns: Sequence[str],
+    class_labels: Sequence[int],
+    n_classes: int,
+    score_normalization: str,
+    aggregation_mode: str,
+    grid_step: float,
+) -> tuple[list[dict], list[dict], list[dict], dict[str, object]]:
+    """Choose source weights per held-out subject using other subjects only."""
+
+    if selector_ensemble not in ensemble_sources:
+        raise ValueError(f"Unknown nested weight-selector ensemble {selector_ensemble!r}.")
+    source_names = tuple(ensemble_sources[selector_ensemble])
+    if len(source_names) < 2:
+        raise ValueError("Nested weight selection requires an ensemble with at least two sources.")
+
+    candidates: list[WeightCandidate] = []
+    for candidate_index, weights in enumerate(_simplex_weight_grid(len(source_names), grid_step)):
+        prediction_rows = _weighted_ensemble_predictions(
+            ensemble_name=f"{selector_name}__candidate_{candidate_index}",
+            source_names=source_names,
+            source_weights=weights,
+            indexed_sources=indexed_sources,
+            key_columns=key_columns,
+            class_labels=class_labels,
+            score_normalization=score_normalization,
+            aggregation_mode=aggregation_mode,
+        )
+        outer_rows = _outer_rows(f"{selector_name}__candidate_{candidate_index}", prediction_rows, n_classes=n_classes)
+        by_participant: dict[str, list[dict]] = defaultdict(list)
+        for row in prediction_rows:
+            by_participant[str(row.get("test_participant", ""))].append(row)
+        candidates.append(
+            WeightCandidate(
+                candidate_index=candidate_index,
+                weights=weights,
+                weight_text=_source_weight_text(source_names, weights),
+                uniform_distance=_weight_uniform_distance(weights),
+                predictions_by_participant=by_participant,
+                outer_by_participant={str(row.get("test_participant", "")): row for row in outer_rows},
+            )
+        )
+
+    participants = sorted(
+        set().union(*(set(candidate.outer_by_participant) for candidate in candidates)),
+        key=_participant_sort_key,
+    )
+    if not participants:
+        raise ValueError("Nested source-weight selector requires test_participant values.")
+
+    selected_predictions: list[dict] = []
+    selection_rows: list[dict] = []
+    for participant in participants:
+        scored_candidates: list[tuple[float, float, int, WeightCandidate, list[dict]]] = []
+        for candidate in candidates:
+            train_outer_rows = [
+                row
+                for other_participant, row in candidate.outer_by_participant.items()
+                if other_participant != participant
+            ]
+            if not train_outer_rows:
+                raise ValueError(f"Cannot select artifact source weights for participant {participant}; no source subjects remain.")
+            balanced = _metric_mean(train_outer_rows, "balanced_accuracy")
+            scored_candidates.append(
+                (
+                    balanced,
+                    -candidate.uniform_distance,
+                    -candidate.candidate_index,
+                    candidate,
+                    train_outer_rows,
+                )
+            )
+
+        selected_balanced, _, _, selected_candidate, train_outer_rows = max(scored_candidates)
+        participant_predictions = selected_candidate.predictions_by_participant.get(participant)
+        if not participant_predictions:
+            raise ValueError(f"Selected source-weight candidate has no predictions for participant {participant}.")
+
+        weight_text = selected_candidate.weight_text
+        selection_rows.append(
+            {
+                "test_participant": participant,
+                "artifact_ensemble": selector_name,
+                "selected_artifact_ensemble": selector_ensemble,
+                "selected_artifact_ensemble_sources": ";".join(source_names),
+                "selected_source_weights": weight_text,
+                "selected_weight_grid_step": grid_step,
+                "selection_metric": "other_subjects_balanced_accuracy",
+                "selection_metric_value": selected_balanced,
+                "selection_accuracy": _metric_mean(train_outer_rows, "accuracy"),
+                "selection_top2_accuracy": _metric_mean(train_outer_rows, "top2_accuracy"),
+                "selection_top3_accuracy": _metric_mean(train_outer_rows, "top3_accuracy"),
+                "selection_n_subjects": len(train_outer_rows),
+                "candidate_source_weight_count": len(candidates),
+            }
+        )
+        for row in participant_predictions:
+            selected_row = dict(row)
+            selected_row["artifact_ensemble"] = selector_name
+            selected_row["artifact_ensemble_weight_selection"] = "leave_subject_out_grid"
+            selected_row["selected_artifact_ensemble"] = selector_ensemble
+            selected_row["selected_artifact_ensemble_sources"] = ";".join(source_names)
+            selected_row["selected_source_weights"] = weight_text
+            selected_row["selected_weight_grid_step"] = grid_step
+            selected_row["selection_metric"] = "other_subjects_balanced_accuracy"
+            selected_row["selection_metric_value"] = selected_balanced
+            selected_predictions.append(selected_row)
+
+    outer_rows = _outer_rows(selector_name, selected_predictions, n_classes=n_classes)
+    summary = _group_summary(
+        selector_name,
+        source_names,
+        outer_rows,
+        n_classes=n_classes,
+        score_normalization=score_normalization,
+        aggregation_mode=aggregation_mode,
+    )
+    summary["artifact_ensemble_weight_selection"] = "leave_subject_out_grid"
+    summary["selected_artifact_ensemble"] = selector_ensemble
+    summary["selection_metric"] = "other_subjects_balanced_accuracy"
+    summary["selected_source_weight_counts"] = _counts_text(str(row["selected_source_weights"]) for row in selection_rows)
+    summary["candidate_source_weight_count"] = len(candidates)
+    summary["selected_weight_grid_step"] = grid_step
+    return selected_predictions, outer_rows, selection_rows, summary
 
 
 def _group_summary(
@@ -653,9 +937,11 @@ def _nested_subject_selector(
     n_classes: int,
     score_normalization: str,
     aggregation_mode: str,
+    nested_selection_metric: str,
 ) -> tuple[list[dict], list[dict], list[dict], dict[str, object]]:
     """Select an artifact ensemble recipe for each subject using other subjects only."""
 
+    nested_selection_metric = _normalize_artifact_nested_selection_metric(nested_selection_metric)
     outer_by_ensemble_participant = {
         ensemble: {str(row.get("test_participant", "")): row for row in rows}
         for ensemble, rows in outer_rows_by_ensemble.items()
@@ -686,10 +972,10 @@ def _nested_subject_selector(
             ]
             if not train_outer_rows:
                 raise ValueError(f"Cannot select an artifact ensemble for participant {participant}; no source subjects remain.")
-            balanced = _metric_mean(train_outer_rows, "balanced_accuracy")
-            candidates.append((balanced, -ensemble_index, ensemble, train_outer_rows))
+            selection_score = _nested_selection_metric_value(train_outer_rows, selection_metric=nested_selection_metric, n_classes=n_classes)
+            candidates.append((selection_score, -ensemble_index, ensemble, train_outer_rows))
 
-        selected_balanced, _, selected_ensemble, train_outer_rows = max(candidates)
+        selected_score, _, selected_ensemble, train_outer_rows = max(candidates)
         selected_sources = ensemble_sources[selected_ensemble]
         participant_predictions = prediction_by_ensemble_participant[selected_ensemble].get(participant)
         if not participant_predictions:
@@ -701,11 +987,14 @@ def _nested_subject_selector(
                 "artifact_ensemble": selector_name,
                 "selected_artifact_ensemble": selected_ensemble,
                 "selected_artifact_ensemble_sources": ";".join(selected_sources),
-                "selection_metric": "other_subjects_balanced_accuracy",
-                "selection_metric_value": selected_balanced,
+                "selection_metric": _nested_selection_metric_label(nested_selection_metric),
+                "selection_metric_name": nested_selection_metric,
+                "selection_metric_value": selected_score,
+                "selection_balanced_accuracy": _metric_mean(train_outer_rows, "balanced_accuracy"),
                 "selection_accuracy": _metric_mean(train_outer_rows, "accuracy"),
                 "selection_top2_accuracy": _metric_mean(train_outer_rows, "top2_accuracy"),
                 "selection_top3_accuracy": _metric_mean(train_outer_rows, "top3_accuracy"),
+                "selection_mean_true_label_rank": _metric_mean(train_outer_rows, "mean_true_label_rank"),
                 "selection_n_subjects": len(train_outer_rows),
                 "candidate_artifact_ensembles": ";".join(ensemble_order),
             }
@@ -716,8 +1005,9 @@ def _nested_subject_selector(
             selected_row["artifact_ensemble_recipe_selection"] = "leave_subject_out"
             selected_row["selected_artifact_ensemble"] = selected_ensemble
             selected_row["selected_artifact_ensemble_sources"] = ";".join(selected_sources)
-            selected_row["selection_metric"] = "other_subjects_balanced_accuracy"
-            selected_row["selection_metric_value"] = selected_balanced
+            selected_row["selection_metric"] = _nested_selection_metric_label(nested_selection_metric)
+            selected_row["selection_metric_name"] = nested_selection_metric
+            selected_row["selection_metric_value"] = selected_score
             selected_predictions.append(selected_row)
 
     outer_rows = _outer_rows(selector_name, selected_predictions, n_classes=n_classes)
@@ -730,7 +1020,8 @@ def _nested_subject_selector(
         aggregation_mode=aggregation_mode,
     )
     summary["artifact_ensemble_recipe_selection"] = "leave_subject_out"
-    summary["selection_metric"] = "other_subjects_balanced_accuracy"
+    summary["selection_metric"] = _nested_selection_metric_label(nested_selection_metric)
+    summary["selection_metric_name"] = nested_selection_metric
     summary["selected_artifact_ensemble_counts"] = _counts_text(
         str(row["selected_artifact_ensemble"]) for row in selection_rows
     )
@@ -747,13 +1038,18 @@ def ensemble_prediction_sources(
     *,
     key_columns: Sequence[str] = DEFAULT_KEY_COLUMNS,
     nested_selector_name: str | None = None,
+    nested_weight_selector_name: str | None = None,
+    nested_weight_selector_ensemble: str | None = None,
+    nested_weight_grid_step: float = 0.25,
     score_normalization: str = "raw",
     aggregation_mode: str = "auto",
+    nested_selection_metric: str = "balanced_accuracy",
 ) -> dict[str, list[dict]]:
-    """Build hard-vote artifact ensembles from already completed prediction CSVs."""
+    """Build leakage-safe artifact ensembles from completed prediction CSVs."""
 
     score_normalization = _normalize_artifact_score_normalization(score_normalization)
     aggregation_mode = _normalize_artifact_aggregation_mode(aggregation_mode)
+    nested_selection_metric = _normalize_artifact_nested_selection_metric(nested_selection_metric)
     source_by_name = {source.name: source for source in sources}
     if len(source_by_name) != len(sources):
         raise ValueError("Source names must be unique.")
@@ -826,11 +1122,34 @@ def ensemble_prediction_sources(
             n_classes=len(class_labels),
             score_normalization=score_normalization,
             aggregation_mode=aggregation_mode,
+            nested_selection_metric=nested_selection_metric,
         )
         artifacts["predictions"].extend(nested_predictions)
         artifacts["outer"].extend(nested_outer)
         artifacts["group_summary"].append(nested_summary)
         artifacts["nested_selection"] = nested_selection
+    if nested_weight_selector_name:
+        if nested_weight_selector_ensemble is None:
+            multi_source_ensembles = [name for name in ensemble_sources if len(ensemble_sources[name]) > 1]
+            if not multi_source_ensembles:
+                raise ValueError("Nested weight selection requires at least one multi-source ensemble.")
+            nested_weight_selector_ensemble = multi_source_ensembles[0]
+        weight_predictions, weight_outer, weight_selection, weight_summary = _nested_source_weight_selector(
+            selector_name=nested_weight_selector_name,
+            selector_ensemble=nested_weight_selector_ensemble,
+            ensemble_sources=ensemble_sources,
+            indexed_sources=indexed_sources,
+            key_columns=key_columns,
+            class_labels=class_labels,
+            n_classes=len(class_labels),
+            score_normalization=score_normalization,
+            aggregation_mode=aggregation_mode,
+            grid_step=nested_weight_grid_step,
+        )
+        artifacts["predictions"].extend(weight_predictions)
+        artifacts["outer"].extend(weight_outer)
+        artifacts["group_summary"].append(weight_summary)
+        artifacts["nested_weight_selection"] = weight_selection
     return artifacts
 
 
@@ -898,8 +1217,28 @@ def main(argv: list[str] | None = None) -> int:
         help="How to combine source predictions: score mean, rank/Borda, hard vote, or automatic score-then-rank fallback.",
     )
     parser.add_argument(
+        "--nested-selection-metric",
+        choices=ARTIFACT_NESTED_SELECTION_METRIC_CHOICES,
+        default="balanced_accuracy",
+        help="Leave-subject-out metric for selecting artifact ensemble recipes.",
+    )
+    parser.add_argument(
         "--nested-selector-name",
         help="Optional leakage-safe leave-subject-out artifact recipe selector row to add to the outputs.",
+    )
+    parser.add_argument(
+        "--nested-weight-selector-name",
+        help="Optional leakage-safe leave-subject-out source-weight selector row to add to the outputs.",
+    )
+    parser.add_argument(
+        "--nested-weight-selector-ensemble",
+        help="Ensemble whose source weights should be grid-selected by --nested-weight-selector-name. Defaults to the first multi-source ensemble.",
+    )
+    parser.add_argument(
+        "--nested-weight-grid-step",
+        type=float,
+        default=0.25,
+        help="Simplex grid step for nested source-weight selection. Use values that divide 1.0, e.g. 0.5, 0.25, or 0.1.",
     )
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--output-stem", default="artifact_ensemble")
@@ -912,14 +1251,20 @@ def main(argv: list[str] | None = None) -> int:
         ensembles,
         key_columns=tuple(args.key_columns or DEFAULT_KEY_COLUMNS),
         nested_selector_name=args.nested_selector_name,
+        nested_weight_selector_name=args.nested_weight_selector_name,
+        nested_weight_selector_ensemble=args.nested_weight_selector_ensemble,
+        nested_weight_grid_step=args.nested_weight_grid_step,
         score_normalization=args.score_normalization,
         aggregation_mode=args.aggregation_mode,
+        nested_selection_metric=args.nested_selection_metric,
     )
     write_csv_rows(args.output_dir / f"{args.output_stem}_predictions.csv", artifacts["predictions"])
     write_csv_rows(args.output_dir / f"{args.output_stem}_outer.csv", artifacts["outer"])
     write_csv_rows(args.output_dir / f"{args.output_stem}_group_summary.csv", artifacts["group_summary"])
     if "nested_selection" in artifacts:
         write_csv_rows(args.output_dir / f"{args.output_stem}_nested_selection.csv", artifacts["nested_selection"])
+    if "nested_weight_selection" in artifacts:
+        write_csv_rows(args.output_dir / f"{args.output_stem}_nested_weight_selection.csv", artifacts["nested_weight_selection"])
     write_markdown_summary(args.output_dir / f"{args.output_stem}_comparison.md", artifacts["group_summary"])
     return 0
 

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -46,6 +46,15 @@ DEFAULT_LATENT_DIM = 64
 DEFAULT_LATENT_HIDDEN_DIM = 128
 DEFAULT_LATENT_RECONSTRUCTION_WEIGHT = 0.03
 DEFAULT_LATENT_VALIDATION_SOURCE_STRATEGY = "rotating"
+DEFAULT_LATENT_SELECTED_SCORE_CALIBRATION_CANDIDATES = (
+    "none",
+    "validation_argmax_class_bias_guarded",
+    "validation_temperature_argmax_class_bias_guarded",
+    "validation_class_zscore_guarded",
+    "validation_score_standardize_guarded",
+    "validation_vector_bias_guarded",
+    "validation_logistic_stack_guarded",
+)
 
 
 @dataclass(frozen=True)
@@ -66,8 +75,11 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     prediction_balance_weight: float = 0.0
     prediction_balance_target_smoothing: float = 1.0
     prediction_balance_temperature: float = 1.0
+    logit_mean_center_weight: float = 0.0
+    confidence_penalty_weight: float = 0.0
     label_smoothing: float = 0.0
     focal_loss_gamma: float = 0.0
+    soft_macro_recall_weight: float = 0.0
     supervised_contrastive_weight: float = 0.0
     supervised_contrastive_temperature: float = 0.20
     balanced_batch_sampling: bool = False
@@ -380,6 +392,56 @@ def _prediction_balance_loss(logits, label_indices, *, target_smoothing: float, 
     return F.mse_loss(predicted_distribution, target_distribution)
 
 
+def _soft_macro_recall_loss(logits, label_indices):
+    """Differentiable balanced-accuracy surrogate for minibatch training."""
+
+    torch, _nn, F = _lazy_torch()
+    if int(logits.shape[0]) == 0:
+        return torch.zeros((), dtype=logits.dtype, device=logits.device)
+    probabilities = F.softmax(logits, dim=1)
+    n_classes = int(logits.shape[1])
+    one_hot = F.one_hot(label_indices, num_classes=n_classes).to(dtype=logits.dtype)
+    class_counts = one_hot.sum(dim=0)
+    represented = class_counts > 0
+    if not bool(torch.any(represented)):
+        return torch.zeros((), dtype=logits.dtype, device=logits.device)
+    soft_true_positive = (one_hot * probabilities).sum(dim=0)
+    soft_recall = soft_true_positive[represented] / class_counts[represented].clamp_min(1.0)
+    return 1.0 - soft_recall.mean()
+
+
+def _logit_mean_center_loss(logits):
+    """Penalize minibatch-level class-logit offsets before softmax.
+
+    The existing prediction-balance loss acts on the average softmax
+    distribution.  In the latent AE smoke run, the hard predictions collapsed
+    onto a few classes even though many margins were modest; in that regime the
+    mean softmax can look less imbalanced than the argmax histogram.  This loss
+    directly discourages persistent class-specific logit offsets while preserving
+    each trial's relative evidence pattern.
+    """
+
+    torch, _nn, _F = _lazy_torch()
+    if int(logits.shape[0]) == 0:
+        return torch.zeros((), dtype=logits.dtype, device=logits.device)
+    row_centered_logits = logits - logits.mean(dim=1, keepdim=True)
+    mean_centered_logits = row_centered_logits.mean(dim=0)
+    mean_centered_logits = mean_centered_logits - mean_centered_logits.mean()
+    return torch.mean(mean_centered_logits.square())
+
+
+def _confidence_penalty(logits):
+    """Return a differentiable penalty for over-confident class posteriors."""
+
+    torch, _nn, F = _lazy_torch()
+    if int(logits.shape[0]) == 0:
+        return torch.zeros((), dtype=logits.dtype, device=logits.device)
+    probabilities = F.softmax(logits, dim=1)
+    entropy = -torch.sum(probabilities * torch.log(torch.clamp(probabilities, min=1e-8)), dim=1)
+    max_entropy = torch.log(torch.tensor(float(logits.shape[1]), dtype=logits.dtype, device=logits.device))
+    return torch.clamp(max_entropy - entropy.mean(), min=0.0)
+
+
 def _supervised_contrastive_loss(latent, label_indices, *, temperature: float):
     """Supervised contrastive loss for class-preserving shared latent spaces.
 
@@ -586,6 +648,8 @@ def _train_model(  # pylint: disable=too-many-arguments,too-many-locals
                     reconstruction_losses.append(F.mse_loss(reconstruction, xb[mask]))
             reconstruction_loss = torch.stack(reconstruction_losses).mean() if reconstruction_losses else torch.zeros((), device=device)
             loss = class_loss + float(config.reconstruction_weight) * reconstruction_loss
+            if float(config.soft_macro_recall_weight) > 0.0:
+                loss = loss + float(config.soft_macro_recall_weight) * _soft_macro_recall_loss(logits, yb)
             if float(config.subject_adversary_weight) > 0.0:
                 subject_logits, subject_targets = model.adversarial_subject_logits(
                     latent,
@@ -601,6 +665,10 @@ def _train_model(  # pylint: disable=too-many-arguments,too-many-locals
                     temperature=config.prediction_balance_temperature,
                 )
                 loss = loss + float(config.prediction_balance_weight) * balance_loss
+            if float(config.logit_mean_center_weight) > 0.0:
+                loss = loss + float(config.logit_mean_center_weight) * _logit_mean_center_loss(logits)
+            if float(config.confidence_penalty_weight) > 0.0:
+                loss = loss + float(config.confidence_penalty_weight) * _confidence_penalty(logits)
             if float(config.supervised_contrastive_weight) > 0.0:
                 contrastive_loss = _supervised_contrastive_loss(
                     latent,
@@ -778,6 +846,8 @@ def _empty_score_calibration_metadata(config: LatentAutoencoderConfig, status: s
     return {
         "score_calibration": config.score_calibration,
         "score_calibration_status": status,
+        "score_calibration_selected_method": "none",
+        "score_calibration_selected_candidates": "",
         "score_calibration_prior_source": "",
         "score_calibration_predicted_prior_source": "none",
         "score_calibration_alpha": 0.0,
@@ -803,6 +873,107 @@ def _empty_score_calibration_metadata(config: LatentAutoencoderConfig, status: s
         "score_calibration_vector_l2": float(config.score_calibration_vector_l2),
         "score_calibration_vector_updates": 0,
     }
+
+
+def _fit_validation_selected_score_calibration(
+    validation_scores: np.ndarray,
+    validation_labels: np.ndarray,
+    classes: np.ndarray,
+    config: LatentAutoencoderConfig,
+) -> tuple[np.ndarray | dict, dict]:
+    """Select one guarded source-validation calibration method.
+
+    The latent AE smoke run showed class-collapse, but the best correction can
+    vary by held-out subject.  This selector tries several existing
+    source-validation-only calibrators, scores them on the source-validation
+    split, and applies only the best one to the held-out subject.  The held-out
+    subject's main-task labels are never used.
+    """
+
+    validation_scores = np.asarray(validation_scores, dtype=float)
+    validation_labels = np.asarray(validation_labels, dtype=int)
+    candidates = DEFAULT_LATENT_SELECTED_SCORE_CALIBRATION_CANDIDATES
+    candidate_list = ";".join(candidates)
+    uncalibrated_metrics = _validation_selection_metrics(
+        validation_labels,
+        validation_scores,
+        classes,
+        config.score_calibration_selection_metric,
+    )
+    uncalibrated_balanced = float(uncalibrated_metrics["balanced_accuracy"])
+    uncalibrated_selection = float(uncalibrated_metrics["selection_score"])
+    guard_floor = uncalibrated_balanced - max(0.0, float(config.score_calibration_guard_tolerance))
+
+    best_calibration: np.ndarray | dict = np.zeros(int(classes.shape[0]), dtype=float)
+    best_method = "none"
+    best_balanced = uncalibrated_balanced
+    best_selection = uncalibrated_selection
+    best_objective = uncalibrated_selection
+    best_rank = 0
+    best_metadata = _empty_score_calibration_metadata(config, "ok")
+    best_metadata.update(
+        {
+            "score_calibration_selected_method": "none",
+            "score_calibration_selected_candidates": candidate_list,
+            "score_calibration_validation_balanced_accuracy": uncalibrated_balanced,
+            "score_calibration_uncalibrated_validation_balanced_accuracy": uncalibrated_balanced,
+            "score_calibration_validation_selection_score": uncalibrated_selection,
+            "score_calibration_uncalibrated_validation_selection_score": uncalibrated_selection,
+        }
+    )
+
+    for rank, method in enumerate(candidates):
+        method_config = replace(config, score_calibration=method)
+        calibration, metadata = _fit_validation_score_calibration(
+            validation_scores,
+            validation_labels,
+            classes,
+            method_config,
+        )
+        calibrated_scores = _apply_score_calibration(validation_scores, calibration)
+        metrics = _validation_selection_metrics(
+            validation_labels,
+            calibrated_scores,
+            classes,
+            config.score_calibration_selection_metric,
+        )
+        balanced = float(metrics["balanced_accuracy"])
+        if balanced + 1e-12 < guard_floor:
+            continue
+        selection_score = float(metrics["selection_score"])
+        objective = selection_score
+        if (
+            objective > best_objective + 1e-12
+            or (abs(objective - best_objective) <= 1e-12 and balanced > best_balanced + 1e-12)
+            or (
+                abs(objective - best_objective) <= 1e-12
+                and abs(balanced - best_balanced) <= 1e-12
+                and rank < best_rank
+            )
+        ):
+            best_calibration = calibration
+            best_method = method
+            best_balanced = balanced
+            best_selection = selection_score
+            best_objective = objective
+            best_rank = rank
+            best_metadata = dict(metadata)
+
+    best_metadata.update(
+        {
+            "score_calibration": config.score_calibration,
+            "score_calibration_status": "ok",
+            "score_calibration_selected_method": best_method,
+            "score_calibration_selected_candidates": candidate_list,
+            "score_calibration_validation_balanced_accuracy": best_balanced,
+            "score_calibration_uncalibrated_validation_balanced_accuracy": uncalibrated_balanced,
+            "score_calibration_validation_selection_score": best_selection,
+            "score_calibration_uncalibrated_validation_selection_score": uncalibrated_selection,
+            "score_calibration_selection_metric": config.score_calibration_selection_metric,
+            "score_calibration_guard_tolerance": config.score_calibration_guard_tolerance,
+        }
+    )
+    return best_calibration, best_metadata
 
 
 def _fit_validation_score_calibration(
@@ -842,6 +1013,7 @@ def _fit_validation_score_calibration(
         "validation_temperature_argmax_class_bias_guarded",
         "validation_score_standardize",
         "validation_score_standardize_guarded",
+        "validation_selected_guarded",
     }
     if config.score_calibration not in supported_calibrations:
         raise ValueError(f"Unsupported latent AE score calibration: {config.score_calibration!r}")
@@ -870,6 +1042,13 @@ def _fit_validation_score_calibration(
         "validation_score_standardize_guarded",
     }:
         return _fit_validation_score_standardization_calibration(validation_scores, validation_labels, classes, config)
+    if config.score_calibration == "validation_selected_guarded":
+        return _fit_validation_selected_score_calibration(
+            validation_scores,
+            validation_labels,
+            classes,
+            config,
+        )
 
     validation_scores = np.asarray(validation_scores, dtype=float)
     validation_labels = np.asarray(validation_labels, dtype=int)
@@ -1587,8 +1766,11 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
             "prediction_balance_weight": config.prediction_balance_weight,
             "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "prediction_balance_temperature": config.prediction_balance_temperature,
+            "logit_mean_center_weight": config.logit_mean_center_weight,
+            "confidence_penalty_weight": config.confidence_penalty_weight,
             "label_smoothing": config.label_smoothing,
             "focal_loss_gamma": config.focal_loss_gamma,
+            "soft_macro_recall_weight": config.soft_macro_recall_weight,
             "supervised_contrastive_weight": config.supervised_contrastive_weight,
             "supervised_contrastive_temperature": config.supervised_contrastive_temperature,
             "balanced_batch_sampling": config.balanced_batch_sampling,
@@ -1677,14 +1859,18 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "prediction_balance_weight": config.prediction_balance_weight,
         "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
         "prediction_balance_temperature": config.prediction_balance_temperature,
+        "logit_mean_center_weight": config.logit_mean_center_weight,
+        "confidence_penalty_weight": config.confidence_penalty_weight,
         "label_smoothing": config.label_smoothing,
         "focal_loss_gamma": config.focal_loss_gamma,
+        "soft_macro_recall_weight": config.soft_macro_recall_weight,
         "supervised_contrastive_weight": config.supervised_contrastive_weight,
         "supervised_contrastive_temperature": config.supervised_contrastive_temperature,
         "balanced_batch_sampling": config.balanced_batch_sampling,
         "validation_prediction_balance_weight": config.validation_prediction_balance_weight,
         "score_calibration": config.score_calibration,
         "score_calibration_status": fit_metadata.get("score_calibration_status", "unknown"),
+        "score_calibration_selected_method": fit_metadata.get("score_calibration_selected_method", "none"),
         "score_calibration_prior_source": fit_metadata.get("score_calibration_prior_source", ""),
         "prediction_postprocessing_selected_method": fit_metadata.get(
             "prediction_postprocessing_selected_method", "none"
@@ -1821,7 +2007,10 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "prediction_balance_weight": config.prediction_balance_weight,
             "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "prediction_balance_temperature": config.prediction_balance_temperature,
+            "logit_mean_center_weight": config.logit_mean_center_weight,
+            "confidence_penalty_weight": config.confidence_penalty_weight,
             "label_smoothing": config.label_smoothing,
+            "soft_macro_recall_weight": config.soft_macro_recall_weight,
             "supervised_contrastive_weight": config.supervised_contrastive_weight,
             "supervised_contrastive_temperature": config.supervised_contrastive_temperature,
             "balanced_batch_sampling": config.balanced_batch_sampling,
@@ -2658,6 +2847,25 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--logit-mean-center-weight",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional source-only regularizer that penalizes minibatch-level class-logit offsets. "
+            "Small values such as 0.001 or 0.003 can reduce hard prediction collapse without "
+            "forcing a balanced assignment at inference."
+        ),
+    )
+    parser.add_argument(
+        "--confidence-penalty-weight",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional entropy confidence penalty on training logits. Small values such as 0.001 "
+            "or 0.003 discourage early over-confident source memorization."
+        ),
+    )
+    parser.add_argument(
         "--label-smoothing",
         type=float,
         default=0.0,
@@ -2670,6 +2878,15 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         help=(
             "Optional focal-loss gamma for latent AE classification. 0 preserves the existing "
             "class-balanced cross-entropy; try 1.0 or 2.0 to emphasize hard source trials/classes."
+        ),
+    )
+    parser.add_argument(
+        "--soft-macro-recall-weight",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional differentiable macro-recall / balanced-accuracy surrogate weight. "
+            "Small values such as 0.05 or 0.10 can discourage zero-recall classes."
         ),
     )
     parser.add_argument(
@@ -2765,6 +2982,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
             "validation_class_zscore_guarded",
             "validation_score_standardize",
             "validation_score_standardize_guarded",
+            "validation_selected_guarded",
         ),
         default="none",
         help="Optional source-validation-only logit calibration for latent AE predictions.",
@@ -2911,8 +3129,11 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         prediction_balance_weight=args.prediction_balance_weight,
         prediction_balance_target_smoothing=args.prediction_balance_target_smoothing,
         prediction_balance_temperature=args.prediction_balance_temperature,
+        logit_mean_center_weight=args.logit_mean_center_weight,
+        confidence_penalty_weight=args.confidence_penalty_weight,
         label_smoothing=args.label_smoothing,
         focal_loss_gamma=args.focal_loss_gamma,
+        soft_macro_recall_weight=args.soft_macro_recall_weight,
         supervised_contrastive_weight=args.supervised_contrastive_weight,
         supervised_contrastive_temperature=args.supervised_contrastive_temperature,
         balanced_batch_sampling=bool(args.balanced_batch_sampling),

--- a/tests/test_stimulus_artifact_ensemble.py
+++ b/tests/test_stimulus_artifact_ensemble.py
@@ -38,6 +38,18 @@ def _stimulus_scored_row(true_label: int, predicted_label: int, stimulus_1_score
     }
 
 
+def _participant_scored_row(
+    participant: int,
+    true_label: int,
+    predicted_label: int,
+    class_0_score: float,
+    class_1_score: float,
+) -> dict[str, str]:
+    row = _scored_row(true_label, predicted_label, class_0_score, class_1_score)
+    row["test_participant"] = str(participant)
+    return row
+
+
 def _ranked_row(true_label: int, predicted_label: int, class_0_rank: float, class_1_rank: float) -> dict[str, str]:
     return {
         **_row(1, 1, true_label, predicted_label, true_label_rank=class_0_rank if true_label == 0 else class_1_rank),
@@ -263,6 +275,89 @@ class TestStimulusArtifactEnsemble(unittest.TestCase):
             row for row in artifacts["predictions"] if row["artifact_ensemble"] == "nested_subject_selector"
         ]
         self.assertEqual([row["predicted_label"] for row in nested_predictions], [1, 1, 0])
+
+    def test_nested_subject_selector_can_use_rank_aware_metric(self) -> None:
+        balanced_first = _source(
+            "balanced_first",
+            [
+                _row(1, 1, 0, 0, true_label_rank=1.0),
+                _row(2, 1, 0, 0, true_label_rank=1.0),
+                _row(3, 1, 0, 1, true_label_rank=3.0),
+            ],
+        )
+        rank_aware = _source(
+            "rank_aware",
+            [
+                _row(1, 1, 0, 1, true_label_rank=2.0),
+                _row(2, 1, 0, 1, true_label_rank=2.0),
+                _row(3, 1, 0, 0, true_label_rank=1.0),
+            ],
+        )
+
+        artifacts = ensemble_prediction_sources(
+            [balanced_first, rank_aware],
+            [
+                ("balanced_first", ("balanced_first",)),
+                ("rank_aware", ("rank_aware",)),
+            ],
+            nested_selector_name="nested_subject_selector",
+            nested_selection_metric="balanced_top2_top3_rank",
+        )
+
+        selections = {
+            row["test_participant"]: row["selected_artifact_ensemble"]
+            for row in artifacts["nested_selection"]
+        }
+        self.assertEqual(selections["1"], "rank_aware")
+        first_selection = next(row for row in artifacts["nested_selection"] if row["test_participant"] == "1")
+        self.assertEqual(first_selection["selection_metric"], "other_subjects_balanced_top2_top3_rank")
+        self.assertEqual(first_selection["selection_metric_name"], "balanced_top2_top3_rank")
+
+        nested_summary = next(
+            row for row in artifacts["group_summary"] if row["artifact_ensemble"] == "nested_subject_selector"
+        )
+        self.assertEqual(nested_summary["selection_metric_name"], "balanced_top2_top3_rank")
+
+    def test_nested_weight_selector_uses_other_subjects_only(self) -> None:
+        source_a = _source(
+            "source_a",
+            [
+                _participant_scored_row(1, 0, 1, 0.10, 0.90),
+                _participant_scored_row(2, 0, 0, 0.90, 0.10),
+                _participant_scored_row(3, 0, 0, 0.90, 0.10),
+            ],
+        )
+        source_b = _source(
+            "source_b",
+            [
+                _participant_scored_row(1, 0, 0, 0.90, 0.10),
+                _participant_scored_row(2, 0, 1, 0.10, 0.90),
+                _participant_scored_row(3, 0, 1, 0.10, 0.90),
+            ],
+        )
+
+        artifacts = ensemble_prediction_sources(
+            [source_a, source_b],
+            [("source_a_b", ("source_a", "source_b"))],
+            aggregation_mode="mean_score",
+            nested_weight_selector_name="nested_weight_selector",
+            nested_weight_selector_ensemble="source_a_b",
+            nested_weight_grid_step=1.0,
+        )
+
+        selections = {
+            row["test_participant"]: row["selected_source_weights"]
+            for row in artifacts["nested_weight_selection"]
+        }
+        self.assertEqual(selections["1"], "source_a:1;source_b:0")
+        nested_predictions = [
+            row for row in artifacts["predictions"] if row["artifact_ensemble"] == "nested_weight_selector"
+        ]
+        participant_1 = next(row for row in nested_predictions if row["test_participant"] == "1")
+        self.assertEqual(participant_1["predicted_label"], 1)
+        self.assertEqual(participant_1["artifact_ensemble_weight_selection"], "leave_subject_out_grid")
+        nested_summary = next(row for row in artifacts["group_summary"] if row["artifact_ensemble"] == "nested_weight_selector")
+        self.assertEqual(nested_summary["candidate_source_weight_count"], 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_stimulus_latent_autoencoder_controls.py
+++ b/tests/test_stimulus_latent_autoencoder_controls.py
@@ -9,13 +9,16 @@ from pymegdec.stimulus_latent_autoencoder import (
     LatentAutoencoderConfig,
     _balanced_epoch_indices,
     _class_balanced_focal_cross_entropy,
+    _confidence_penalty,
     _effective_ensemble_seeds,
     _final_refit_epochs,
     _gradient_reverse,
+    _logit_mean_center_loss,
     _make_model_class,
     _prediction_balance_score,
     _postprocess_predictions,
     _split_source_participants,
+    _soft_macro_recall_loss,
     _supervised_contrastive_loss,
     _validation_selection_metrics,
 )
@@ -75,6 +78,38 @@ def test_prediction_balance_score_detects_collapse():
     balanced = _prediction_balance_score(np.asarray([1, 2, 3, 4]), classes)
 
     assert 0.0 <= collapsed < balanced <= 1.0
+
+
+def test_logit_mean_center_loss_penalizes_batch_class_offsets_when_torch_is_available():
+    torch = _import_torch_or_skip()
+    collapsed = torch.tensor(
+        [
+            [4.0, 0.0, 0.0],
+            [4.0, 0.0, 0.0],
+            [4.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    balanced = torch.tensor(
+        [
+            [4.0, 0.0, 0.0],
+            [0.0, 4.0, 0.0],
+            [0.0, 0.0, 4.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    assert _logit_mean_center_loss(collapsed) > _logit_mean_center_loss(balanced)
+    assert torch.isclose(_logit_mean_center_loss(balanced), torch.tensor(0.0))
+
+
+def test_confidence_penalty_penalizes_peaked_scores_when_torch_is_available():
+    torch = _import_torch_or_skip()
+    peaked = torch.tensor([[6.0, 0.0, 0.0], [0.0, 6.0, 0.0]], dtype=torch.float32)
+    flat = torch.zeros((2, 3), dtype=torch.float32)
+
+    assert _confidence_penalty(peaked) > _confidence_penalty(flat)
+    assert torch.isclose(_confidence_penalty(flat), torch.tensor(0.0))
 
 
 def test_source_prior_balanced_assignment_postprocessing_uses_source_quotas():
@@ -255,6 +290,31 @@ def test_latent_model_maps_sparse_participant_ids_for_subject_adversary_when_tor
     targets = model.subject_targets(torch.tensor([8, 2, 4, 8]))
 
     assert targets.tolist() == [2, 0, 1, 2]
+
+
+def test_soft_macro_recall_loss_rewards_per_class_correct_scores():
+    torch = _import_torch_or_skip()
+
+    labels = torch.tensor([0, 0, 1, 1, 2, 2], dtype=torch.long)
+    good_logits = torch.tensor(
+        [
+            [4.0, 0.0, 0.0],
+            [3.5, 0.2, 0.0],
+            [0.0, 4.0, 0.0],
+            [0.1, 3.5, 0.0],
+            [0.0, 0.0, 4.0],
+            [0.0, 0.1, 3.5],
+        ],
+        dtype=torch.float32,
+    )
+    collapsed_logits = torch.tensor([[4.0, 0.0, 0.0]] * 6, dtype=torch.float32)
+
+    good_loss = _soft_macro_recall_loss(good_logits, labels)
+    collapsed_loss = _soft_macro_recall_loss(collapsed_logits, labels)
+
+    assert torch.isfinite(good_loss)
+    assert torch.isfinite(collapsed_loss)
+    assert good_loss < collapsed_loss
 
 
 def test_supervised_contrastive_loss_rewards_same_class_latent_neighbors():

--- a/tests/test_stimulus_latent_autoencoder_score_calibration.py
+++ b/tests/test_stimulus_latent_autoencoder_score_calibration.py
@@ -250,6 +250,41 @@ def test_guarded_validation_vector_bias_can_fix_multiple_collapsed_classes():
     assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
 
 
+def test_validation_selected_guarded_score_calibration_picks_nontrivial_fix():
+    classes = np.asarray([1, 2, 3])
+    labels = np.asarray([1, 1, 2, 2, 3, 3])
+    scores = np.asarray(
+        [
+            [2.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [2.0, 1.9, 0.0],
+            [2.0, 1.8, 0.0],
+            [2.0, 0.0, 1.9],
+            [2.0, 0.0, 1.8],
+        ]
+    )
+    config = LatentAutoencoderConfig(
+        score_calibration="validation_selected_guarded",
+        score_calibration_alphas=(0.0, 0.5, 1.0, 2.0),
+        score_calibration_temperatures=(0.5, 1.0, 2.0),
+        score_calibration_vector_steps=(1.0, 0.5),
+        score_calibration_vector_rounds=2,
+        score_calibration_selection_metric="balanced_top2_top3_rank_balance",
+        score_calibration_guard_tolerance=0.0,
+    )
+
+    calibration, metadata = _fit_validation_score_calibration(scores, labels, classes, config)
+    uncalibrated_predictions = classes[np.argmax(scores, axis=1)]
+    calibrated_predictions = classes[np.argmax(_apply_score_calibration(scores, calibration), axis=1)]
+
+    assert metadata["score_calibration_status"] == "ok"
+    assert metadata["score_calibration"] == "validation_selected_guarded"
+    assert metadata["score_calibration_selected_method"] != "none"
+    assert "validation_argmax_class_bias_guarded" in metadata["score_calibration_selected_candidates"]
+    assert len(set(calibrated_predictions.tolist())) > len(set(uncalibrated_predictions.tolist()))
+    assert metadata["score_calibration_validation_balanced_accuracy"] >= metadata["score_calibration_uncalibrated_validation_balanced_accuracy"]
+
+
 def test_validation_confusion_blend_reassigns_systematic_confusions():
     classes = np.asarray([1, 2, 3])
     labels = np.asarray([1, 1, 2, 2, 3, 3])


### PR DESCRIPTION
## Summary
- add artifact nested selection metrics and nested source-weight selection
- add latent score calibration selection and logit/soft macro recall controls
- update workflows and focused coverage for the new controls

## Validation
- `python -m py_compile src\pymegdec\stimulus_artifact_ensemble.py src\pymegdec\stimulus_latent_autoencoder.py tests\test_stimulus_artifact_ensemble.py tests\test_stimulus_latent_autoencoder_controls.py tests\test_stimulus_latent_autoencoder_score_calibration.py`
- parsed `.github/workflows/stimulus-artifact-ensemble.yml` and `.github/workflows/stimulus-latent-autoencoder.yml` with PyYAML
- `git diff --check`

Did not run tests per request.