### PR TITLE
Reuse artifact scores and add contrastive preset

### DIFF
--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -40,6 +40,7 @@ on:
           - anti_collapse_calibrated
           - anti_collapse_refit
           - anti_collapse_head_refit
+          - anti_collapse_contrastive
       validation_source_count:
         description: Source participants held out for early stopping/calibration.
         required: true

--- a/src/pymegdec/stimulus_artifact_ensemble.py
+++ b/src/pymegdec/stimulus_artifact_ensemble.py
@@ -747,6 +747,93 @@ def _format_percent(value: float) -> str:
     return "" if not math.isfinite(value) else f"{100.0 * value:.6f}"
 
 
+def _scores_are_probability_like(scores: dict[int, float], class_labels: Sequence[int]) -> bool:
+    """Return whether a complete score vector is safe to expose as probabilities."""
+
+    values: list[float] = []
+    for label in class_labels:
+        if label not in scores:
+            return False
+        value = float(scores[label])
+        if not math.isfinite(value) or value < -1e-9:
+            return False
+        values.append(max(0.0, value))
+    return math.isclose(sum(values), 1.0, rel_tol=1e-6, abs_tol=1e-6)
+
+
+def _add_score_alias_columns(
+    row: dict[str, object],
+    *,
+    scores: dict[int, float],
+    class_labels: Sequence[int],
+    display_labels: dict[int, int],
+) -> None:
+    """Expose artifact ensemble scores in the standard prediction schema.
+
+    ``artifact_score_class_*`` columns are retained for backward compatibility,
+    while ``score_class_*`` / ``score_*`` make artifact-ensemble outputs usable as
+    first-class inputs for later score-level artifact ensembling.  Probability
+    aliases are emitted only when the complete class vector is non-negative and
+    sums to one, which avoids labelling log-score or z-normalized values as
+    probabilities.
+    """
+
+    probability_like = _scores_are_probability_like(scores, class_labels)
+    for label in class_labels:
+        if label not in scores:
+            continue
+        value = float(scores[label])
+        display_label = display_labels.get(label, label)
+        row[f"artifact_score_class_{label}"] = value
+        row[f"score_class_{label}"] = value
+        row[f"score_{display_label}"] = value
+        if probability_like:
+            row[f"prob_class_{label}"] = value
+            row[f"prob_{display_label}"] = value
+
+
+def _add_rank_alias_columns(
+    row: dict[str, object],
+    *,
+    ranked_labels: Sequence[int],
+    class_labels: Sequence[int],
+    display_labels: dict[int, int],
+) -> None:
+    """Expose per-class ranks in the standard prediction schema."""
+
+    rank_by_label = {int(label): rank for rank, label in enumerate(ranked_labels, start=1)}
+    for label in class_labels:
+        rank = rank_by_label.get(int(label))
+        if rank is None:
+            continue
+        display_label = display_labels.get(label, label)
+        row[f"rank_class_{label}"] = rank
+        row[f"rank_{display_label}"] = rank
+
+
+def _update_rank_metrics_from_labels(
+    row: dict[str, object],
+    *,
+    ranked_labels: Sequence[int],
+    true_label: int,
+    class_labels: Sequence[int],
+    display_labels: dict[int, int],
+) -> None:
+    """Synchronize rank/top-k fields after a post-hoc prediction update."""
+
+    true_rank = float(list(ranked_labels).index(true_label) + 1)
+    row["true_label_rank"] = true_rank
+    row["top2_correct"] = true_rank <= 2
+    row["top3_correct"] = true_rank <= 3
+    row["vote_ranked_labels"] = ";".join(str(value) for value in ranked_labels)
+    _add_rank_alias_columns(
+        row,
+        ranked_labels=ranked_labels,
+        class_labels=class_labels,
+        display_labels=display_labels,
+    )
+
+
 def _prediction_row(
     *,
     ensemble_name: str,
@@ -843,6 +930,14 @@ def _prediction_row(
         "source_predicted_labels": ";".join(str(value) for value in source_predictions),
         "vote_ranked_labels": ";".join(str(value) for value in ranked_labels),
     }
+    if rank_source != "source_true_label_rank":
+        _add_rank_alias_columns(
+            row,
+            ranked_labels=ranked_labels,
+            class_labels=class_labels,
+            display_labels=display_labels,
+        )
+
     for column, value in zip(key_columns, key, strict=True):
         row[column] = value
     for optional in ("test_participant", "test_trial_index", "trial", "test_trial_number", "outer_fold"):
@@ -859,9 +954,12 @@ def _prediction_row(
     )
     if aggregated is not None:
         aggregate_scores, _score_source = aggregated
-        for label in class_labels:
-            if label in aggregate_scores:
-                row[f"artifact_score_class_{label}"] = aggregate_scores[label]
+        _add_score_alias_columns(
+            row,
+            scores=aggregate_scores,
+            class_labels=class_labels,
+            display_labels=display_labels,
+        )
     return row
 
 
@@ -951,6 +1049,27 @@ def _balanced_assignment_indices(score_matrix: Sequence[Sequence[float]], quotas
     return predicted, float(assignment_score - argmax_score)
 
 
+def _rank_labels_with_forced_first_label(
+    row: dict[str, object],
+    class_labels: Sequence[int],
+    first_label: int,
+) -> list[int]:
+    """Return a full ranking with a post-hoc assigned class in first position."""
+
+    score_by_label: dict[int, float] = {}
+    for label in class_labels:
+        value = str(row.get(f"artifact_score_class_{label}", "")).strip()
+        if value == "":
+            continue
+        score_by_label[int(label)] = _to_float(value)
+    remaining = [int(label) for label in class_labels if int(label) != int(first_label)]
+    remaining = sorted(
+        remaining,
+        key=lambda label: (-score_by_label.get(label, float("-inf")), label),
+    )
+    return [int(first_label), *remaining]
+
+
 def _apply_balanced_assignment_rows(
     prediction_rows: Sequence[dict[str, object]],
     class_labels: Sequence[int],
@@ -995,6 +1114,19 @@ def _apply_balanced_assignment_rows(
             row["artifact_ensemble_balanced_assignment_uniform_alpha"] = f"{uniform_alpha:.6g}"
             row["artifact_ensemble_balanced_assignment_quota_counts"] = quota_text
             row["artifact_ensemble_balanced_assignment_objective_delta"] = objective_delta
+            row["artifact_ensemble_rank_source"] = row["artifact_ensemble_mode"]
+            ranked_labels = _rank_labels_with_forced_first_label(
+                row,
+                label_list,
+                predicted_label,
+            )
+            _update_rank_metrics_from_labels(
+                row,
+                ranked_labels=ranked_labels,
+                true_label=true_label,
+                class_labels=label_list,
+                display_labels=display_labels,
+            )
     return rows
 
 

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -52,6 +52,7 @@ LATENT_TRAINING_PRESET_CHOICES = (
     "anti_collapse_calibrated",
     "anti_collapse_refit",
     "anti_collapse_head_refit",
+    "anti_collapse_contrastive",
 )
 DEFAULT_LATENT_VALIDATION_SOURCE_STRATEGY = "rotating"
 DEFAULT_LATENT_SELECTED_SCORE_CALIBRATION_CANDIDATES = (
@@ -233,6 +234,10 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
     representation ranks classes reasonably but the neural head collapses to a few argmax classes.
     ``anti_collapse_head_refit`` adds a source-validation-selected logistic
     classifier on the learned latent space before the guarded calibration stack.
+    ``anti_collapse_contrastive`` keeps the anti-collapse training safeguards but
+    also turns on a small supervised contrastive latent loss.  This directly
+    encourages same-stimulus trials from different source subjects to share latent
+    neighborhoods before the classifier head is fitted.
     """
 
     preset = str(preset or DEFAULT_LATENT_TRAINING_PRESET)
@@ -316,6 +321,29 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
             ),
         )
 
+    if preset == "anti_collapse_contrastive":
+        return replace(
+            config,
+            training_preset=preset,
+            balanced_batch_sampling=True,
+            subject_class_balanced_batch_sampling=True,
+            label_smoothing=label_smoothing,
+            prediction_balance_weight=prediction_balance_weight,
+            prediction_balance_target_smoothing=1.0,
+            prediction_balance_temperature=prediction_balance_temperature,
+            logit_mean_center_weight=logit_mean_center_weight,
+            soft_macro_recall_weight=soft_macro_recall_weight,
+            validation_source_count=validation_source_count,
+            validation_prediction_balance_weight=validation_prediction_balance_weight,
+            validation_selection_metric="balanced_top2_top3_rank_balance",
+            final_min_epochs=final_min_epochs,
+            supervised_contrastive_weight=max(float(config.supervised_contrastive_weight), 0.02),
+            supervised_contrastive_temperature=_min_positive_temperature(
+                config.supervised_contrastive_temperature,
+                0.20,
+            ),
+        )
+
     latent_head_refit = config.latent_head_refit
     latent_head_refit_selection_metric = config.latent_head_refit_selection_metric
     latent_head_refit_c_values = config.latent_head_refit_c_values
@@ -343,6 +371,7 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
         validation_prediction_balance_weight=validation_prediction_balance_weight,
         validation_selection_metric="balanced_top2_top3_rank_balance",
         final_min_epochs=final_min_epochs,
+        supervised_contrastive_temperature=_min_positive_temperature(config.supervised_contrastive_temperature, 0.20),
         score_calibration="validation_selected_guarded",
         score_calibration_selection_metric="balanced_top2_top3_rank_balance",
         score_calibration_guard_tolerance=min(float(config.score_calibration_guard_tolerance), 0.0),

--- a/tests/test_stimulus_artifact_ensemble.py
+++ b/tests/test_stimulus_artifact_ensemble.py
@@ -192,9 +192,25 @@ class TestStimulusArtifactEnsemble(unittest.TestCase):
             [("score_mean", ("compact", "finetune"))],
         )
 
-        self.assertEqual(artifacts["predictions"][0]["predicted_label"], 0)
-        self.assertEqual(artifacts["predictions"][0]["artifact_ensemble_mode"], "class_score_mean")
+        prediction = artifacts["predictions"][0]
+        self.assertEqual(prediction["predicted_label"], 0)
+        self.assertEqual(prediction["artifact_ensemble_mode"], "class_score_mean")
+        self.assertAlmostEqual(float(prediction["score_class_0"]), 0.65)
+        self.assertAlmostEqual(float(prediction["score_1"]), 0.65)
+        self.assertAlmostEqual(float(prediction["prob_class_0"]), 0.65)
+        self.assertEqual(prediction["rank_class_0"], 1)
+        self.assertEqual(prediction["rank_1"], 1)
         self.assertEqual(artifacts["group_summary"][0]["balanced_accuracy_mean"], 1.0)
+
+        stacked = _source("stacked", artifacts["predictions"])
+        stacked_artifacts = ensemble_prediction_sources(
+            [stacked],
+            [("stacked", ("stacked",))],
+            aggregation_mode="mean_score",
+        )
+        stacked_prediction = stacked_artifacts["predictions"][0]
+        self.assertEqual(stacked_prediction["predicted_label"], 0)
+        self.assertEqual(stacked_prediction["artifact_ensemble_mode"], "class_score_mean")
 
     def test_log_score_mean_uses_geometric_consensus(self) -> None:
         source_names = tuple(f"source_{index}" for index in range(4))
@@ -407,6 +423,13 @@ class TestStimulusArtifactEnsemble(unittest.TestCase):
         predictions = artifacts["predictions"]
         self.assertEqual([row["predicted_label"] for row in predictions], [0, 1, 0, 1])
         self.assertEqual({row["artifact_ensemble_mode"] for row in predictions}, {"class_score_balanced_assignment"})
+        second_prediction = predictions[1]
+        self.assertEqual(second_prediction["true_label"], 1)
+        self.assertEqual(second_prediction["predicted_label"], 1)
+        self.assertEqual(second_prediction["true_label_rank"], 1.0)
+        self.assertTrue(second_prediction["top2_correct"])
+        self.assertEqual(second_prediction["rank_class_1"], 1)
+        self.assertTrue(str(second_prediction["vote_ranked_labels"]).startswith("1;"))
         self.assertEqual(artifacts["group_summary"][0]["balanced_accuracy_mean"], 1.0)
 
     def test_balanced_assignment_shrinkage_is_less_aggressive_than_uniform_assignment(self) -> None:

--- a/tests/test_stimulus_latent_autoencoder_presets.py
+++ b/tests/test_stimulus_latent_autoencoder_presets.py
@@ -70,6 +70,25 @@ def test_anti_collapse_head_refit_preset_adds_source_validation_logistic_head():
     assert config.latent_head_refit_c_values == (0.03, 0.1, 0.3, 1.0, 3.0)
 
 
+def test_anti_collapse_contrastive_preset_adds_source_only_latent_clustering():
+    config = _apply_latent_training_preset(
+        LatentAutoencoderConfig(),
+        "anti_collapse_contrastive",
+    )
+
+    assert config.training_preset == "anti_collapse_contrastive"
+    assert config.balanced_batch_sampling is True
+    assert config.subject_class_balanced_batch_sampling is True
+    assert config.label_smoothing >= 0.05
+    assert config.prediction_balance_weight >= 0.02
+    assert config.soft_macro_recall_weight >= 0.02
+    assert config.validation_source_count >= 4
+    assert config.validation_selection_metric == "balanced_top2_top3_rank_balance"
+    assert config.final_min_epochs >= 8
+    assert config.supervised_contrastive_weight >= 0.02
+    assert config.supervised_contrastive_temperature <= 0.20
+
+
 def test_none_preset_preserves_explicit_config_values():
     original = LatentAutoencoderConfig(
         label_smoothing=0.2,


### PR DESCRIPTION
## Summary
- reuse normalized artifact score maps across aggregation paths instead of recomputing per mode
- add latent anti-collapse contrastive preset wiring
- add focused regression coverage for reusable artifact scores and the new preset

## Validation
- Not run per request
- Syntax checked: `python -m py_compile src/pymegdec/stimulus_artifact_ensemble.py src/pymegdec/stimulus_latent_autoencoder.py`
- Checked with `git diff --check`