### PR TITLE
Extend artifact normalization and low-margin postprocessing

### DIFF
--- a/.github/workflows/stimulus-artifact-ensemble.yml
+++ b/.github/workflows/stimulus-artifact-ensemble.yml
@@ -33,6 +33,11 @@ on:
         required: true
         default: auto,hard_vote,mean_score,confidence_weighted_mean_score,entropy_weighted_mean_score,log_score_mean,score_rank_fusion,mean_rank,borda,score_tiebreak_first_source,balanced_assignment,balanced_assignment_shrink25,balanced_assignment_shrink50,balanced_assignment_shrink75
         type: string
+      score_normalizations:
+        description: Comma-separated per-source score normalizations to compare before score aggregation.
+        required: true
+        default: raw,rank_softmax,z_softmax
+        type: string
       nested_selection_metrics:
         description: Comma-separated leave-subject-out selector metrics to compare.
         required: true
@@ -93,6 +98,7 @@ jobs:
       - name: Combine predictions
         env:
           AGGREGATION_MODES: ${{ inputs.aggregation_modes }}
+          SCORE_NORMALIZATIONS: ${{ inputs.score_normalizations }}
           NESTED_SELECTION_METRICS: ${{ inputs.nested_selection_metrics }}
           NESTED_WEIGHT_SELECTOR_ENSEMBLE: ${{ inputs.nested_weight_selector_ensemble }}
           NESTED_WEIGHT_GRID_STEP: ${{ inputs.nested_weight_grid_step }}
@@ -100,45 +106,58 @@ jobs:
         run: |
           set -euo pipefail
           IFS=',' read -r -a modes <<< "${AGGREGATION_MODES}"
+          IFS=',' read -r -a normalizations <<< "${SCORE_NORMALIZATIONS}"
           IFS=',' read -r -a selection_metrics <<< "${NESTED_SELECTION_METRICS}"
-          for raw_mode in "${modes[@]}"; do
-            mode="$(echo "${raw_mode}" | xargs)"
-            if [[ -z "${mode}" ]]; then
+          for raw_normalization in "${normalizations[@]}"; do
+            normalization="$(echo "${raw_normalization}" | xargs)"
+            if [[ -z "${normalization}" ]]; then
               continue
             fi
-            for raw_metric in "${selection_metrics[@]}"; do
-              metric="$(echo "${raw_metric}" | xargs)"
-              if [[ -z "${metric}" ]]; then
+            normalization_slug="${normalization//-/_}"
+            for raw_mode in "${modes[@]}"; do
+              mode="$(echo "${raw_mode}" | xargs)"
+              if [[ -z "${mode}" ]]; then
                 continue
               fi
-              stem="artifact_ensemble_${mode//-/_}"
-              selector_name="nested_subject_selector"
-              if [[ "${metric}" != "balanced_accuracy" ]]; then
-                metric_slug="${metric//-/_}"
-                stem="${stem}_${metric_slug}"
-                selector_name="nested_subject_selector_${metric_slug}"
-              fi
-              python -m pymegdec.stimulus_artifact_ensemble \
-                --source compact=artifacts/compact \
-                --source small_finetune=artifacts/small_finetune \
-                --source w150_pca128=artifacts/w150_pca128 \
-                --source w125=artifacts/w125 \
-                --ensemble compact=compact \
-                --ensemble compact_small_finetune=compact,small_finetune \
-                --ensemble compact_w150_pca128=compact,w150_pca128 \
-                --ensemble compact_w125=compact,w125 \
-                --ensemble compact_small_finetune_w150_pca128=compact,small_finetune,w150_pca128 \
-                --key-column test_participant \
-                --key-column test_trial_index \
-                --key-column true_label \
-                --nested-selector-name "${selector_name}" \
-                --nested-selection-metric "${metric}" \
-                --nested-weight-selector-name nested_weight_selector \
-                --nested-weight-selector-ensemble "${NESTED_WEIGHT_SELECTOR_ENSEMBLE}" \
-                --nested-weight-grid-step "${NESTED_WEIGHT_GRID_STEP}" \
-                --aggregation-mode "${mode}" \
-                --output-dir outputs \
-                --output-stem "${stem}"
+              mode_slug="${mode//-/_}"
+              for raw_metric in "${selection_metrics[@]}"; do
+                metric="$(echo "${raw_metric}" | xargs)"
+                if [[ -z "${metric}" ]]; then
+                  continue
+                fi
+                stem="artifact_ensemble_${normalization_slug}_${mode_slug}"
+                selector_name="nested_subject_selector"
+                if [[ "${normalization}" != "raw" ]]; then
+                  selector_name="nested_subject_selector_${normalization_slug}"
+                fi
+                if [[ "${metric}" != "balanced_accuracy" ]]; then
+                  metric_slug="${metric//-/_}"
+                  stem="${stem}_${metric_slug}"
+                  selector_name="${selector_name}_${metric_slug}"
+                fi
+                python -m pymegdec.stimulus_artifact_ensemble \
+                  --source compact=artifacts/compact \
+                  --source small_finetune=artifacts/small_finetune \
+                  --source w150_pca128=artifacts/w150_pca128 \
+                  --source w125=artifacts/w125 \
+                  --ensemble compact=compact \
+                  --ensemble compact_small_finetune=compact,small_finetune \
+                  --ensemble compact_w150_pca128=compact,w150_pca128 \
+                  --ensemble compact_w125=compact,w125 \
+                  --ensemble compact_small_finetune_w150_pca128=compact,small_finetune,w150_pca128 \
+                  --key-column test_participant \
+                  --key-column test_trial_index \
+                  --key-column true_label \
+                  --nested-selector-name "${selector_name}" \
+                  --nested-selection-metric "${metric}" \
+                  --nested-weight-selector-name nested_weight_selector \
+                  --nested-weight-selector-ensemble "${NESTED_WEIGHT_SELECTOR_ENSEMBLE}" \
+                  --nested-weight-grid-step "${NESTED_WEIGHT_GRID_STEP}" \
+                  --score-normalization "${normalization}" \
+                  --aggregation-mode "${mode}" \
+                  --output-dir outputs \
+                  --output-stem "${stem}"
+              done
             done
           done
 

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -3146,6 +3146,27 @@ def _validation_balanced_assignment_candidates(
             quota_source="shrunk_source_label_prior",
             quotas=shrunk_quotas,
         )
