### PR TITLE
Emit latent artifact score aliases

### DIFF
--- a/src/pymegdec/stimulus_artifact_ensemble.py
+++ b/src/pymegdec/stimulus_artifact_ensemble.py
@@ -568,7 +568,72 @@ def _uniform_prior_shift_alpha(aggregation_mode: str) -> float:
     return 1.0
 
 
-def _class_value_columns(rows: Sequence[dict[str, str]], patterns: Sequence[tuple[re.Pattern[str], int]]) -> dict[int, str]:
+def _common_value_columns(rows: Sequence[dict[str, str]], pattern: re.Pattern[str], *, offset: int = 0) -> dict[int, str]:
+    """Return value columns common to all rows for one regex pattern."""
+
+    common: dict[int, str] | None = None
+    for row in rows:
+        columns: dict[int, str] = {}
+        for column in row:
+            if str(row.get(column, "")).strip() == "":
+                continue
+            match = pattern.match(column)
+            if match:
+                columns[int(match.group(1)) + int(offset)] = column
+        common = columns if common is None else {label: column for label, column in common.items() if label in columns}
+    return common or {}
+
+
+def _class_value_columns(
+    rows: Sequence[dict[str, str]],
+    patterns: Sequence[tuple[re.Pattern[str], int]],
+    *,
+    class_labels: Sequence[int] | None = None,
+) -> dict[int, str]:
+    """Return per-class score/rank columns with label-basis inference.
+
+    Prediction artifacts come from both the legacy nested-matrix path and newer
+    latent-AE experiments.  The legacy path often emits display/stimulus columns
+    such as ``score_1`` for raw class label ``0``.  Latent-AE outputs can be
+    genuinely 1-based, where ``score_1`` means class label ``1``.  The old fixed
+    ``score_N -> class N-1`` rule therefore silently misaligned scores when
+    ensembling 1-based latent artifacts with logistic artifacts.
+
+    Prefer explicit ``score_class_<raw_label>`` / ``rank_class_<raw_label>``
+    columns whenever available.  For display-only ``score_<N>`` / ``rank_<N>``
+    columns, infer whether the labels are raw or one-shifted from the ensemble's
+    observed class labels.  This keeps the old zero-based stimulus behavior while
+    making 1-based latent outputs first-class artifact-ensemble inputs.
+    """
+
+    if class_labels is not None and len(patterns) >= 2:
+        labels = tuple(int(label) for label in class_labels)
+        label_set = set(labels)
+
+        # The first pattern is the raw-label form: score_class_*/rank_class_*.
+        explicit_columns = _common_value_columns(rows, patterns[0][0], offset=0)
+        if explicit_columns:
+            return {label: explicit_columns[label] for label in labels if label in explicit_columns}
+
+        # The second pattern is the display/stimulus form: score_*/rank_*.
+        display_pattern = patterns[1][0]
+        direct_columns = _common_value_columns(rows, display_pattern, offset=0)
+        shifted_columns = _common_value_columns(rows, display_pattern, offset=-1)
+        if direct_columns or shifted_columns:
+            direct_hits = len(label_set.intersection(direct_columns))
+            shifted_hits = len(label_set.intersection(shifted_columns))
+            if label_set and label_set.issubset(direct_columns):
+                chosen = direct_columns
+            elif label_set and label_set.issubset(shifted_columns):
+                chosen = shifted_columns
+            elif direct_hits > shifted_hits:
+                chosen = direct_columns
+            else:
+                # Preserve the historical zero-based stimulus-column fallback on
+                # ties or when the observed label set is incomplete.
+                chosen = shifted_columns
+            return {label: chosen[label] for label in labels if label in chosen}
+
     common: dict[int, str] | None = None
     for row in rows:
         columns: dict[int, str] = {}
@@ -595,7 +660,7 @@ def _aggregate_class_scores(
     entropy_weighted: bool = False,
     agreement_weighted: bool = False,
 ) -> tuple[dict[int, float], str] | None:
-    score_columns = _class_value_columns(source_rows, CLASS_SCORE_PATTERNS)
+    score_columns = _class_value_columns(source_rows, CLASS_SCORE_PATTERNS, class_labels=class_labels)
     if not score_columns:
         return None
     normalized = _normalize_artifact_score_normalization(score_normalization)
