### PR TITLE
Add artifact ensemble and latent AE selection modes

### DIFF
--- a/.github/workflows/stimulus-artifact-ensemble.yml
+++ b/.github/workflows/stimulus-artifact-ensemble.yml
@@ -31,7 +31,7 @@ on:
       aggregation_modes:
         description: Comma-separated artifact aggregation modes to compare.
         required: true
-        default: auto,hard_vote,mean_score,confidence_weighted_mean_score,log_score_mean,mean_rank,borda,score_tiebreak_first_source,balanced_assignment
+        default: auto,hard_vote,mean_score,confidence_weighted_mean_score,entropy_weighted_mean_score,log_score_mean,score_rank_fusion,mean_rank,borda,score_tiebreak_first_source,balanced_assignment,balanced_assignment_shrink25,balanced_assignment_shrink50,balanced_assignment_shrink75
         type: string
       nested_selection_metrics:
         description: Comma-separated leave-subject-out selector metrics to compare.

--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -38,6 +38,8 @@ on:
           - none
           - anti_collapse_train
           - anti_collapse_calibrated
+          - anti_collapse_refit
+          - anti_collapse_head_refit
       validation_source_count:
         description: Source participants held out for early stopping/calibration.
         required: true
@@ -265,6 +267,15 @@ on:
           - validation_guarded_source_prior_soft_balanced_assignment
           - validation_guarded_shrunk_source_prior_balanced_assignment
           - validation_selected_balanced_assignment
+      prediction_postprocessing_selection_metric:
+        description: Source-validation objective for validation_selected_balanced_assignment.
+        required: true
+        default: balanced_accuracy
+        type: choice
+        options:
+          - balanced_accuracy
+          - balanced_top2_top3_rank
+          - balanced_top2_top3_rank_balance
       prediction_postprocessing_shrinkage_alphas:
         description: Candidate shrinkage strengths for guarded shrunk source-prior assignment.
         required: true
@@ -365,6 +376,7 @@ jobs:
             --score-calibration-selection-metric "${{ inputs.score_calibration_selection_metric }}"
             --score-calibration-guard-tolerance "${{ inputs.score_calibration_guard_tolerance }}"
             --prediction-postprocessing "${{ inputs.prediction_postprocessing }}"
+            --prediction-postprocessing-selection-metric "${{ inputs.prediction_postprocessing_selection_metric }}"
             --prediction-postprocessing-shrinkage-alphas "${{ inputs.prediction_postprocessing_shrinkage_alphas }}"
             --prediction-postprocessing-margin-thresholds "${{ inputs.prediction_postprocessing_margin_thresholds }}"
             --prediction-postprocessing-guard-tolerance "${{ inputs.prediction_postprocessing_guard_tolerance }}"

