### PR TITLE
[codex] Preserve typed artifact prediction labels

### DIFF
--- a/src/pymegdec/stimulus_artifact_ensemble.py
+++ b/src/pymegdec/stimulus_artifact_ensemble.py
@@ -1247,7 +1247,8 @@ def _prediction_row(
         )
 
     for column, value in zip(key_columns, key, strict=True):
-        row[column] = value
+        if column not in row:
+            row[column] = value
     for optional in ("test_participant", "test_trial_index", "trial", "test_trial_number", "outer_fold"):
         if optional in reference and optional not in row:
             row[optional] = reference.get(optional, "")


### PR DESCRIPTION
## Summary
- Keep semantic fields such as `true_label` in the typed prediction-row form created by `_prediction_row` instead of overwriting them with key-column CSV strings.
- This addresses the remote unit-test failure where balanced-assignment prediction rows returned `'1'` instead of `1` for `true_label`.

## Validation
- Not run locally per request; waiting for GitHub checks.