@@ -681,7 +746,7 @@ def _aggregate_class_scores(
 def _class_rank_values(row: dict[str, str], class_labels: Sequence[int]) -> tuple[dict[int, float], str]:
     """Return per-class ranks from explicit rank columns or score-derived ranks."""
 
-    rank_columns = _class_value_columns([row], CLASS_RANK_PATTERNS)
+    rank_columns = _class_value_columns([row], CLASS_RANK_PATTERNS, class_labels=class_labels)
     ranks: dict[int, float] = {}
     for label in class_labels:
         column = rank_columns.get(label)
@@ -693,7 +758,7 @@ def _class_rank_values(row: dict[str, str], class_labels: Sequence[int]) -> tupl
     if ranks:
         return ranks, "rank"
 
-    score_columns = _class_value_columns([row], CLASS_SCORE_PATTERNS)
+    score_columns = _class_value_columns([row], CLASS_SCORE_PATTERNS, class_labels=class_labels)
     scored: list[tuple[int, float]] = []
     for label in class_labels:
         column = score_columns.get(label)

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -2555,16 +2555,30 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
 ) -> list[dict]:
     window_start, window_stop = _centered_window(config.window_center, config.window_size)
     display_labels = _display_label_map(classes)
+    score_order = np.argsort(-np.asarray(scores, dtype=float), axis=1)
+    rank_by_trial_class = np.empty_like(score_order, dtype=int)
+    for trial_rank_index in range(int(score_order.shape[0])):
+        rank_by_trial_class[trial_rank_index, score_order[trial_rank_index]] = np.arange(1, int(score_order.shape[1]) + 1)
     rows = []
     for trial_index, (true_label, predicted_label) in enumerate(zip(true_labels, predicted_labels)):
