### PR TITLE
[codex] Add worst-class latent AE selection metric

### DIFF
--- a/.github/workflows/stimulus-latent-autoencoder.yml
+++ b/.github/workflows/stimulus-latent-autoencoder.yml
@@ -156,6 +156,17 @@ on:
           - head
           - round_robin
           - seeded_random
+      validation_selection_metric:
+        description: Source-validation metric used for early stopping/epoch selection.
+        required: true
+        default: balanced_top2_top3_rank_worstclass_balance
+        type: choice
+        options:
+          - balanced_accuracy
+          - balanced_top2_top3_rank
+          - balanced_top2_top3_rank_balance
+          - balanced_top2_top3_rank_worstclass
+          - balanced_top2_top3_rank_worstclass_balance
       balanced_batch_sampling:
         description: Interleave classes within training epochs so minibatches are class-diverse.
         required: true
@@ -258,6 +269,8 @@ on:
           - balanced_accuracy
           - balanced_top2_top3_rank
           - balanced_top2_top3_rank_balance
+          - balanced_top2_top3_rank_worstclass
+          - balanced_top2_top3_rank_worstclass_balance
       score_calibration_guard_tolerance:
         description: Allowed guarded-calibration balanced-accuracy drop on source validation.
         required: true
@@ -290,6 +303,8 @@ on:
           - balanced_accuracy
           - balanced_top2_top3_rank
           - balanced_top2_top3_rank_balance
+          - balanced_top2_top3_rank_worstclass
+          - balanced_top2_top3_rank_worstclass_balance
       prediction_postprocessing_shrinkage_alphas:
         description: Candidate shrinkage strengths for guarded shrunk source-prior assignment.
         required: true
@@ -380,6 +395,7 @@ jobs:
             --batch-size "${{ inputs.batch_size }}"
             --validation-source-count "${{ inputs.validation_source_count }}"
             --validation-source-strategy "${{ inputs.validation_source_strategy }}"
+            --validation-selection-metric "${{ inputs.validation_selection_metric }}"
             --patience "${{ inputs.patience }}"
             --device cpu
             --num-threads 1

--- a/src/pymegdec/stimulus_latent_autoencoder.py
+++ b/src/pymegdec/stimulus_latent_autoencoder.py
@@ -70,6 +70,13 @@ DEFAULT_LATENT_SELECTED_SCORE_CALIBRATION_CANDIDATES = (
     "validation_vector_bias_guarded",
     "validation_logistic_stack_guarded",
 )