--- a/src/pymegdec/grouped_cli.py
+++ b/src/pymegdec/grouped_cli.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Sequence
 from pymegdec import alpha_cli, neureptrace_compat
 from pymegdec import cli as legacy_cli
 from pymegdec import (
+    stimulus_artifact_ensemble,
     stimulus_cli,
     stimulus_covariance_features,
     stimulus_cue_low_capacity,
@@ -56,6 +57,7 @@ def _stimulus_handlers() -> dict[str, CommandHandler]:
         "cross-subject-smoke": stimulus_cli.stimulus_cross_subject_smoke,
         "decoding": legacy_cli.stimulus_decoding,
         "predictions": stimulus_cli.stimulus_predictions,
+        "artifact-ensemble": stimulus_artifact_ensemble.main,
         "robustness": stimulus_cli.stimulus_robustness,
         "temporal-generalization": stimulus_temporal_generalization,
         "onset-scan": stimulus_onset_scan,
@@ -100,6 +102,7 @@ def _top_level_handlers() -> dict[str, CommandHandler]:
         "stimulus-cross-subject-nested": stimulus_cli.stimulus_cross_subject_nested,
         "stimulus-cross-subject-smoke": stimulus_cli.stimulus_cross_subject_smoke,
         "stimulus-predictions": stimulus_cli.stimulus_predictions,
+        "stimulus-artifact-ensemble": stimulus_artifact_ensemble.main,
         "stimulus-robustness": stimulus_cli.stimulus_robustness,
         "stimulus-temporal-generalization": stimulus_temporal_generalization,
         "stimulus-onset-scan": stimulus_onset_scan,
@@ -121,8 +124,8 @@ def _print_main_help() -> None:
     parser.print_help()
     print(
         "\nCommand groups:\n"
-        "  pymegdec stimulus <cross-subject-cue-calibrated|cross-subject-covariance|cross-subject-full-epoch-lowrank|cross-subject-hyperalignment|cross-subject-logit-stack|cross-subject-source-inner-stack|cross-subject-mcca|cross-subject-nested|cross-subject-smoke|"
-        "decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
+        "  pymegdec stimulus <cross-subject-cue-calibrated|cross-subject-covariance|cross-subject-full-epoch-lowrank|cross-subject-hyperalignment|cross-subject-logit-stack|cross-subject-source-inner-stack|cross-subject-latent-autoencoder|cross-subject-mcca|cross-subject-nested|cross-subject-smoke|"
+        "artifact-ensemble|decoding|predictions|robustness|temporal-generalization|onset-scan>\n"
         "  pymegdec alpha <metrics|movement|movement-results|reaction-time|rt>  # legacy paper-specific analyses\n"
         "  pymegdec config <NeuRepTrace command>  # e.g. validate-manifest, dataset, decode-from-config, transfer-from-config\n"
         "  pymegdec data <write-neureptrace-spec>\n"

--- a/src/pymegdec/stimulus_artifact_ensemble.py
+++ b/src/pymegdec/stimulus_artifact_ensemble.py
@@ -27,11 +27,16 @@ ARTIFACT_AGGREGATION_MODE_CHOICES = (
     "hard_vote",
     "mean_score",
     "confidence_weighted_mean_score",
+    "entropy_weighted_mean_score",
     "log_score_mean",
+    "score_rank_fusion",
     "mean_rank",
     "borda",
     "score_tiebreak_first_source",
     "balanced_assignment",
+    "balanced_assignment_shrink25",
+    "balanced_assignment_shrink50",
+    "balanced_assignment_shrink75",
 )
 ARTIFACT_NESTED_SELECTION_METRIC_CHOICES = (
     "balanced_accuracy",
@@ -295,6 +300,19 @@ def _safe_log_score(value: float) -> float:
     return math.log(value)
 
 
+def _normalize_fusion_values(values: Sequence[float]) -> list[float]:
+    """Return non-negative comparable values for score/rank fusion."""
+
+    finite_values = [float(value) for value in values]
+    if not finite_values:
+        return []
+    if all(math.isfinite(value) and value >= 0.0 for value in finite_values):
+        total = sum(finite_values)
+        if total > 0.0 and math.isfinite(total):
+            return [value / total for value in finite_values]
+    return _normalize_score_values(finite_values, "z_softmax")
+
+
 def _score_margin_confidence(values: Sequence[float]) -> float:
     """Return a label-free confidence proxy for one source's class scores."""
 
@@ -308,6 +326,26 @@ def _score_margin_confidence(values: Sequence[float]) -> float:
     if not math.isfinite(margin):
         return 0.0
     return max(0.0, float(margin))
+
+
+def _score_entropy_confidence(values: Sequence[float]) -> float:
+    """Return a label-free confidence proxy based on normalized score entropy.
+
+    This favors sources with concentrated class-score mass while downweighting
+    nearly uniform, high-entropy score vectors.  The value is in ``[0, 1]`` for
+    non-negative scores and is safe to use as a dynamic source weight.
+    """
+
+    finite = [max(0.0, float(value)) for value in values if math.isfinite(float(value))]
+    total = sum(finite)
+    if total <= 0.0:
+        return 0.0
+    probabilities = [value / total for value in finite]
+    if len(probabilities) <= 1:
+        return 1.0
+    entropy = -sum(probability * math.log(probability) for probability in probabilities if probability > 0.0)
+    normalized_entropy = entropy / math.log(len(probabilities))
+    return min(1.0, max(0.0, 1.0 - normalized_entropy))
 
 
 def _normalize_artifact_score_normalization(score_normalization: str) -> str:
@@ -329,10 +367,13 @@ def _normalize_artifact_aggregation_mode(aggregation_mode: str) -> str:
         "confidence_weighted": "confidence_weighted_mean_score",
         "confidence_weighted_score": "confidence_weighted_mean_score",
         "confidence_weighted_score_mean": "confidence_weighted_mean_score",
-        "entropy_weighted_score_mean": "confidence_weighted_mean_score",
         "margin_weighted_score_mean": "confidence_weighted_mean_score",
         "rank": "mean_rank",
         "rank_mean": "mean_rank",
+        "entropy_weighted": "entropy_weighted_mean_score",
+        "entropy_weighted_mean": "entropy_weighted_mean_score",
+        "entropy_weighted_score": "entropy_weighted_mean_score",
+        "entropy_weighted_score_mean": "entropy_weighted_mean_score",
         "class_rank_mean": "mean_rank",
         "class_rank_borda": "borda",
         "hard": "hard_vote",
@@ -344,9 +385,24 @@ def _normalize_artifact_aggregation_mode(aggregation_mode: str) -> str:
         "geometric_mean": "log_score_mean",
         "geometric_score_mean": "log_score_mean",
         "product_score": "log_score_mean",
+        "score_rank": "score_rank_fusion",
+        "rank_score": "score_rank_fusion",
+        "score_rank_mean": "score_rank_fusion",
+        "rank_score_mean": "score_rank_fusion",
+        "score_borda_fusion": "score_rank_fusion",
         "quota": "balanced_assignment",
         "balanced": "balanced_assignment",
         "uniform_balanced_assignment": "balanced_assignment",
+        "balanced_assignment_shrinkage": "balanced_assignment_shrink50",
+        "balanced_assignment_shrinkage_25": "balanced_assignment_shrink25",
+        "balanced_assignment_shrinkage_50": "balanced_assignment_shrink50",
+        "balanced_assignment_shrinkage_75": "balanced_assignment_shrink75",
+        "balanced_assignment_25": "balanced_assignment_shrink25",
+        "balanced_assignment_50": "balanced_assignment_shrink50",
+        "balanced_assignment_75": "balanced_assignment_shrink75",
+        "quota_shrink25": "balanced_assignment_shrink25",
+        "quota_shrink50": "balanced_assignment_shrink50",
+        "quota_shrink75": "balanced_assignment_shrink75",
     }
     normalized = aliases.get(normalized, normalized)
     if normalized not in ARTIFACT_AGGREGATION_MODE_CHOICES:
@@ -375,6 +431,25 @@ def _normalize_artifact_nested_selection_metric(selection_metric: str) -> str:
     return normalized
 
 
+def _is_balanced_assignment_mode(aggregation_mode: str) -> bool:
+    """Return whether an aggregation mode applies participant-level assignment."""
+
+    return _normalize_artifact_aggregation_mode(aggregation_mode).startswith("balanced_assignment")
+
+
+def _balanced_assignment_uniform_alpha(aggregation_mode: str) -> float:
+    """Return the assignment quota shrinkage toward a uniform class prior."""
+
+    normalized = _normalize_artifact_aggregation_mode(aggregation_mode)
+    if normalized == "balanced_assignment_shrink25":
+        return 0.25
+    if normalized == "balanced_assignment_shrink50":
+        return 0.50
+    if normalized == "balanced_assignment_shrink75":
+        return 0.75
+    return 1.0
+
+
 def _class_value_columns(rows: Sequence[dict[str, str]], patterns: Sequence[tuple[re.Pattern[str], int]]) -> dict[int, str]:
     common: dict[int, str] | None = None
     for row in rows:
@@ -399,6 +474,7 @@ def _aggregate_class_scores(
     score_normalization: str = "raw",
     use_log_scores: bool = False,
     confidence_weighted: bool = False,
+    entropy_weighted: bool = False,
 ) -> tuple[dict[int, float], str] | None:
     score_columns = _class_value_columns(source_rows, CLASS_SCORE_PATTERNS)
     if not score_columns:
@@ -406,6 +482,8 @@ def _aggregate_class_scores(
     normalized = _normalize_artifact_score_normalization(score_normalization)
     weights = _normalized_source_weights(source_weights, len(source_rows))
     scored_labels = [label for label in class_labels if label in score_columns]
+    if confidence_weighted and entropy_weighted:
+        raise ValueError("Artifact score aggregation cannot use margin and entropy weighting at the same time.")
     if not scored_labels:
         return None
     normalized_rows: list[tuple[list[float], float]] = []
@@ -413,9 +491,11 @@ def _aggregate_class_scores(
         values = [float(row[score_columns[label]]) for label in scored_labels]
         normalized_values = _normalize_score_values(values, normalized)
         confidence = _score_margin_confidence(normalized_values) if confidence_weighted else 1.0
+        if entropy_weighted:
+            confidence = _score_entropy_confidence(normalized_values)
         normalized_rows.append((normalized_values, base_weight * confidence))
 
-    if confidence_weighted:
+    if confidence_weighted or entropy_weighted:
         dynamic_total = sum(weight for _values, weight in normalized_rows if math.isfinite(weight) and weight > 0.0)
         if dynamic_total > 0.0:
             dynamic_weights = [max(0.0, weight) / dynamic_total for _values, weight in normalized_rows]
@@ -429,7 +509,15 @@ def _aggregate_class_scores(
         for label, value in zip(scored_labels, normalized_values, strict=True):
             contribution = _safe_log_score(value) if use_log_scores else value
             scores[label] = scores.get(label, 0.0) + weight * contribution
-    if confidence_weighted and normalized == "raw" and source_weights is None:
+    if entropy_weighted and normalized == "raw" and source_weights is None:
+        source = "class_score_entropy_weighted_mean"
+    elif entropy_weighted and normalized == "raw":
+        source = "class_score_prior_entropy_weighted_mean"
+    elif entropy_weighted and source_weights is not None:
+        source = f"class_score_{normalized}_prior_entropy_weighted_mean"
+    elif entropy_weighted:
+        source = f"class_score_{normalized}_entropy_weighted_mean"
+    elif confidence_weighted and normalized == "raw" and source_weights is None:
         source = "class_score_confidence_weighted_mean"
     elif confidence_weighted and normalized == "raw":
         source = "class_score_prior_confidence_weighted_mean"
@@ -456,6 +544,29 @@ def _aggregate_class_scores(
     return scores, source
 
 
+def _aggregate_class_ranks(
+    source_rows: Sequence[dict[str, str]],
+    *,
+    class_labels: Sequence[int],
+    source_weights: Sequence[float] | None = None,
+) -> tuple[dict[int, float], str] | None:
+    rank_columns = _class_value_columns(source_rows, CLASS_RANK_PATTERNS)
+    if not rank_columns:
+        return None
+    weights = _normalized_source_weights(source_weights, len(source_rows))
+    rank_scores: dict[int, float] = {}
+    for label in class_labels:
+        column = rank_columns.get(label)
+        if column is None:
+            continue
+        values = [
+            weight * float(row[column])
+            for row, weight in zip(source_rows, weights, strict=True)
+        ]
+        rank_scores[label] = -sum(values)
+    return (rank_scores, "class_rank_mean") if rank_scores else None
+
+
 def _rank_labels_by_scores(
     source_rows: Sequence[dict[str, str]],
     *,
@@ -470,9 +581,13 @@ def _rank_labels_by_scores(
         "auto",
         "mean_score",
         "confidence_weighted_mean_score",
+        "entropy_weighted_mean_score",
         "log_score_mean",
         "score_tiebreak_first_source",
-        "balanced_assignment",
+    }
+    score_modes = {
+        *score_modes,
+        *(mode for mode in ARTIFACT_AGGREGATION_MODE_CHOICES if _is_balanced_assignment_mode(mode)),
     }
     aggregated = None
     if mode in score_modes:
@@ -483,13 +598,61 @@ def _rank_labels_by_scores(
             score_normalization=score_normalization,
             use_log_scores=mode == "log_score_mean",
             confidence_weighted=mode == "confidence_weighted_mean_score",
+            entropy_weighted=mode == "entropy_weighted_mean_score",
+        )
+    if mode == "score_rank_fusion":
+        score_aggregated = _aggregate_class_scores(
+            source_rows,
+            class_labels=class_labels,
+            source_weights=source_weights,
+            score_normalization=score_normalization,
+        )
+        rank_aggregated = _aggregate_class_ranks(
+            source_rows,
+            class_labels=class_labels,
+            source_weights=source_weights,
+        )
+        if score_aggregated is None or rank_aggregated is None:
+            return None
+        scores, score_source = score_aggregated
+        rank_scores, rank_source = rank_aggregated
+        fused_labels = [
+            label for label in class_labels if label in scores and label in rank_scores
+        ]
+        if not fused_labels:
+            return None
+        score_values = _normalize_fusion_values([scores[label] for label in fused_labels])
+        rank_values = _normalize_score_values(
+            [rank_scores[label] for label in fused_labels],
+            "z_softmax",
+        )
+        fused_scores = {
+            label: 0.5 * score_value + 0.5 * rank_value
+            for label, score_value, rank_value in zip(
+                fused_labels,
+                score_values,
+                rank_values,
+                strict=True,
+            )
+        }
+        tie_order = {label: index for index, label in enumerate(tie_break_labels)}
+        return (
+            sorted(
+                class_labels,
+                key=lambda label: (
+                    -fused_scores.get(label, float("-inf")),
+                    tie_order.get(label, len(tie_order)),
+                    label,
+                ),
+            ),
+            f"{score_source}_{rank_source}_fusion",
         )
     if aggregated is not None:
         scores, source = aggregated
         if mode == "score_tiebreak_first_source":
             source = f"{source}_tiebreak_first_source"
-        if mode == "balanced_assignment":
-            source = f"{source}_balanced_assignment_candidate"
+        if _is_balanced_assignment_mode(mode):
+            source = f"{source}_{mode}_candidate"
         tie_order = {label: index for index, label in enumerate(tie_break_labels)}
         return (
             sorted(
@@ -503,25 +666,28 @@ def _rank_labels_by_scores(
             source,
         )
 
-    if mode in {"mean_score", "confidence_weighted_mean_score", "log_score_mean", "score_tiebreak_first_source"}:
+    if mode in {"mean_score", "confidence_weighted_mean_score", "entropy_weighted_mean_score", "log_score_mean", "score_tiebreak_first_source"}:
         return None
 
     if mode in {"auto", "mean_rank", "borda"}:
-        rank_columns = _class_value_columns(source_rows, CLASS_RANK_PATTERNS)
+        rank_aggregated = _aggregate_class_ranks(
+            source_rows,
+            class_labels=class_labels,
+            source_weights=source_weights,
+        )
     else:
-        rank_columns = {}
-    if rank_columns:
-        weights = _normalized_source_weights(source_weights, len(source_rows))
-        borda_scores: dict[int, float] = {}
-        for label in class_labels:
-            column = rank_columns.get(label)
-            if column is None:
-                continue
-            values = [weight * float(row[column]) for row, weight in zip(source_rows, weights, strict=True)]
-            borda_scores[label] = -sum(values)
-        if borda_scores:
+        rank_aggregated = None
+    if rank_aggregated is not None:
+        rank_scores, _rank_source = rank_aggregated
+        if rank_scores:
             rank_source = "class_rank_mean" if mode == "mean_rank" else "class_rank_borda"
-            return sorted(class_labels, key=lambda label: (-borda_scores.get(label, float("-inf")), label)), rank_source
+            return (
+                sorted(
+                    class_labels,
+                    key=lambda label: (-rank_scores.get(label, float("-inf")), label),
+                ),
+                rank_source,
+            )
 
     return None
 
@@ -689,6 +855,7 @@ def _prediction_row(
         score_normalization=score_normalization,
         use_log_scores=aggregation_mode == "log_score_mean",
         confidence_weighted=aggregation_mode == "confidence_weighted_mean_score",
+        entropy_weighted=aggregation_mode == "entropy_weighted_mean_score",
     )
     if aggregated is not None:
         aggregate_scores, _score_source = aggregated
@@ -705,6 +872,59 @@ def _uniform_class_quotas(n_items: int, n_classes: int) -> list[int]:
     for index in range(int(n_items) - sum(quotas)):
         quotas[index] += 1
     return quotas
+
+
+def _rounded_quota_counts(expected_counts: Sequence[float], *, n_items: int) -> list[int]:
+    """Round expected class counts while preserving the total row count."""
+
+    expected = [max(0.0, float(value)) for value in expected_counts]
+    if not expected:
+        return []
+    floors = [int(math.floor(value)) for value in expected]
+    remaining = int(n_items) - sum(floors)
+    if remaining < 0:
+        total = sum(expected)
+        if total <= 0.0:
+            return _uniform_class_quotas(n_items, len(expected))
+        return _rounded_quota_counts(
+            [value * float(n_items) / total for value in expected],
+            n_items=n_items,
+        )
+
+    remainders = [value - math.floor(value) for value in expected]
+    order = sorted(range(len(expected)), key=lambda index: (-remainders[index], index))
+    quotas = list(floors)
+    for index in order[:remaining]:
+        quotas[index] += 1
+    return quotas
+
+
+def _balanced_assignment_class_quotas(
+    rows: Sequence[dict[str, object]],
+    indices: Sequence[int],
+    class_labels: Sequence[int],
+    *,
+    uniform_alpha: float,
+) -> list[int]:
+    """Return class quotas for exact or shrinkage balanced assignment."""
+
+    label_list = [int(label) for label in class_labels]
+    uniform_alpha = min(max(float(uniform_alpha), 0.0), 1.0)
+    uniform = _uniform_class_quotas(len(indices), len(label_list))
+    if uniform_alpha >= 1.0 - 1e-12:
+        return uniform
+
+    label_to_index = {label: index for index, label in enumerate(label_list)}
+    predicted_counts = [0 for _ in label_list]
+    for row_index in indices:
+        predicted = _to_int(rows[row_index]["predicted_label"], field="predicted_label")
+        if predicted in label_to_index:
+            predicted_counts[label_to_index[predicted]] += 1
+    expected = [
+        (1.0 - uniform_alpha) * predicted + uniform_alpha * quota
+        for predicted, quota in zip(predicted_counts, uniform, strict=True)
+    ]
+    return _rounded_quota_counts(expected, n_items=len(indices))
 
 
 def _balanced_assignment_indices(score_matrix: Sequence[Sequence[float]], quotas: Sequence[int]) -> tuple[list[int], float]:
@@ -731,7 +951,12 @@ def _balanced_assignment_indices(score_matrix: Sequence[Sequence[float]], quotas
     return predicted, float(assignment_score - argmax_score)
 
 
-def _apply_balanced_assignment_rows(prediction_rows: Sequence[dict[str, object]], class_labels: Sequence[int]) -> list[dict[str, object]]:
+def _apply_balanced_assignment_rows(
+    prediction_rows: Sequence[dict[str, object]],
+    class_labels: Sequence[int],
+    *,
+    uniform_alpha: float = 1.0,
+) -> list[dict[str, object]]:
     rows = [dict(row) for row in prediction_rows]
     label_list = [int(label) for label in class_labels]
     display_labels = _display_label_map(label_list)
@@ -747,7 +972,12 @@ def _apply_balanced_assignment_rows(prediction_rows: Sequence[dict[str, object]]
                 f"missing examples={missing[:5]}."
             )
         score_matrix = [[_to_float(rows[index][column]) for column in score_columns] for index in indices]
-        quotas = _uniform_class_quotas(len(indices), len(label_list))
+        quotas = _balanced_assignment_class_quotas(
+            rows,
+            indices,
+            label_list,
+            uniform_alpha=uniform_alpha,
+        )
         assigned_indices, objective_delta = _balanced_assignment_indices(score_matrix, quotas)
         quota_text = ";".join(f"{label}:{quota}" for label, quota in zip(label_list, quotas, strict=True))
         for row_index, assigned_index in zip(indices, assigned_indices, strict=True):
@@ -757,7 +987,12 @@ def _apply_balanced_assignment_rows(prediction_rows: Sequence[dict[str, object]]
             row["predicted_label"] = predicted_label
             row["predicted_stimulus"] = display_labels.get(predicted_label, predicted_label)
             row["correct"] = predicted_label == true_label
-            row["artifact_ensemble_mode"] = "class_score_balanced_assignment"
+            row["artifact_ensemble_mode"] = (
+                "class_score_balanced_assignment"
+                if uniform_alpha >= 1.0 - 1e-12
+                else f"class_score_balanced_assignment_shrink{int(round(100.0 * uniform_alpha)):02d}"
+            )
+            row["artifact_ensemble_balanced_assignment_uniform_alpha"] = f"{uniform_alpha:.6g}"
             row["artifact_ensemble_balanced_assignment_quota_counts"] = quota_text
             row["artifact_ensemble_balanced_assignment_objective_delta"] = objective_delta
     return rows
@@ -968,6 +1203,12 @@ def _nested_source_weight_selector(
             score_normalization=score_normalization,
             aggregation_mode=aggregation_mode,
         )
+        if _is_balanced_assignment_mode(aggregation_mode):
+            prediction_rows = _apply_balanced_assignment_rows(
+                prediction_rows,
+                class_labels,
+                uniform_alpha=_balanced_assignment_uniform_alpha(aggregation_mode),
+            )
         outer_rows = _outer_rows(f"{selector_name}__candidate_{candidate_index}", prediction_rows, n_classes=n_classes)
         by_participant: dict[str, list[dict]] = defaultdict(list)
         for row in prediction_rows:
@@ -1298,8 +1539,12 @@ def ensemble_prediction_sources(
             )
             for key in sorted(reference_keys, key=_prediction_key_sort_key)
         ]
-        if aggregation_mode == "balanced_assignment":
-            prediction_rows = _apply_balanced_assignment_rows(prediction_rows, class_labels)
+        if _is_balanced_assignment_mode(aggregation_mode):
+            prediction_rows = _apply_balanced_assignment_rows(
+                prediction_rows,
+                class_labels,
+                uniform_alpha=_balanced_assignment_uniform_alpha(aggregation_mode),
+            )
         outer_rows = _outer_rows(ensemble_name, prediction_rows, n_classes=len(class_labels))
         summary = _group_summary(
             ensemble_name,
@@ -1419,7 +1664,7 @@ def main(argv: list[str] | None = None) -> int:
         "--aggregation-mode",
         choices=ARTIFACT_AGGREGATION_MODE_CHOICES,
         default="auto",
-        help="How to combine source predictions: score/log-score mean, rank/Borda, hard vote, balanced assignment, or automatic score-then-rank fallback.",
+        help="How to combine source predictions: score/log-score/entropy-weighted mean, rank/Borda, hard vote, balanced assignment, or automatic score-then-rank fallback.",
     )
     parser.add_argument(
         "--nested-selection-metric",

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -50,6 +50,8 @@ LATENT_TRAINING_PRESET_CHOICES = (
     "none",
     "anti_collapse_train",
     "anti_collapse_calibrated",
+    "anti_collapse_refit",
+    "anti_collapse_head_refit",
 )
 DEFAULT_LATENT_VALIDATION_SOURCE_STRATEGY = "rotating"
 DEFAULT_LATENT_SELECTED_SCORE_CALIBRATION_CANDIDATES = (
@@ -134,6 +136,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     score_calibration_final_refit: bool = False
     prediction_postprocessing: str = "none"
     prediction_postprocessing_guard_tolerance: float = 0.0
+    prediction_postprocessing_selection_metric: str = "balanced_accuracy"
     prediction_postprocessing_quota_strength: float = 1.0
     prediction_postprocessing_shrinkage_alphas: tuple[float, ...] = (0.0, 0.25, 0.5, 0.75, 1.0)
     prediction_postprocessing_margin_thresholds: tuple[float, ...] = (0.0, 0.1, 0.2, 0.3, 0.5, 0.75, 1.0)
@@ -224,6 +227,12 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
     ``anti_collapse_train`` changes training/epoch-selection only.
     ``anti_collapse_calibrated`` additionally enables guarded source-validation
     score calibration and source-validation-selected balanced assignment.
+    ``anti_collapse_refit`` also replaces the joint neural classifier head with
+    a source-validation-selected multinomial logistic probe on the frozen shared
+    latent space.  This targets the smoke-run failure mode where the learned
+    representation ranks classes reasonably but the neural head collapses to a few argmax classes.
+    ``anti_collapse_head_refit`` adds a source-validation-selected logistic
+    classifier on the learned latent space before the guarded calibration stack.
     """
 
     preset = str(preset or DEFAULT_LATENT_TRAINING_PRESET)
@@ -272,6 +281,53 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
             final_min_epochs=final_min_epochs,
         )
 
+    if preset == "anti_collapse_refit":
+        return replace(
+            config,
+            training_preset=preset,
+            balanced_batch_sampling=True,
+            label_smoothing=label_smoothing,
+            prediction_balance_weight=prediction_balance_weight,
+            prediction_balance_target_smoothing=1.0,
+            prediction_balance_temperature=prediction_balance_temperature,
+            logit_mean_center_weight=logit_mean_center_weight,
+            soft_macro_recall_weight=soft_macro_recall_weight,
+            validation_source_count=validation_source_count,
+            validation_prediction_balance_weight=validation_prediction_balance_weight,
+            validation_selection_metric="balanced_top2_top3_rank_balance",
+            final_min_epochs=final_min_epochs,
+            # The neural classifier head is trained jointly with reconstruction.
+            # In the smoke run, the latent space still carried useful rank signal
+            # while the argmax distribution collapsed.  A source-only logistic
+            # probe on frozen latents gives the classifier a convex balanced
+            # objective after representation learning, without touching held-out
+            # main-task labels.
+            latent_head_refit="validation_selected_source_logistic",
+            latent_head_refit_selection_metric="balanced_top2_top3_rank_balance",
+            score_calibration="validation_selected_guarded",
+            score_calibration_selection_metric="balanced_top2_top3_rank_balance",
+            score_calibration_guard_tolerance=min(float(config.score_calibration_guard_tolerance), 0.0),
+            score_calibration_final_refit=True,
+            prediction_postprocessing="validation_selected_balanced_assignment",
+            prediction_postprocessing_selection_metric="balanced_top2_top3_rank_balance",
+            prediction_postprocessing_guard_tolerance=min(
+                float(config.prediction_postprocessing_guard_tolerance),
+                0.0,
+            ),
+        )
+
+    head_refit_kwargs = {}
+    if preset == "anti_collapse_head_refit":
+        # Keep the neural encoder/decoders as the representation learner, but
+        # let a source-only, class-balanced logistic head handle the final
+        # decision boundary.  The C value is selected on source-validation
+        # participants only; no held-out-subject labels are used.
+        head_refit_kwargs = {
+            "latent_head_refit": "validation_selected_source_logistic",
+            "latent_head_refit_selection_metric": "balanced_top2_top3_rank_balance",
+            "latent_head_refit_c_values": (0.03, 0.1, 0.3, 1.0, 3.0),
+        }
+
     return replace(
         config,
         training_preset=preset,
@@ -292,10 +348,12 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
         score_calibration_guard_tolerance=min(float(config.score_calibration_guard_tolerance), 0.0),
         score_calibration_final_refit=True,
         prediction_postprocessing="validation_selected_balanced_assignment",
+        prediction_postprocessing_selection_metric="balanced_top2_top3_rank_balance",
         prediction_postprocessing_guard_tolerance=min(
             float(config.prediction_postprocessing_guard_tolerance),
             0.0,
         ),
+        **head_refit_kwargs,
     )
 
 
@@ -1152,6 +1210,50 @@ def _validation_selection_metrics(
     else:
         raise ValueError(
             "validation_selection_metric must be one of: "
+            "balanced_accuracy, balanced_top2_top3_rank, balanced_top2_top3_rank_balance"
+        )
+    return {
+        "selection_score": float(selection_score),
+        "balanced_accuracy": balanced,
+        "top2_accuracy": top2,
+        "top3_accuracy": top3,
+        "mean_true_label_rank": float(np.nanmean(ranks)),
+        "rank_score": rank_score,
+        "prediction_balance_score": balance_score,
+    }
+
+
+def _validation_selection_metrics_from_predictions(
+    true_labels: np.ndarray,
+    scores: np.ndarray,
+    classes: np.ndarray,
+    predicted_labels: np.ndarray,
+    metric: str,
+) -> dict[str, float]:
+    """Score source-validation predictions using rank-aware objectives."""
+
+    true_labels = np.asarray(true_labels, dtype=int)
+    scores = np.asarray(scores, dtype=float)
+    classes = np.asarray(classes, dtype=int)
+    predicted_labels = np.asarray(predicted_labels, dtype=int)
+    ranks = _true_label_ranks(true_labels, scores, classes)
+    balanced = float(balanced_accuracy_score(true_labels, predicted_labels))
+    top2 = float(np.mean(ranks <= 2))
+    top3 = float(np.mean(ranks <= 3))
+    rank_score = _rank_score_from_ranks(ranks, n_classes=int(classes.shape[0]))
+    balance_score = _prediction_balance_score(predicted_labels, classes)
+    metric = str(metric or "balanced_accuracy")
+    if metric == "balanced_accuracy":
+        selection_score = balanced
+    elif metric == "balanced_top2_top3_rank":
+        selection_score = balanced + 0.20 * top2 + 0.10 * top3 + 0.10 * rank_score
+    elif metric == "balanced_top2_top3_rank_balance":
+        selection_score = (
+            balanced + 0.20 * top2 + 0.10 * top3 + 0.10 * rank_score + 0.05 * balance_score
+        )
+    else:
+        raise ValueError(
+            "prediction_postprocessing_selection_metric must be one of: "
             "balanced_accuracy, balanced_top2_top3_rank, balanced_top2_top3_rank_balance"
         )
     return {
@@ -2457,6 +2559,16 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "prediction_postprocessing_validation_objective_delta": fit_metadata.get(
             "prediction_postprocessing_validation_objective_delta", np.nan
         ),
+        "prediction_postprocessing_validation_selection_score": fit_metadata.get(
+            "prediction_postprocessing_validation_selection_score", np.nan
+        ),
+        "prediction_postprocessing_uncalibrated_validation_selection_score": fit_metadata.get(
+            "prediction_postprocessing_uncalibrated_validation_selection_score", np.nan
+        ),
+        "prediction_postprocessing_selection_metric": fit_metadata.get(
+            "prediction_postprocessing_selection_metric",
+            config.prediction_postprocessing_selection_metric,
+        ),
         "prediction_postprocessing_margin_threshold": fit_metadata.get(
             "prediction_postprocessing_margin_threshold", np.nan
         ),
@@ -2606,6 +2718,7 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "prediction_postprocessing_selected_method_counts": _format_counter(
                 Counter(row.get("prediction_postprocessing_selected_method", "none") for row in outer_rows)
             ),
+            "prediction_postprocessing_selection_metric": config.prediction_postprocessing_selection_metric,
             "prediction_postprocessing_guard_tolerance": config.prediction_postprocessing_guard_tolerance,
             "prediction_postprocessing_margin_thresholds": ";".join(
                 str(float(threshold)) for threshold in config.prediction_postprocessing_margin_thresholds
@@ -2943,11 +3056,21 @@ def _validation_balanced_assignment_candidates(
         margin_threshold: float = np.nan,
         fixed_predictions: int = 0,
     ) -> None:
+        metrics = _validation_selection_metrics_from_predictions(
+            validation_labels,
+            validation_scores,
+            classes,
+            predictions,
+            config.prediction_postprocessing_selection_metric,
+        )
         rows.append(
             {
                 "selected_method": selected_method,
                 "validation_predictions": np.asarray(predictions, dtype=int),
-                "validation_balanced_accuracy": float(balanced_accuracy_score(validation_labels, predictions)),
+                "validation_balanced_accuracy": float(metrics["balanced_accuracy"]),
+                "validation_selection_score": float(metrics["selection_score"]),
+                "validation_selection_metric": config.prediction_postprocessing_selection_metric,
+                "validation_prediction_balance_score": float(metrics["prediction_balance_score"]),
                 "validation_objective_delta": float(objective_delta),
                 "shrinkage_alpha": float(shrinkage_alpha) if np.isfinite(shrinkage_alpha) else np.nan,
                 "quota_source": quota_source,
@@ -3035,6 +3158,7 @@ def _validation_balanced_assignment_candidates(
     }
     rows.sort(
         key=lambda row: (
+            row["validation_selection_score"],
             row["validation_balanced_accuracy"],
             row["validation_objective_delta"],
             -method_priority[row["selected_method"]],
@@ -3066,8 +3190,11 @@ def _postprocess_predictions(
         "prediction_postprocessing_validation_balanced_accuracy": np.nan,
         "prediction_postprocessing_uncalibrated_validation_balanced_accuracy": np.nan,
         "prediction_postprocessing_validation_objective_delta": np.nan,
+        "prediction_postprocessing_validation_selection_score": np.nan,
+        "prediction_postprocessing_uncalibrated_validation_selection_score": np.nan,
         "prediction_postprocessing_guard_tolerance": float(config.prediction_postprocessing_guard_tolerance),
         "prediction_postprocessing_quota_strength": float(config.prediction_postprocessing_quota_strength),
+        "prediction_postprocessing_selection_metric": config.prediction_postprocessing_selection_metric,
         "prediction_postprocessing_apply": False,
         "prediction_postprocessing_shrinkage_alpha": np.nan,
         "prediction_postprocessing_shrinkage_alphas": ";".join(str(float(alpha)) for alpha in config.prediction_postprocessing_shrinkage_alphas),
@@ -3138,6 +3265,12 @@ def _postprocess_predictions(
                 ],
                 "prediction_postprocessing_validation_objective_delta": selected_row[
                     "validation_objective_delta"
+                ],
+                "prediction_postprocessing_validation_selection_score": selected_row[
+                    "validation_selection_score"
+                ],
+                "prediction_postprocessing_uncalibrated_validation_selection_score": unprocessed_row[
+                    "validation_selection_score"
                 ],
                 "prediction_postprocessing_shrinkage_alpha": selected_row["shrinkage_alpha"],
                 "prediction_postprocessing_margin_threshold": selected_row["margin_threshold"],
@@ -3913,6 +4046,15 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--prediction-postprocessing-selection-metric",
+        choices=("balanced_accuracy", "balanced_top2_top3_rank", "balanced_top2_top3_rank_balance"),
+        default="balanced_accuracy",
+        help=(
+            "Source-validation objective used by validation_selected_balanced_assignment. "
+            "Use balanced_top2_top3_rank_balance when selecting among assignment candidates."
+        ),
+    )
+    parser.add_argument(
         "--prediction-postprocessing-shrinkage-alphas",
         type=_parse_float_sequence,
         default=(0.0, 0.25, 0.5, 0.75, 1.0),
@@ -4022,6 +4164,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         score_calibration_final_refit=bool(args.score_calibration_final_refit),
         prediction_postprocessing=args.prediction_postprocessing,
         prediction_postprocessing_guard_tolerance=args.prediction_postprocessing_guard_tolerance,
+        prediction_postprocessing_selection_metric=args.prediction_postprocessing_selection_metric,
         prediction_postprocessing_quota_strength=args.prediction_postprocessing_quota_strength,
         prediction_postprocessing_margin_thresholds=args.prediction_postprocessing_margin_thresholds,
         prediction_postprocessing_shrinkage_alphas=args.prediction_postprocessing_shrinkage_alphas,

--- a/tests/test_stimulus_artifact_ensemble.py
+++ b/tests/test_stimulus_artifact_ensemble.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import unittest
+from collections import Counter
 from pathlib import Path
 
 from pymegdec.stimulus_artifact_ensemble import PredictionSource, ensemble_prediction_sources, parse_ensemble_spec, resolve_prediction_csv
@@ -52,6 +53,25 @@ def _multi_scored_row(predicted_label: int, scores: list[float]) -> dict[str, st
             for class_index, score in enumerate(scores)
         }
     )
+    return row
+
+
+def _multi_two_class_scored_row(
+    trial_index: int,
+    true_label: int,
+    predicted_label: int,
+    class_0_score: float,
+    class_1_score: float,
+) -> dict[str, str]:
+    row = _row(
+        1,
+        trial_index,
+        true_label,
+        predicted_label,
+        true_label_rank=1.0 if true_label == predicted_label else 2.0,
+    )
+    row["score_class_0"] = f"{class_0_score:.2f}"
+    row["score_class_1"] = f"{class_1_score:.2f}"
     return row
 
 
@@ -226,6 +246,32 @@ class TestStimulusArtifactEnsemble(unittest.TestCase):
         self.assertEqual(prediction["predicted_label"], 0)
         self.assertEqual(prediction["artifact_ensemble_mode"], "class_score_confidence_weighted_mean")
 
+    def test_entropy_weighted_score_mean_downweights_high_entropy_sources(self) -> None:
+        confident = _source("confident", [_multi_scored_row(0, [0.99, 0.01])])
+        uncertain_wrong_sources = [
+            _source(f"uncertain_wrong_{index}", [_multi_scored_row(1, [0.40, 0.60])])
+            for index in range(5)
+        ]
+        sources = [confident, *uncertain_wrong_sources]
+        source_names = tuple(source.name for source in sources)
+
+        mean_artifacts = ensemble_prediction_sources(
+            sources,
+            [("mean", source_names)],
+            aggregation_mode="mean_score",
+        )
+        entropy_artifacts = ensemble_prediction_sources(
+            sources,
+            [("entropy", source_names)],
+            aggregation_mode="entropy_weighted_mean_score",
+        )
+
+        self.assertEqual(mean_artifacts["predictions"][0]["predicted_label"], 1)
+        prediction = entropy_artifacts["predictions"][0]
+        self.assertEqual(prediction["predicted_label"], 0)
+        self.assertEqual(prediction["artifact_ensemble_mode"], "class_score_entropy_weighted_mean")
+        self.assertEqual(entropy_artifacts["group_summary"][0]["balanced_accuracy_mean"], 1.0)
+
     def test_can_force_hard_vote_when_scores_are_available(self) -> None:
         compact = _source("compact", [_scored_row(0, 1, 0.95, 0.05)])
         finetune = _source("finetune", [_scored_row(0, 0, 0.95, 0.05)])
@@ -255,6 +301,32 @@ class TestStimulusArtifactEnsemble(unittest.TestCase):
         self.assertEqual(prediction["predicted_label"], 0)
         self.assertEqual(prediction["artifact_ensemble_requested_aggregation_mode"], "borda")
         self.assertEqual(prediction["artifact_ensemble_mode"], "class_rank_borda")
+
+    def test_score_rank_fusion_combines_score_and_rank_columns(self) -> None:
+        compact = _source(
+            "compact",
+            [{**_scored_row(0, 1, 0.49, 0.51), "rank_class_0": "1.0", "rank_class_1": "2.0"}],
+        )
+        finetune = _source(
+            "finetune",
+            [{**_scored_row(0, 1, 0.49, 0.51), "rank_class_0": "1.0", "rank_class_1": "2.0"}],
+        )
+
+        mean_artifacts = ensemble_prediction_sources(
+            [compact, finetune],
+            [("mean", ("compact", "finetune"))],
+            aggregation_mode="mean_score",
+        )
+        fusion_artifacts = ensemble_prediction_sources(
+            [compact, finetune],
+            [("fusion", ("compact", "finetune"))],
+            aggregation_mode="score_rank_fusion",
+        )
+
+        self.assertEqual(mean_artifacts["predictions"][0]["predicted_label"], 1)
+        prediction = fusion_artifacts["predictions"][0]
+        self.assertEqual(prediction["predicted_label"], 0)
+        self.assertEqual(prediction["artifact_ensemble_mode"], "class_score_mean_class_rank_mean_fusion")
 
     def test_mean_rank_uses_rank_columns(self) -> None:
         compact = _source("compact", [_ranked_row(0, 1, 1.0, 2.0)])
@@ -336,6 +408,44 @@ class TestStimulusArtifactEnsemble(unittest.TestCase):
         self.assertEqual([row["predicted_label"] for row in predictions], [0, 1, 0, 1])
         self.assertEqual({row["artifact_ensemble_mode"] for row in predictions}, {"class_score_balanced_assignment"})
         self.assertEqual(artifacts["group_summary"][0]["balanced_accuracy_mean"], 1.0)
+
+    def test_balanced_assignment_shrinkage_is_less_aggressive_than_uniform_assignment(self) -> None:
+        latent = _source(
+            "latent",
+            [
+                _multi_two_class_scored_row(1, 0, 0, 5.0, 4.0),
+                _multi_two_class_scored_row(2, 1, 0, 4.9, 4.8),
+                _multi_two_class_scored_row(3, 0, 0, 4.7, 1.0),
+                _multi_two_class_scored_row(4, 1, 0, 4.6, 4.5),
+            ],
+        )
+
+        uniform = ensemble_prediction_sources(
+            [latent],
+            [("balanced", ("latent",))],
+            aggregation_mode="balanced_assignment",
+        )
+        shrink50 = ensemble_prediction_sources(
+            [latent],
+            [("balanced", ("latent",))],
+            aggregation_mode="balanced_assignment_shrink50",
+        )
+
+        uniform_counts = Counter(row["predicted_label"] for row in uniform["predictions"])
+        shrink_counts = Counter(row["predicted_label"] for row in shrink50["predictions"])
+        self.assertEqual(dict(uniform_counts), {0: 2, 1: 2})
+        self.assertEqual(dict(shrink_counts), {0: 3, 1: 1})
+        self.assertEqual(
+            {row["artifact_ensemble_mode"] for row in shrink50["predictions"]},
+            {"class_score_balanced_assignment_shrink50"},
+        )
+        self.assertEqual(
+            {
+                row["artifact_ensemble_balanced_assignment_uniform_alpha"]
+                for row in shrink50["predictions"]
+            },
+            {"0.5"},
+        )
 
     def test_rejects_misaligned_source_prediction_keys(self) -> None:
         compact = _source("compact", [_row(1, 1, 0, 0)])

--- a/tests/test_stimulus_latent_autoencoder_postprocessing.py
+++ b/tests/test_stimulus_latent_autoencoder_postprocessing.py
@@ -235,6 +235,37 @@ def test_validation_selected_balanced_assignment_uses_source_validation_choice()
     assert metadata["prediction_postprocessing_selected_method"] != "none"
 
 
+def test_validation_selected_balanced_assignment_records_rank_balance_selection_metric():
+    classes = np.asarray([1, 2, 3, 4])
+    source_labels = np.repeat(classes, 12)
+    scores = np.asarray(
+        [
+            [5.0, 4.0, 0.0, 0.0],
+            [4.9, 4.8, 0.0, 0.0],
+            [4.7, 0.0, 5.0, 0.0],
+            [4.6, 0.0, 0.0, 5.0],
+        ]
+    )
+
+    predictions, metadata = _postprocess_predictions(
+        scores,
+        classes,
+        source_labels,
+        LatentAutoencoderConfig(
+            prediction_postprocessing="validation_selected_balanced_assignment",
+            prediction_postprocessing_selection_metric="balanced_top2_top3_rank_balance",
+        ),
+        validation_scores=scores,
+        validation_labels=np.asarray([1, 2, 3, 4]),
+    )
+
+    assert sorted(predictions.tolist()) == [1, 2, 3, 4]
+    assert metadata["prediction_postprocessing_selection_metric"] == "balanced_top2_top3_rank_balance"
+    assert metadata["prediction_postprocessing_validation_selection_score"] >= metadata[
+        "prediction_postprocessing_uncalibrated_validation_selection_score"
+    ]
+
+
 def test_validation_selected_balanced_assignment_can_select_no_postprocessing():
     classes = np.asarray([1, 2, 3, 4])
     source_labels = np.repeat(classes, 12)

--- a/tests/test_stimulus_latent_autoencoder_presets.py
+++ b/tests/test_stimulus_latent_autoencoder_presets.py
@@ -38,6 +38,38 @@ def test_anti_collapse_calibrated_preset_adds_guarded_source_validation_correcti
     assert config.prediction_postprocessing_guard_tolerance == 0.0
 
 
+def test_anti_collapse_refit_preset_adds_source_only_latent_logistic_probe():
+    config = _apply_latent_training_preset(
+        LatentAutoencoderConfig(),
+        "anti_collapse_refit",
+    )
+
+    assert config.training_preset == "anti_collapse_refit"
+    assert config.balanced_batch_sampling is True
+    assert config.validation_source_count >= 4
+    assert config.validation_selection_metric == "balanced_top2_top3_rank_balance"
+    assert config.latent_head_refit == "validation_selected_source_logistic"
+    assert config.latent_head_refit_selection_metric == "balanced_top2_top3_rank_balance"
+    assert config.score_calibration == "validation_selected_guarded"
+    assert config.score_calibration_selection_metric == "balanced_top2_top3_rank_balance"
+    assert config.score_calibration_final_refit is True
+    assert config.prediction_postprocessing == "validation_selected_balanced_assignment"
+
+
+def test_anti_collapse_head_refit_preset_adds_source_validation_logistic_head():
+    config = _apply_latent_training_preset(
+        LatentAutoencoderConfig(),
+        "anti_collapse_head_refit",
+    )
+
+    assert config.training_preset == "anti_collapse_head_refit"
+    assert config.score_calibration == "validation_selected_guarded"
+    assert config.prediction_postprocessing == "validation_selected_balanced_assignment"
+    assert config.latent_head_refit == "validation_selected_source_logistic"
+    assert config.latent_head_refit_selection_metric == "balanced_top2_top3_rank_balance"
+    assert config.latent_head_refit_c_values == (0.03, 0.1, 0.3, 1.0, 3.0)
+
+
 def test_none_preset_preserves_explicit_config_values():
     original = LatentAutoencoderConfig(
         label_smoothing=0.2,


### PR DESCRIPTION
## Summary
- expose artifact ensemble through the grouped CLI and add balanced-assignment shrinkage, entropy-weighted scoring, and score-rank fusion modes
- add latent AE anti-collapse refit/head-refit presets and source-validation selection metrics for postprocessing
- update workflow inputs/defaults and add focused regression coverage

## Validation
- Not run (per request).
- Syntax only: `python -m py_compile src/pymegdec/grouped_cli.py src/pymegdec/stimulus_artifact_ensemble.py src/pymegdec/stimulus_latent_autoencoder.py`.