### PR TITLE
Add latent class-bias L2 regularization

### DIFF
--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -81,6 +81,11 @@ on:
         required: true
         default: "0"
         type: string
+      class_bias_l2_weight:
+        description: L2 penalty on the latent classifier bias vector; 0 disables it.
+        required: true
+        default: "0"
+        type: string
       confidence_penalty_weight:
         description: Entropy confidence penalty on training logits; 0 disables it.
         required: true
@@ -357,6 +362,7 @@ jobs:
             --prediction-balance-target-smoothing "${{ inputs.prediction_balance_target_smoothing }}"
             --prediction-balance-temperature "${{ inputs.prediction_balance_temperature }}"
             --logit-mean-center-weight "${{ inputs.logit_mean_center_weight }}"
+            --class-bias-l2-weight "${{ inputs.class_bias_l2_weight }}"
             --confidence-penalty-weight "${{ inputs.confidence_penalty_weight }}"
             --label-smoothing "${{ inputs.label_smoothing }}"
             --focal-loss-gamma "${{ inputs.focal_loss_gamma }}"

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -95,6 +95,7 @@ class LatentAutoencoderConfig:  # pylint: disable=too-many-instance-attributes
     prediction_balance_target_smoothing: float = 1.0
     prediction_balance_temperature: float = 1.0
     logit_mean_center_weight: float = 0.0
+    class_bias_l2_weight: float = 0.0
     confidence_penalty_weight: float = 0.0
     label_smoothing: float = 0.0
     focal_loss_gamma: float = 0.0
@@ -266,6 +267,7 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
         0.10,
     )
     logit_mean_center_weight = max(float(config.logit_mean_center_weight), 0.003)
+    class_bias_l2_weight = max(float(config.class_bias_l2_weight), 0.003)
     soft_macro_recall_weight = max(float(config.soft_macro_recall_weight), 0.02)
     # The smoke fold selected epoch 3 from only two validation sources.  A
     # slightly larger rotating validation set and a final minimum epoch count
@@ -288,6 +290,7 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
             prediction_balance_target_smoothing=1.0,
             prediction_balance_temperature=prediction_balance_temperature,
             logit_mean_center_weight=logit_mean_center_weight,
+            class_bias_l2_weight=class_bias_l2_weight,
             soft_macro_recall_weight=soft_macro_recall_weight,
             validation_source_count=validation_source_count,
             validation_prediction_balance_weight=validation_prediction_balance_weight,
@@ -306,6 +309,7 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
             prediction_balance_target_smoothing=1.0,
             prediction_balance_temperature=prediction_balance_temperature,
             logit_mean_center_weight=logit_mean_center_weight,
+            class_bias_l2_weight=class_bias_l2_weight,
             soft_macro_recall_weight=soft_macro_recall_weight,
             validation_source_count=validation_source_count,
             validation_prediction_balance_weight=validation_prediction_balance_weight,
@@ -342,6 +346,7 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
             prediction_balance_target_smoothing=1.0,
             prediction_balance_temperature=prediction_balance_temperature,
             logit_mean_center_weight=logit_mean_center_weight,
+            class_bias_l2_weight=class_bias_l2_weight,
             soft_macro_recall_weight=soft_macro_recall_weight,
             validation_source_count=validation_source_count,
             validation_prediction_balance_weight=validation_prediction_balance_weight,
@@ -383,6 +388,7 @@ def _apply_latent_training_preset(config: LatentAutoencoderConfig, preset: str) 
         prediction_balance_target_smoothing=1.0,
         prediction_balance_temperature=prediction_balance_temperature,
         logit_mean_center_weight=logit_mean_center_weight,
+        class_bias_l2_weight=class_bias_l2_weight,
         soft_macro_recall_weight=soft_macro_recall_weight,
         validation_source_count=validation_source_count,
         validation_prediction_balance_weight=validation_prediction_balance_weight,
@@ -468,6 +474,12 @@ def _make_model_class():
                 nn.LayerNorm(latent_dim),
             )
             self.classifier = nn.Linear(latent_dim, n_classes)
+            # The first latent-AE smoke run showed hard argmax collapse onto a
+            # few classes.  A randomly initialized class bias can persist when
+            # early stopping selects very early epochs, so start the classifier
+            # from a neutral class prior and let source labels learn deviations.
+            nn.init.xavier_uniform_(self.classifier.weight, gain=0.5)
+            nn.init.zeros_(self.classifier.bias)
             subject_ids_tuple = tuple(int(subject_id) for subject_id in subject_ids)
             self.subject_classifier = nn.Linear(latent_dim, max(1, len(subject_ids_tuple)))
             max_subject_id = max(subject_ids_tuple) if subject_ids_tuple else 0