+        for margin_threshold in margin_thresholds:
+            (
+                shrunk_low_margin_assigned,
+                shrunk_low_margin_objective_delta,
+                fixed_predictions,
+            ) = _low_margin_balanced_assignment_predictions(
+                validation_scores,
+                classes,
+                shrunk_quotas,
+                margin_threshold=margin_threshold,
+            )
+            _append_row(
+                selected_method="shrunk_source_prior_low_margin_balanced_assignment",
+                predictions=shrunk_low_margin_assigned,
+                objective_delta=shrunk_low_margin_objective_delta,
+                shrinkage_alpha=candidate_alpha,
+                quota_source="shrunk_source_label_prior_low_margin",
+                quotas=shrunk_quotas,
+                margin_threshold=margin_threshold,
+                fixed_predictions=fixed_predictions,
+            )
 
     # Conservative tie-breaker: prefer raw argmax if validation performance is
     # indistinguishable, then prefer lower assignment cost.  This makes the mode
@@ -3154,6 +3175,7 @@ def _validation_balanced_assignment_candidates(
         "none": 0,
         "source_prior_low_margin_balanced_assignment": 1,
         "shrunk_source_prior_balanced_assignment": 1,
+        "shrunk_source_prior_low_margin_balanced_assignment": 1,
         "source_prior_balanced_assignment": 2,
     }
     rows.sort(
@@ -3291,6 +3313,22 @@ def _postprocess_predictions(
             quota_source = "shrunk_source_label_prior"
             predicted_labels, objective_delta = _balanced_assignment_predictions(scores, classes, quotas)
             fixed_predictions = 0
+        elif selected_row["selected_method"] == "shrunk_source_prior_low_margin_balanced_assignment":
+            selected_shrinkage_alpha = float(selected_row["shrinkage_alpha"])
+            quotas = _shrunk_source_prior_class_quotas(
+                source_labels,
+                argmax_labels,
+                classes,
+                int(scores.shape[0]),
+                shrinkage_alpha=selected_shrinkage_alpha,
+            )
+            quota_source = "shrunk_source_label_prior_low_margin"
+            predicted_labels, objective_delta, fixed_predictions = _low_margin_balanced_assignment_predictions(
+                scores,
+                classes,
+                quotas,
+                margin_threshold=float(selected_row["margin_threshold"]),
+            )
         elif selected_row["selected_method"] == "source_prior_low_margin_balanced_assignment":
             quotas = _source_prior_class_quotas(source_labels, classes, int(scores.shape[0]))
             quota_source = "source_label_prior_low_margin"

--- a/tests/test_stimulus_latent_autoencoder_low_margin.py
+++ b/tests/test_stimulus_latent_autoencoder_low_margin.py
@@ -78,6 +78,7 @@ def test_validation_candidates_include_low_margin_variants():
     rows = _validation_balanced_assignment_candidates(scores, labels, source_labels, classes, config)
 
     assert any(row["selected_method"] == "source_prior_low_margin_balanced_assignment" for row in rows)
+    assert any(row["selected_method"] == "shrunk_source_prior_low_margin_balanced_assignment" for row in rows)
     assert all("margin_threshold" in row for row in rows)
     # The original full assignment path is still available for comparison.
     full_labels, _objective_delta = _balanced_assignment_predictions(scores, classes, np.asarray([2, 2, 2]))


### PR DESCRIPTION
## Summary
- expand the artifact ensemble workflow with score-normalization grid variants
- add validation-selected shrunk low-margin balanced assignment postprocessing
- cover the new low-margin shrinkage option in regression expectations

## Validation
- Not run per request
- Syntax checked: `python -m py_compile src/pymegdec/stimulus_latent_autoencoder.py`