### PR TITLE
Extend latent validation source strategies

### DIFF
--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -153,6 +153,8 @@ on:
           - spread
           - tail
           - head
+          - round_robin
+          - seeded_random
       balanced_batch_sampling:
         description: Interleave classes within training epochs so minibatches are class-diverse.
         required: true

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -841,6 +841,7 @@ def _split_source_participants(
     validation_source_count: int,
     *,
     strategy: str = "tail",
+    seed: int = 0,
     anchor: int | None = None,
 ) -> tuple[tuple[int, ...], tuple[int, ...]]:
     source_participants = tuple(int(value) for value in source_participants)
@@ -849,7 +850,7 @@ def _split_source_participants(
         return source_participants, tuple()
 
     n_sources = len(source_participants)
-    strategy = str(strategy or "tail")
+    strategy = str(strategy or "tail").strip().lower().replace("-", "_")
     if strategy == "tail":
         validation_indices = tuple(range(n_sources - count, n_sources))
     elif strategy == "head":
@@ -865,9 +866,20 @@ def _split_source_participants(
     elif strategy == "rotating":
         start = 0 if anchor is None else abs(int(anchor)) % n_sources
         validation_indices = tuple((start + offset) % n_sources for offset in range(count))
+    elif strategy == "round_robin":
+        start = (int(seed) + (0 if anchor is None else int(anchor))) % n_sources
+        validation_indices = tuple((start + offset) % n_sources for offset in range(count))
+    elif strategy == "seeded_random":
+        seed_values = [int(seed), int(count), int(n_sources)]
+        if anchor is not None:
+            seed_values.append(int(anchor))
+        rng = np.random.default_rng(np.random.SeedSequence(seed_values))
+        validation_indices = tuple(
+            sorted(int(index) for index in rng.choice(n_sources, size=count, replace=False).tolist())
+        )
     else:
         raise ValueError(
-            "validation_source_strategy must be one of: tail, head, spread, rotating"
+            "validation_source_strategy must be one of: tail, head, spread, rotating, round_robin, seeded_random"
         )
 
     validation = tuple(source_participants[index] for index in validation_indices[:count])
@@ -3658,6 +3670,7 @@ def evaluate_latent_autoencoder_loso(  # pylint: disable=too-many-locals
             source_participants,
             config.validation_source_count,
             strategy=config.validation_source_strategy,
+            seed=config.seed,
             anchor=test_participant,
         )
         train_features_raw, train_labels_raw, train_subjects = _concat_features(feature_sets, train_epoch_participants)
@@ -4075,7 +4088,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     parser.add_argument("--validation-source-count", type=int, default=2)
     parser.add_argument(
         "--validation-source-strategy",
-        choices=("tail", "head", "spread", "rotating"),
+        choices=("tail", "head", "spread", "rotating", "round_robin", "seeded_random"),
         default=DEFAULT_LATENT_VALIDATION_SOURCE_STRATEGY,
         help=(
             "How to choose source participants for early stopping/calibration validation. "

--- a/tests/test_stimulus_latent_autoencoder_validation_policy.py
+++ b/tests/test_stimulus_latent_autoencoder_validation_policy.py
@@ -1,0 +1,30 @@
+from pymegdec.stimulus_latent_autoencoder import _split_source_participants
+
+
+def test_split_source_participants_seeded_random_is_deterministic():
+    kwargs = {"strategy": "seeded_random", "seed": 7, "anchor": 3}
+
+    train_a, validation_a = _split_source_participants((1, 2, 4, 5, 6, 8), 2, **kwargs)
+    train_b, validation_b = _split_source_participants((1, 2, 4, 5, 6, 8), 2, **kwargs)
+
+    assert train_a == train_b
+    assert validation_a == validation_b
+    assert len(validation_a) == 2
+    assert set(train_a).isdisjoint(validation_a)
+    assert tuple(sorted((*train_a, *validation_a))) == (1, 2, 4, 5, 6, 8)
+
+
+def test_split_source_participants_seeded_random_changes_with_anchor():
+    source = (1, 2, 4, 5, 6, 8, 9, 10)
+
+    _train_a, validation_a = _split_source_participants(source, 3, strategy="seeded_random", seed=11, anchor=3)
+    _train_b, validation_b = _split_source_participants(source, 3, strategy="seeded_random", seed=11, anchor=4)
+
+    assert validation_a != validation_b
+
+
+def test_split_source_participants_round_robin_uses_seed_and_anchor_offset():
+    train, validation = _split_source_participants((1, 2, 4, 5, 6), 2, strategy="round_robin", seed=0, anchor=3)
+
+    assert validation == (5, 6)
+    assert train == (1, 2, 4)


### PR DESCRIPTION
## Summary
- extend the existing latent validation source strategy API with `round_robin` and `seeded_random`
- expose the new strategy options in the latent autoencoder workflow
- add deterministic split coverage for seeded random and round-robin validation selection

## Validation
- Not run per request
- Syntax checked with `python -m py_compile src/pymegdec/stimulus_latent_autoencoder.py tests/test_stimulus_latent_autoencoder_validation_policy.py`
- Checked diff with `git diff --check`