@@ -977,6 +989,9 @@ def _train_model(  # pylint: disable=too-many-arguments,too-many-locals
                 loss = loss + float(config.prediction_balance_weight) * balance_loss
             if float(config.logit_mean_center_weight) > 0.0:
                 loss = loss + float(config.logit_mean_center_weight) * _logit_mean_center_loss(logits)
+            if float(config.class_bias_l2_weight) > 0.0 and model.classifier.bias is not None:
+                # Source labels are balanced, so persistent class-bias offsets are more likely collapse than signal.
+                loss = loss + float(config.class_bias_l2_weight) * torch.mean(model.classifier.bias.square())
             if float(config.confidence_penalty_weight) > 0.0:
                 loss = loss + float(config.confidence_penalty_weight) * _confidence_penalty(logits)
             if float(config.supervised_contrastive_weight) > 0.0:
@@ -2510,6 +2525,7 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
             "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "prediction_balance_temperature": config.prediction_balance_temperature,
             "logit_mean_center_weight": config.logit_mean_center_weight,
+            "class_bias_l2_weight": config.class_bias_l2_weight,
             "confidence_penalty_weight": config.confidence_penalty_weight,
             "label_smoothing": config.label_smoothing,
             "focal_loss_gamma": config.focal_loss_gamma,
@@ -2615,6 +2631,7 @@ def _outer_row(  # pylint: disable=too-many-arguments
         "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
         "prediction_balance_temperature": config.prediction_balance_temperature,
         "logit_mean_center_weight": config.logit_mean_center_weight,
+        "class_bias_l2_weight": config.class_bias_l2_weight,
         "confidence_penalty_weight": config.confidence_penalty_weight,
         "label_smoothing": config.label_smoothing,
         "focal_loss_gamma": config.focal_loss_gamma,
@@ -2793,6 +2810,7 @@ def _group_summary(outer_rows: list[dict], config: LatentAutoencoderConfig) -> l
             "prediction_balance_target_smoothing": config.prediction_balance_target_smoothing,
             "prediction_balance_temperature": config.prediction_balance_temperature,
             "logit_mean_center_weight": config.logit_mean_center_weight,
+            "class_bias_l2_weight": config.class_bias_l2_weight,
             "confidence_penalty_weight": config.confidence_penalty_weight,
             "label_smoothing": config.label_smoothing,
             "focal_loss_gamma": config.focal_loss_gamma,
@@ -3944,6 +3962,16 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--class-bias-l2-weight",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional L2 penalty on the latent classifier bias vector.  Source labels are balanced, "
+            "so small values such as 0.001 or 0.003 discourage persistent class-prior offsets "
+            "without constraining trial-specific evidence."
+        ),
+    )
+    parser.add_argument(
         "--confidence-penalty-weight",
         type=float,
         default=0.0,
@@ -4308,6 +4336,7 @@ def main(argv: Sequence[str] | None = None, prog: str | None = None) -> int:
         prediction_balance_target_smoothing=args.prediction_balance_target_smoothing,
         prediction_balance_temperature=args.prediction_balance_temperature,
         logit_mean_center_weight=args.logit_mean_center_weight,
+        class_bias_l2_weight=args.class_bias_l2_weight,
         confidence_penalty_weight=args.confidence_penalty_weight,
         label_smoothing=args.label_smoothing,
         focal_loss_gamma=args.focal_loss_gamma,

--- a/tests/test_stimulus_latent_autoencoder_presets.py
+++ b/tests/test_stimulus_latent_autoencoder_presets.py
@@ -17,6 +17,7 @@ def test_anti_collapse_train_preset_enables_source_only_regularizers():
     assert config.prediction_balance_weight >= 0.02
     assert config.prediction_balance_temperature <= 0.10
     assert config.logit_mean_center_weight >= 0.003
+    assert config.class_bias_l2_weight >= 0.003
     assert config.soft_macro_recall_weight >= 0.02
     assert config.validation_source_count >= 4
     assert config.validation_prediction_balance_weight >= 0.03
@@ -69,6 +70,7 @@ def test_anti_collapse_head_refit_preset_adds_source_validation_logistic_head():
     assert config.latent_head_refit == "validation_selected_source_logistic"
     assert config.latent_head_refit_selection_metric == "balanced_top2_top3_rank_balance"
     assert config.latent_head_refit_c_values == (0.03, 0.1, 0.3, 1.0, 3.0)
+    assert config.class_bias_l2_weight >= 0.003
 
 
 def test_anti_collapse_contrastive_preset_adds_source_only_latent_clustering():


### PR DESCRIPTION
## Summary
- add latent classifier bias initialization and optional L2 bias regularization
- wire class-bias regularization through anti-collapse presets, CLI, workflow inputs, and metadata
- update preset coverage for the new regularizer

## Validation
- Not run per request
- Syntax checked with `python -m py_compile src/pymegdec/stimulus_latent_autoencoder.py tests/test_stimulus_latent_autoencoder_presets.py`
- Checked diff with `git diff --check`