+LATENT_VALIDATION_SELECTION_METRIC_CHOICES = (
+    "balanced_accuracy",
+    "balanced_top2_top3_rank",
+    "balanced_top2_top3_rank_balance",
+    "balanced_top2_top3_rank_worstclass",
+    "balanced_top2_top3_rank_worstclass_balance",
+)
 LATENT_HEAD_REFIT_CHOICES = (
     "none",
     "source_logistic",
@@ -1384,6 +1391,26 @@ def _row_rank_logits(scores: np.ndarray, *, temperature: float) -> np.ndarray:
     return rank_logits - np.mean(rank_logits, axis=1, keepdims=True)
 
 
+def _worst_class_recall_score(
+    true_labels: np.ndarray,
+    predicted_labels: np.ndarray,
+    classes: np.ndarray,
+) -> float:
+    """Return the worst per-class recall among classes present in true_labels."""
+
+    true_labels = np.asarray(true_labels, dtype=int).ravel()
+    predicted_labels = np.asarray(predicted_labels, dtype=int).ravel()
+    classes = np.asarray(classes, dtype=int).ravel()
+    if true_labels.shape[0] != predicted_labels.shape[0]:
+        raise ValueError("true_labels and predicted_labels must have the same length.")
+    recalls = []
+    for class_label in classes:
+        mask = true_labels == int(class_label)
+        if np.any(mask):
+            recalls.append(float(np.mean(predicted_labels[mask] == int(class_label))))
+    return float(min(recalls)) if recalls else 0.0
+
+
 def _validation_selection_metrics(
     true_labels: np.ndarray,
     scores: np.ndarray,
@@ -1399,6 +1426,7 @@ def _validation_selection_metrics(
     top3 = float(np.mean(ranks <= 3))
     rank_score = _rank_score_from_ranks(ranks, n_classes=int(classes.shape[0]))
     balance_score = _prediction_balance_score(predictions, classes)
+    worst_class_recall = _worst_class_recall_score(true_labels, predictions, classes)
     metric = str(metric or "balanced_accuracy")
     if metric == "balanced_accuracy":
         selection_score = balanced
@@ -1406,10 +1434,21 @@ def _validation_selection_metrics(
         selection_score = balanced + 0.20 * top2 + 0.10 * top3 + 0.10 * rank_score
     elif metric == "balanced_top2_top3_rank_balance":
         selection_score = balanced + 0.20 * top2 + 0.10 * top3 + 0.10 * rank_score + 0.05 * balance_score
+    elif metric == "balanced_top2_top3_rank_worstclass":
+        selection_score = balanced + 0.20 * top2 + 0.10 * top3 + 0.10 * rank_score + 0.10 * worst_class_recall
+    elif metric == "balanced_top2_top3_rank_worstclass_balance":
+        selection_score = (
+            balanced
+            + 0.20 * top2
+            + 0.10 * top3
+            + 0.10 * rank_score
+            + 0.10 * worst_class_recall
+            + 0.05 * balance_score
+        )
     else:
         raise ValueError(
             "validation_selection_metric must be one of: "
-            "balanced_accuracy, balanced_top2_top3_rank, balanced_top2_top3_rank_balance"
+            f"{', '.join(LATENT_VALIDATION_SELECTION_METRIC_CHOICES)}"
         )
     return {
         "selection_score": float(selection_score),
@@ -1419,6 +1458,7 @@ def _validation_selection_metrics(
         "mean_true_label_rank": float(np.nanmean(ranks)),
         "rank_score": rank_score,
         "prediction_balance_score": balance_score,
+        "worst_class_recall": worst_class_recall,
     }
 
 
@@ -1441,6 +1481,7 @@ def _validation_selection_metrics_from_predictions(
     top3 = float(np.mean(ranks <= 3))
     rank_score = _rank_score_from_ranks(ranks, n_classes=int(classes.shape[0]))
     balance_score = _prediction_balance_score(predicted_labels, classes)
+    worst_class_recall = _worst_class_recall_score(true_labels, predicted_labels, classes)
     metric = str(metric or "balanced_accuracy")
     if metric == "balanced_accuracy":
         selection_score = balanced
@@ -1450,10 +1491,21 @@ def _validation_selection_metrics_from_predictions(
         selection_score = (
             balanced + 0.20 * top2 + 0.10 * top3 + 0.10 * rank_score + 0.05 * balance_score
         )
+    elif metric == "balanced_top2_top3_rank_worstclass":
+        selection_score = balanced + 0.20 * top2 + 0.10 * top3 + 0.10 * rank_score + 0.10 * worst_class_recall
+    elif metric == "balanced_top2_top3_rank_worstclass_balance":
+        selection_score = (
+            balanced
+            + 0.20 * top2
+            + 0.10 * top3
+            + 0.10 * rank_score
+            + 0.10 * worst_class_recall
+            + 0.05 * balance_score
+        )
     else:
         raise ValueError(
             "prediction_postprocessing_selection_metric must be one of: "
-            "balanced_accuracy, balanced_top2_top3_rank, balanced_top2_top3_rank_balance"
+            f"{', '.join(LATENT_VALIDATION_SELECTION_METRIC_CHOICES)}"
         )
     return {
         "selection_score": float(selection_score),
@@ -1463,6 +1515,7 @@ def _validation_selection_metrics_from_predictions(
         "mean_true_label_rank": float(np.nanmean(ranks)),
         "rank_score": rank_score,
         "prediction_balance_score": balance_score,
+        "worst_class_recall": worst_class_recall,
     }
 
 
@@ -4169,7 +4222,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--validation-selection-metric",
-        choices=("balanced_accuracy", "balanced_top2_top3_rank", "balanced_top2_top3_rank_balance"),
+        choices=LATENT_VALIDATION_SELECTION_METRIC_CHOICES,
         default="balanced_accuracy",
         help="Source-validation metric used for epoch selection and early stopping.",
     )
@@ -4216,7 +4269,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--latent-head-refit-selection-metric",
-        choices=("balanced_accuracy", "balanced_top2_top3_rank", "balanced_top2_top3_rank_balance"),
+        choices=LATENT_VALIDATION_SELECTION_METRIC_CHOICES,
         default="balanced_accuracy",
         help="Source-validation metric used to select C for validation_selected_source_logistic.",
     )
@@ -4279,7 +4332,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--score-calibration-selection-metric",
-        choices=("balanced_accuracy", "balanced_top2_top3_rank", "balanced_top2_top3_rank_balance"),
+        choices=LATENT_VALIDATION_SELECTION_METRIC_CHOICES,
         default="balanced_accuracy",
         help=(
             "Source-validation objective used by validation_class_bias_guarded. "
@@ -4347,7 +4400,7 @@ def _build_parser(prog: str | None = None) -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--prediction-postprocessing-selection-metric",
-        choices=("balanced_accuracy", "balanced_top2_top3_rank", "balanced_top2_top3_rank_balance"),
+        choices=LATENT_VALIDATION_SELECTION_METRIC_CHOICES,
         default="balanced_accuracy",
         help=(
             "Source-validation objective used by validation_selected_balanced_assignment. "

--- a/tests/test_stimulus_latent_autoencoder_controls.py
+++ b/tests/test_stimulus_latent_autoencoder_controls.py
@@ -23,6 +23,7 @@ from pymegdec.stimulus_latent_autoencoder import (
     _soft_worst_class_recall_loss,
     _supervised_contrastive_loss,
     _validation_selection_metrics,
+    _worst_class_recall_score,
 )
 
 
@@ -161,6 +162,54 @@ def test_validation_selection_metrics_rank_balance_variant_rewards_balanced_pred
 
     assert math.isfinite(balanced["selection_score"])
     assert balanced["selection_score"] > collapsed["selection_score"]
+
+
+def test_worst_class_recall_score_detects_zero_recall_class():
+    labels = np.asarray([1, 1, 2, 2, 3, 3, 4, 4])
+    classes = np.asarray([1, 2, 3, 4])
+    collapsed_predictions = np.asarray([1, 1, 2, 2, 3, 3, 3, 3])
+    separated_predictions = np.asarray([1, 1, 2, 2, 3, 3, 4, 4])
+
+    assert _worst_class_recall_score(labels, collapsed_predictions, classes) == 0.0
+    assert _worst_class_recall_score(labels, separated_predictions, classes) == 1.0
+
+
+def test_validation_selection_metrics_worstclass_variant_penalizes_zero_recall():
+    labels = np.asarray([1, 2, 3, 4])
+    classes = np.asarray([1, 2, 3, 4])
+    separated_scores = np.asarray(
+        [
+            [4.0, 1.0, 0.0, 0.0],
+            [1.0, 4.0, 0.0, 0.0],
+            [0.0, 1.0, 4.0, 0.0],
+            [0.0, 1.0, 0.0, 4.0],
+        ]
+    )
+    zero_recall_scores = np.asarray(
+        [
+            [4.0, 1.0, 0.0, 0.0],
+            [1.0, 4.0, 0.0, 0.0],
+            [0.0, 1.0, 4.0, 0.0],
+            [0.0, 1.0, 4.0, 3.5],
+        ]
+    )
+
+    separated = _validation_selection_metrics(
+        labels,
+        separated_scores,
+        classes,
+        "balanced_top2_top3_rank_worstclass_balance",
+    )
+    zero_recall = _validation_selection_metrics(
+        labels,
+        zero_recall_scores,
+        classes,
+        "balanced_top2_top3_rank_worstclass_balance",
+    )
+
+    assert separated["worst_class_recall"] == 1.0
+    assert zero_recall["worst_class_recall"] == 0.0
+    assert separated["selection_score"] > zero_recall["selection_score"]
 
 
 def test_balanced_epoch_indices_interleaves_classes_and_preserves_rows():


### PR DESCRIPTION
## Summary
- Add worst-class recall as a source-validation selection component for latent autoencoder model selection.
- Support `balanced_top2_top3_rank_worstclass` and `balanced_top2_top3_rank_worstclass_balance` across epoch selection, head refit, score calibration, and prediction postprocessing CLI choices.
- Expose the new workflow input and extend workflow choices for calibration/postprocessing selection metrics.
- Add regression tests for the worst-class recall score and selection metric.

## Validation
- Not run locally per request; waiting for GitHub checks.