### PR TITLE
Reduce MEG WebDAV download disk pressure

### DIFF
--- a/scripts/download_private_meg_data.py
+++ b/scripts/download_private_meg_data.py
@@ -15,7 +15,7 @@ import subprocess  # nosec B404
 import time
 import urllib.parse
 import urllib.request
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 _ALLOWED_URL_SCHEMES = {"https"}
@@ -158,6 +158,8 @@ def _rclone_options(*, webdav_url: str, webdav_user: str, obscured_password: str
         "3",
         "--low-level-retries",
         "3",
+        "--multi-thread-streams",
+        "1",
     ]
 
 
@@ -179,6 +181,7 @@ def _run_rclone_with_retries(
     timeout: int | None = None,
     description: str = "rclone",
     attempts: int = 1,
+    retry_cleanup: Callable[[], None] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     if attempts < 1:
         raise SystemExit(f"{description} attempts must be positive.")
@@ -188,10 +191,20 @@ def _run_rclone_with_retries(
         except SystemExit:
             if attempt >= attempts:
                 raise
+            if retry_cleanup is not None:
+                retry_cleanup()
             delay = attempt * 30
             print(f"{description} failed on attempt {attempt}/{attempts}; retrying in {delay}s...", flush=True)
             time.sleep(delay)
     raise AssertionError("unreachable")
+
+
+def _remove_rclone_partial_files(target: Path) -> None:
+    for path in [target, *target.parent.glob(f"{target.name}*.partial")]:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
 
 
 def _download_from_url_list(args: argparse.Namespace, data_dir: Path) -> list[Path]:
@@ -298,6 +311,7 @@ def _download_from_webdav_rclone(args: argparse.Namespace, data_dir: Path) -> li
             timeout=args.rclone_copy_timeout_s,
             description=f"rclone copy {remote_file!r}",
             attempts=args.rclone_copy_attempts,
+            retry_cleanup=lambda target=target: _remove_rclone_partial_files(target),
         )
         downloaded.append(target)
         print(f"Downloaded file {index}/{len(remote_files)}: {target.name}", flush=True)


### PR DESCRIPTION
## Summary
- force rclone WebDAV file copies to use one stream to reduce temporary disk overhead on GitHub-hosted runners
- remove stale target and `.partial` files before retrying a failed file copy

This targets the post-PR #282 failure where fallback shard downloads worked but some GitHub-hosted jobs ran out of disk while copying `Part20Data.mat`.

## Validation
- `python -m ruff check scripts/download_private_meg_data.py`
- direct importlib smoke test for retry cleanup behavior
- `python scripts/download_private_meg_data.py --help`