+        true_class_matches = np.flatnonzero(np.asarray(classes, dtype=int) == int(true_label))
+        true_label_rank = (
+            float(rank_by_trial_class[trial_index, int(true_class_matches[0])])
+            if true_class_matches.size
+            else np.nan
+        )
         row = {
             "test_participant": int(test_participant),
             "trial": int(trial_index),
+            "test_trial_index": int(trial_index),
             "true_label": int(true_label),
             "predicted_label": int(predicted_label),
             "true_stimulus": display_labels.get(int(true_label), int(true_label)),
             "predicted_stimulus": display_labels.get(int(predicted_label), int(predicted_label)),
             "correct": bool(int(true_label) == int(predicted_label)),
+            "true_label_rank": true_label_rank,
+            "top2_correct": bool(np.isfinite(true_label_rank) and true_label_rank <= 2),
+            "top3_correct": bool(np.isfinite(true_label_rank) and true_label_rank <= 3),
             "window_center_s": config.window_center,
             "window_size_s": config.window_size,
             "window_start_s": window_start,
@@ -2607,9 +2621,13 @@ def _prediction_rows(  # pylint: disable=too-many-arguments
             "label_shuffle_seed": config.label_shuffle_seed if config.label_shuffle_control else np.nan,
         }
         for class_index, class_label in enumerate(classes):
-            row[f"score_{display_labels.get(int(class_label), int(class_label))}"] = float(
-                scores[trial_index, class_index]
-            )
+            score_value = float(scores[trial_index, class_index])
+            display_label = display_labels.get(int(class_label), int(class_label))
+            rank_value = int(rank_by_trial_class[trial_index, class_index])
+            row[f"score_class_{int(class_label)}"] = score_value
+            row[f"score_{display_label}"] = score_value
+            row[f"rank_class_{int(class_label)}"] = rank_value
+            row[f"rank_{display_label}"] = rank_value
         rows.append(row)
     return rows
 

--- a/tests/test_stimulus_artifact_ensemble.py
+++ b/tests/test_stimulus_artifact_ensemble.py
@@ -212,6 +212,56 @@ class TestStimulusArtifactEnsemble(unittest.TestCase):
         self.assertEqual(stacked_prediction["predicted_label"], 0)
         self.assertEqual(stacked_prediction["artifact_ensemble_mode"], "class_score_mean")
 
+    def test_display_score_columns_follow_one_based_labels_when_labels_are_one_based(self) -> None:
+        def one_based_row(trial_index: int, true_label: int, predicted_label: int, score_1: float, score_2: float) -> dict[str, str]:
+            ranked_labels = sorted(((1, score_1), (2, score_2)), key=lambda item: (-item[1], item[0]))
+            return {
+                "test_participant": "1",
+                "test_trial_index": str(trial_index),
+                "true_label": str(true_label),
+                "predicted_label": str(predicted_label),
+                "true_stimulus": str(true_label),
+                "predicted_stimulus": str(predicted_label),
+                "true_label_rank": str(ranked_labels.index((true_label, score_1 if true_label == 1 else score_2)) + 1),
+                "score_1": f"{score_1:.2f}",
+                "score_2": f"{score_2:.2f}",
+            }
+
+        latent = _source(
+            "latent",
+            [
+                one_based_row(1, 1, 1, 0.90, 0.10),
+                one_based_row(2, 2, 2, 0.10, 0.90),
+            ],
+        )
+
+        artifacts = ensemble_prediction_sources(
+            [latent],
+            [("latent", ("latent",))],
+            aggregation_mode="mean_score",
+        )
+        predictions = artifacts["predictions"]
+
+        self.assertEqual([row["predicted_label"] for row in predictions], [1, 2])
+        self.assertAlmostEqual(float(predictions[0]["score_class_1"]), 0.90)
+        self.assertAlmostEqual(float(predictions[1]["score_class_2"]), 0.90)
+
+    def test_display_score_columns_keep_legacy_zero_based_stimulus_shift(self) -> None:
+        first = _stimulus_scored_row(0, 0, 0.90, 0.10)
+        second = _stimulus_scored_row(1, 1, 0.10, 0.90)
+        second["test_trial_index"] = "2"
+        legacy = _source("legacy", [first, second])
+
+        artifacts = ensemble_prediction_sources(
+            [legacy],
+            [("legacy", ("legacy",))],
+            aggregation_mode="mean_score",
+        )
+
+        self.assertEqual([row["predicted_label"] for row in artifacts["predictions"]], [0, 1])
+        self.assertAlmostEqual(float(artifacts["predictions"][0]["score_class_0"]), 0.90)
+        self.assertAlmostEqual(float(artifacts["predictions"][1]["score_class_1"]), 0.90)
+
     def test_log_score_mean_uses_geometric_consensus(self) -> None:
         source_names = tuple(f"source_{index}" for index in range(4))
         sources = []

--- a/tests/test_stimulus_latent_autoencoder_predictions.py
+++ b/tests/test_stimulus_latent_autoencoder_predictions.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pymegdec.stimulus_latent_autoencoder import LatentAutoencoderConfig, _prediction_rows
+
+
+def test_prediction_rows_emit_artifact_ensemble_ready_score_and_rank_aliases_for_one_based_labels():
+    rows = _prediction_rows(
+        test_participant=1,
+        true_labels=np.asarray([1, 2]),
+        predicted_labels=np.asarray([2, 2]),
+        scores=np.asarray(
+            [
+                [0.40, 0.60],
+                [0.10, 0.90],
+            ]
+        ),
+        classes=np.asarray([1, 2]),
+        config=LatentAutoencoderConfig(),
+        pca_components=2,
+        pca_explained_variance_percent=100.0,
+    )
+
+    first, second = rows
+    assert first["trial"] == 0
+    assert first["test_trial_index"] == 0
+    assert first["true_label"] == 1
+    assert first["true_stimulus"] == 1
+    assert first["predicted_label"] == 2
+    assert first["predicted_stimulus"] == 2
+    assert first["true_label_rank"] == 2.0
+    assert first["top2_correct"] is True
+    assert first["top3_correct"] is True
+    assert first["score_class_1"] == 0.40
+    assert first["score_1"] == 0.40
+    assert first["score_class_2"] == 0.60
+    assert first["score_2"] == 0.60
+    assert first["rank_class_1"] == 2
+    assert first["rank_1"] == 2
+    assert first["rank_class_2"] == 1
+    assert first["rank_2"] == 1
+    assert second["true_label_rank"] == 1.0
+    assert second["correct"] is True
+
+
+def test_prediction_rows_keep_display_labels_shifted_for_zero_based_labels():
+    rows = _prediction_rows(
+        test_participant=1,
+        true_labels=np.asarray([0]),
+        predicted_labels=np.asarray([0]),
+        scores=np.asarray([[0.75, 0.25]]),
+        classes=np.asarray([0, 1]),
+        config=LatentAutoencoderConfig(),
+        pca_components=2,
+        pca_explained_variance_percent=100.0,
+    )
+
+    row = rows[0]
+    assert row["true_label"] == 0
+    assert row["true_stimulus"] == 1
+    assert row["score_class_0"] == 0.75
+    assert row["score_1"] == 0.75
+    assert row["rank_class_0"] == 1
+    assert row["rank_1"] == 1


### PR DESCRIPTION
## Summary
- make artifact ensemble score/rank column detection handle one-based latent outputs and legacy shifted stimulus outputs
- emit class-score and rank aliases from latent autoencoder prediction rows
- add regression coverage for latent prediction aliases and artifact score-column inference

## Validation
- `python -m py_compile src\\pymegdec\\stimulus_artifact_ensemble.py src\\pymegdec\\stimulus_latent_autoencoder.py tests\\test_stimulus_artifact_ensemble.py tests\\test_stimulus_latent_autoencoder_predictions.py`
- `git diff --check`

Tests were not run per request.